### PR TITLE
style(overlay): single-line buttons in pre-alarm modal

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -710,6 +710,27 @@ body {
   animation: none;
 }
 
+.overlay-card--pre-alarm .overlay-card__actions--split {
+  width: 100%;
+  gap: 1.2rem;
+  margin-top: 1.5rem;
+}
+
+.overlay-card--pre-alarm .overlay-card__actions--split .overlay-button,
+.overlay-card--pre-alarm .overlay-card__actions--split .overlay-button--primary {
+  flex: 1;
+  width: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.4rem 1rem;
+  font-size: clamp(1rem, 1.6vw, 1.35rem);
+  font-weight: 600;
+  line-height: 1.1;
+  white-space: nowrap;
+  border-radius: 0.85rem;
+}
+
 .overlay-card--reminder {
   text-align: left;
 }


### PR DESCRIPTION
## Summary
The **Dismiss alarm** / **Keep alarm** buttons in the pre-alarm warning modal (added in #152) looked mismatched and ugly:

- **Dismiss alarm** inherited `.overlay-button--primary`'s `font-size: clamp(1.4rem, 3vw, 2.6rem)` — huge text that often wrapped to two lines
- **Keep alarm** got the base `.overlay-button` `font-size: 1rem` — tiny by comparison
- Asymmetric flex weights (1.25 vs 1.0) made one wider than the other

## Fix
Adds a `.overlay-card--pre-alarm`-scoped rule that:

- Equalizes both buttons with `flex: 1` and a shared smaller font (`clamp(1rem, 1.6vw, 1.35rem)`)
- Keeps generous padding (`1.4rem 1rem`) so the touch target stays large
- Adds `white-space: nowrap` so each label always fits on a single line
- Bumps the gap and top margin slightly for breathing room

Scoped to `.overlay-card--pre-alarm` so the existing ringing-alarm card styling is unaffected.

## Test plan
- [x] `tests/test_overlay.py` — all 58 overlay tests pass (CSS-only change, no class names touched)
- [ ] Visual smoke on a kiosk: pre-alarm modal renders with two equally-sized large buttons, single-line text on each

🤖 Generated with [Claude Code](https://claude.com/claude-code)