### PR TITLE
style(overlay): solid dark controls bar with filled white icons

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -890,18 +890,18 @@ body {
   gap: 1.6rem;
   margin-top: 0.6rem;
   padding: 0.4rem 1.2rem;
-  background: rgba(255, 255, 255, 0.06);
+  background: #2a2a2a;
   border-radius: 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: none;
 }
 
 .overlay-now-playing__control {
   background: transparent;
   border: none;
-  color: var(--overlay-accent-color, #88C0D0);
+  color: #FFFFFF;
   font-size: 1.6rem;
   cursor: pointer;
-  opacity: 0.55;
+  opacity: 0.75;
   padding: 0.4rem;
   transition: opacity 0.2s, transform 0.15s;
   line-height: 1;
@@ -911,7 +911,7 @@ body {
 
 .overlay-now-playing__control--primary {
   font-size: 2rem;
-  opacity: 0.75;
+  opacity: 1;
 }
 
 .overlay-now-playing__control:hover,

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -899,10 +899,15 @@ body {
   background: transparent;
   border: none;
   color: #FFFFFF;
-  font-size: 1.6rem;
+  font-size: 1.3rem;
   cursor: pointer;
-  opacity: 0.75;
-  padding: 0.4rem;
+  opacity: 0.85;
+  padding: 0.3rem 0.5rem;
+  width: 2.4rem;
+  height: 2.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   transition: opacity 0.2s, transform 0.15s;
   line-height: 1;
   font-family: var(--overlay-font-family, system-ui, sans-serif);
@@ -910,7 +915,7 @@ body {
 }
 
 .overlay-now-playing__control--primary {
-  font-size: 2rem;
+  font-size: 1.3rem;
   opacity: 1;
 }
 

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -942,6 +942,10 @@ class KioskMqttListener:
             return "", ""
         text = self._format_now_playing(payload)
         ha_state = str(payload.get("state") or "").lower()
+        # Snapcast players report "idle" when paused — treat as paused if
+        # media metadata is still present so the now-playing card stays visible.
+        if ha_state == "idle" and text:
+            ha_state = "paused"
         return text, ha_state
 
     def _build_ha_ssl_context(self) -> ssl.SSLContext | None:
@@ -1270,7 +1274,9 @@ class KioskMqttListener:
             self.log(f"media control: failed to send {service} to {entity}: {exc}")
         # Refresh now-playing state after the action
         if self.overlay_state:
+            time.sleep(1)
             now_playing, now_playing_state = self._collect_now_playing_text()
+            self.log(f"media control: after {service}, state={now_playing_state!r}, text={now_playing[:60]!r}")
             change = self.overlay_state.update_now_playing(now_playing, state=now_playing_state)
             self._handle_overlay_change(change)
 
@@ -1302,7 +1308,7 @@ class KioskMqttListener:
                 return clean_state
             return ""
 
-        if state not in {"playing", "on", "buffering", "paused"}:
+        if state not in {"playing", "on", "buffering", "paused", "idle"}:
             return ""
 
         title = (

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -960,20 +960,20 @@ def _build_now_playing_card(snapshot: OverlaySnapshot) -> tuple[str, str] | None
     state = snapshot.now_playing_state
     is_playing = state == "playing"
     paused_class = " overlay-now-playing--paused" if state == "paused" else ""
-    play_pause_icon = "\u2016" if is_playing else "\u25b7"
+    play_pause_icon = "\u2016" if is_playing else "\u25b6"
     play_pause_action = "media_pause" if is_playing else "media_play"
     play_pause_label = "Pause" if is_playing else "Play"
     btn = "overlay-now-playing__control"
     pri = f"{btn} {btn}--primary"
     controls = (
         f'<button class="{btn}" data-media-action="media_previous_track"'
-        f' aria-label="Previous">\u25c1\u25c1</button>'
+        f' aria-label="Previous">\u25c0\u25c0</button>'
         f'<button class="{pri}" data-media-action="{play_pause_action}"'
         f' aria-label="{play_pause_label}">{play_pause_icon}</button>'
         f'<button class="{btn}" data-media-action="media_stop"'
-        f' aria-label="Stop">\u25a1</button>'
+        f' aria-label="Stop">\u25a0</button>'
         f'<button class="{btn}" data-media-action="media_next_track"'
-        f' aria-label="Next">\u25b7\u25b7</button>'
+        f' aria-label="Next">\u25b6\u25b6</button>'
     )
     card = f"""
 <div class="overlay-card overlay-card--ambient overlay-card--now-playing{paused_class}">


### PR DESCRIPTION
## Summary
- Replace the translucent now-playing control bar with a solid dark gray (`#2a2a2a`) background for better visibility
- Switch player icons from outlined (◁◁ ▷ □) to filled (◀◀ ▶ ■) Unicode symbols
- Change button color from cyan accent to white with increased opacity
- Make all control buttons uniform size (2.4rem) so they match regardless of icon
- Fix: keep now-playing card visible when pausing — snapcast reports "idle" instead of "paused", now treated as paused when media metadata is still present

## Test plan
- [x] Verified on pulse-office display — controls bar is clearly visible and buttons stand out
- [x] Pause/play cycle keeps the now-playing card visible
- [x] All buttons render at equal size

🤖 Generated with [Claude Code](https://claude.com/claude-code)