### PR TITLE
fix(security): upgrade Pygments and resolve code scanning alert

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Security audit dependencies
         if: needs.changes.outputs.python == 'true'
-        run: pip-audit --desc --skip-editable --ignore-vuln GHSA-5239-wwwm-4pmq --ignore-vuln CVE-2026-25645  # pygments ReDoS + requests 2.32.5, no fix available
+        run: pip-audit --desc --skip-editable --ignore-vuln CVE-2026-25645  # requests 2.32.5, no fix available
 
   # Gate job that always runs - use this as the required status check
   ci:

--- a/tests/test_wake_detector.py
+++ b/tests/test_wake_detector.py
@@ -324,9 +324,11 @@ async def test_local_audio_block_increments_and_decrements():
 @pytest.mark.anyio
 async def test_local_audio_block_decrements_on_exception():
     d = _make_detector()
-    with pytest.raises(RuntimeError):
+    try:
         async with d.local_audio_block():
             raise RuntimeError("boom")
+    except RuntimeError:
+        pass
     assert d._local_audio_depth == 0
 
 

--- a/tests/test_wake_detector.py
+++ b/tests/test_wake_detector.py
@@ -324,11 +324,13 @@ async def test_local_audio_block_increments_and_decrements():
 @pytest.mark.anyio
 async def test_local_audio_block_decrements_on_exception():
     d = _make_detector()
+    raised = False
     try:
         async with d.local_audio_block():
             raise RuntimeError("boom")
     except RuntimeError:
-        pass
+        raised = True
+    assert raised
     assert d._local_audio_depth == 0
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -592,11 +592,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade Pygments 2.19.2 → 2.20.0 to fix ReDoS vulnerability (Dependabot #3 / GHSA-5239-wwwm-4pmq)
- Remove the now-unnecessary pip-audit ignore for Pygments
- Restructure test to avoid CodeQL false-positive unreachable code warning (#194)

## Test plan
- [x] `test_local_audio_block_decrements_on_exception` passes
- [ ] CI passes (pip-audit no longer needs Pygments ignore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)