### PR TITLE
ci: drop hardcoded pytest pin in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -116,7 +116,7 @@ jobs:
         run: |
           python -m pip install --upgrade "pip==26.0"
           pip install -e ".[dev]"
-          pip install "pip-audit==2.7.3" "pytest==9.0.2"
+          pip install "pip-audit==2.7.3"
 
       - name: Run tests
         if: needs.changes.outputs.python == 'true'


### PR DESCRIPTION
## Summary
- Removes the explicit `pytest==9.0.2` install in build.yaml that was overriding dependabot's pytest bumps.
- pytest now resolves from the `.[dev]` extras in pyproject.toml.

## Why
Dependabot PRs #158 and #162 bumped pytest to 9.0.3 (fixing CVE-2025-71176), but the workflow's hardcoded install of pytest==9.0.2 reverted it before pip-audit ran, causing failures.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)