### PR TITLE
fix: prevent renderer throttling in kiosk mode

### DIFF
--- a/bin/kiosk-wrap.sh
+++ b/bin/kiosk-wrap.sh
@@ -190,6 +190,9 @@ while true; do
     --disable-logging \
     --disable-features=RendererCodeIntegrity,PreconnectToSearch,OptimizationHints,AutofillServerCommunication,PushMessaging \
     --disable-breakpad \
+    --disable-backgrounding-occluded-windows \
+    --disable-renderer-backgrounding \
+    --disable-background-timer-throttling \
     --kiosk \
     --start-fullscreen \
     --window-position=0,0 \


### PR DESCRIPTION
## Summary
Adds three Chrome flags to keep the kiosk renderer alive when the window is occluded, backgrounded, or briefly loses focus (e.g. during HA restart, multi-display switching). Without these, the display goes blank/stale until the window is foregrounded again.

- \`--disable-backgrounding-occluded-windows\`
- \`--disable-renderer-backgrounding\`
- \`--disable-background-timer-throttling\`

## Test plan
- [ ] Run kiosk, force the window behind another display, confirm it keeps painting / timers run
- [ ] Trigger an HA restart, confirm the watchdog reload still works