### PR TITLE
fix(alarms): durable dismiss + silent false-wake

### DIFF
--- a/pulse/assistant/calendar_sync.py
+++ b/pulse/assistant/calendar_sync.py
@@ -12,7 +12,7 @@ from urllib.parse import unquote, urlparse
 
 import httpx
 import recurring_ical_events
-from icalendar import Calendar  # type: ignore[import-untyped]
+from icalendar import Calendar, Component  # type: ignore[import-untyped]
 
 from .config import CalendarConfig
 
@@ -269,7 +269,7 @@ class CalendarSyncService:
 
     def _collect_reminders(
         self,
-        calendar: Calendar,
+        calendar: Component,
         state: _FeedState,
         now: datetime,
     ) -> list[CalendarReminder]:

--- a/pulse/assistant/conversation_manager.py
+++ b/pulse/assistant/conversation_manager.py
@@ -134,6 +134,79 @@ def evaluate_follow_up_transcript(
     return True, normalized
 
 
+# Transcripts that almost always indicate a false wake (silence or background noise) rather
+# than a real request. Whisper-class models commonly hallucinate these on near-silent audio.
+# We bail out silently when the initial transcript matches one of these so a spurious wake
+# doesn't trigger an "I'm here, how can I help?" style response.
+_NOISE_INITIAL_TRANSCRIPTS: frozenset[str] = frozenset(
+    {
+        # Single-token filler / STT artifacts
+        "you",
+        "ya",
+        "u",
+        "i",
+        "a",
+        "the",
+        "is",
+        "it",
+        "to",
+        "of",
+        "uh",
+        "um",
+        "umm",
+        "uhh",
+        "uhm",
+        "hmm",
+        "hm",
+        "huh",
+        "mm",
+        "mmm",
+        "mhm",
+        "ah",
+        "ahh",
+        "eh",
+        "oh",
+        "ooh",
+        "ow",
+        "yo",
+        # Whisper outro hallucinations
+        "thanks",
+        "thank you",
+        "thanks for watching",
+        "thank you for watching",
+        "thanks for watching the video",
+        "thank you for watching the video",
+        "see you next time",
+        "see you in the next video",
+        "subtitles by the amara org community",
+        "subtitles by",
+        "bye",
+        "goodbye",
+        "okay",
+        "ok",
+    }
+)
+
+
+def looks_like_noise_initial_transcript(transcript: str | None) -> bool:
+    """Return True if `transcript` looks like noise/silence rather than a real request.
+
+    Used to silently ignore false wakes when the post-wake STT produces empty output or
+    a known hallucination/filler token. Should only be applied to the very first transcript
+    of a turn — follow-ups have their own filter in `evaluate_follow_up_transcript`.
+    """
+    if not transcript:
+        return True
+    normalized = re.sub(r"[^a-z0-9'\s]", " ", transcript.lower())
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    if not normalized:
+        return True
+    cleaned = normalized.replace("'", "")
+    if cleaned in _NOISE_INITIAL_TRANSCRIPTS:
+        return True
+    return False
+
+
 def is_conversation_stop_command(transcript: str | None, conversation_stop_prefixes: tuple[str, ...]) -> bool:
     """Check if transcript is a conversation stop command."""
     normalized = normalize_conversation_stop_text(

--- a/pulse/assistant/pipeline_orchestrator.py
+++ b/pulse/assistant/pipeline_orchestrator.py
@@ -11,7 +11,10 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from pulse.assistant.conversation_manager import should_listen_for_follow_up
+from pulse.assistant.conversation_manager import (
+    looks_like_noise_initial_transcript,
+    should_listen_for_follow_up,
+)
 from pulse.assistant.response_modes import select_ha_response
 from pulse.assistant.wyoming import play_tts_stream, transcribe_audio
 from pulse.audio import play_sound, play_volume_feedback
@@ -173,6 +176,14 @@ class PipelineOrchestrator:
             if not transcript:
                 self._finalize_assist_run(status="no_transcript")
                 return
+            if looks_like_noise_initial_transcript(transcript):
+                self.logger.info(
+                    "[pipeline] Ignoring likely-noise transcript for wake word %s: %r",
+                    wake_word,
+                    transcript,
+                )
+                self._finalize_assist_run(status="no_transcript")
+                return
             if self.config.log_transcripts:
                 self.logger.info("[pipeline] Transcript [%s]: %s", wake_word, transcript)
             if self.preference_manager.log_llm_messages:
@@ -321,14 +332,21 @@ class PipelineOrchestrator:
                 self._finalize_assist_run(status="error")
                 return
             transcript = self._extract_ha_transcript(ha_result)
-            if transcript:
-                if self.config.log_transcripts:
-                    self.logger.info("[pipeline] Transcript [%s/HA]: %s", wake_word, transcript)
-                if self.preference_manager.log_llm_messages:
-                    self.publisher._publish_message(
-                        self.config.transcript_topic,
-                        json.dumps({"text": transcript, "wake_word": wake_word, "pipeline": "home_assistant"}),
-                    )
+            if not transcript or looks_like_noise_initial_transcript(transcript):
+                self.logger.info(
+                    "[pipeline] Ignoring HA result with empty/noise transcript for wake word %s: %r",
+                    wake_word,
+                    transcript,
+                )
+                self._finalize_assist_run(status="no_transcript")
+                return
+            if self.config.log_transcripts:
+                self.logger.info("[pipeline] Transcript [%s/HA]: %s", wake_word, transcript)
+            if self.preference_manager.log_llm_messages:
+                self.publisher._publish_message(
+                    self.config.transcript_topic,
+                    json.dumps({"text": transcript, "wake_word": wake_word, "pipeline": "home_assistant"}),
+                )
             speech_text = self._extract_ha_speech(ha_result) or "Okay."
             if self.config.log_transcripts:
                 self.logger.info("[pipeline] Response [%s/HA]: %s", wake_word, speech_text)

--- a/pulse/assistant/schedule_service.py
+++ b/pulse/assistant/schedule_service.py
@@ -777,9 +777,22 @@ class ScheduleService:
         self._ooo_skip_dates: set[str] = set()
         self._ui_pause_dates: set[str] = set()
         self._ui_enable_dates: dict[str, set[str]] = {}  # date -> set of alarm_ids for paused alarms
+        # Per-alarm dismissed dates: alarm_id -> set of ISO date strings. Honored as additional
+        # skip dates so a user-dismissed occurrence stays dismissed even when other recomputes
+        # (e.g. periodic OOO calendar sync) reschedule alarms.
+        self._dismissed_dates: dict[str, set[str]] = {}
 
     def _effective_skip_dates(self) -> set[str]:
         return set(self._manual_skip_dates) | set(self._ooo_skip_dates) | set(self._ui_pause_dates)
+
+    def _prune_dismissed_dates(self) -> None:
+        today = _now().date().isoformat()
+        for alarm_id in list(self._dismissed_dates.keys()):
+            kept = {d for d in self._dismissed_dates[alarm_id] if d >= today}
+            if kept:
+                self._dismissed_dates[alarm_id] = kept
+            else:
+                del self._dismissed_dates[alarm_id]
 
     async def set_manual_skip_dates(self, dates: set[str]) -> None:
         async with self._lock:
@@ -884,10 +897,17 @@ class ScheduleService:
         event_id: str | None = None,
     ) -> datetime:
         skip_dates = None if is_paused_alarm else self._effective_skip_dates()
+        # Per-alarm dismissed dates always count as skip dates, including for paused alarms,
+        # so user dismisses survive subsequent reschedules.
+        dismissed = self._dismissed_dates.get(event_id) if event_id else None
+        if dismissed:
+            skip_dates = (skip_dates or set()) | dismissed
         # For paused alarms, get enable dates that belong to this specific alarm
         enable_dates: set[str] | None = None
         if is_paused_alarm and event_id:
             enable_dates = {date for date, alarm_ids in self._ui_enable_dates.items() if event_id in alarm_ids}
+            if dismissed:
+                enable_dates -= dismissed
 
         return _compute_next_alarm_fire(
             time_str,
@@ -1091,6 +1111,7 @@ class ScheduleService:
                 self._ui_enable_dates[date_str].discard(event_id)
                 if not self._ui_enable_dates[date_str]:
                     del self._ui_enable_dates[date_str]
+            self._dismissed_dates.pop(event_id, None)
             await self._persist_events()
             await self._publish_state()
             return True
@@ -1159,6 +1180,9 @@ class ScheduleService:
         For recurring alarms, advances next_fire past the current occurrence so the alarm
         will still fire on subsequent days. For single-shot alarms, deletes the alarm
         entirely (since dismissing prevents the only occurrence).
+
+        The dismissed occurrence date is recorded in `_dismissed_dates` so that later
+        reschedules (e.g. periodic calendar OOO sync) don't restore today's fire time.
         """
         async with self._lock:
             event = self._events.get(event_id)
@@ -1166,6 +1190,8 @@ class ScheduleService:
                 return False
             current_fire = event.next_fire_dt()
             if event.repeat_days:
+                self._dismissed_dates.setdefault(event_id, set()).add(current_fire.date().isoformat())
+                self._prune_dismissed_dates()
                 next_fire = self._compute_alarm_fire(
                     event.time_of_day or "08:00",
                     event.repeat_days,
@@ -1178,6 +1204,7 @@ class ScheduleService:
             else:
                 self._events.pop(event_id, None)
                 self._cancel_event_tasks(event_id)
+                self._dismissed_dates.pop(event_id, None)
             await self._persist_events()
             await self._publish_state()
         self._notify_active("alarm", None)
@@ -1428,12 +1455,14 @@ class ScheduleService:
         await self.stop_event(event_id, reason="auto_timeout")
 
     async def _persist_events(self) -> None:
+        self._prune_dismissed_dates()
         payload = {
             "events": [event.to_json_dict() for event in self._events.values()],
             "paused_dates": sorted(self._ui_pause_dates),
             "enabled_dates": {
                 date: sorted(alarm_ids) for date, alarm_ids in self._ui_enable_dates.items()
             },  # dict[str, list[str]] of date -> alarm_ids
+            "dismissed_dates": {alarm_id: sorted(dates) for alarm_id, dates in self._dismissed_dates.items()},
         }
         self._storage_path.parent.mkdir(parents=True, exist_ok=True)
         tmp_path = self._storage_path.with_suffix(".tmp")
@@ -1468,6 +1497,15 @@ class ScheduleService:
         elif isinstance(enabled_dates, list):
             # Very old legacy format: list of dates without alarm_ids - cannot be migrated, drop
             pass
+        dismissed_dates = data.get("dismissed_dates") or {}
+        if isinstance(dismissed_dates, dict):
+            for alarm_id, dates in dismissed_dates.items():
+                if not isinstance(alarm_id, str) or not isinstance(dates, list):
+                    continue
+                cleaned = {d for d in dates if isinstance(d, str)}
+                if cleaned:
+                    self._dismissed_dates[alarm_id] = cleaned
+        self._prune_dismissed_dates()
         for item in data.get("events", []):
             try:
                 event = ScheduledEvent.from_dict(item)

--- a/tests/test_conversation_manager.py
+++ b/tests/test_conversation_manager.py
@@ -12,6 +12,7 @@ from pulse.assistant.conversation_manager import (
     build_conversation_stop_prefixes,
     evaluate_follow_up_transcript,
     is_conversation_stop_command,
+    looks_like_noise_initial_transcript,
     normalize_conversation_stop_text,
     should_listen_for_follow_up,
 )
@@ -239,3 +240,41 @@ class TestConversationManager:
         mgr.mic.read_chunk = AsyncMock(return_value=b"\x00" * 960)
         result = await mgr.record_follow_up_phrase()
         assert isinstance(result, bytes)
+
+
+class TestLooksLikeNoiseInitialTranscript:
+    @pytest.mark.parametrize(
+        "transcript",
+        [
+            None,
+            "",
+            "   ",
+            "uh",
+            "Um.",
+            "Hmm?",
+            "you",
+            "Thanks for watching!",
+            "thank you for watching the video",
+            "Bye.",
+            "Okay",
+            "ok",
+        ],
+    )
+    def test_classifies_as_noise(self, transcript):
+        assert looks_like_noise_initial_transcript(transcript) is True
+
+    @pytest.mark.parametrize(
+        "transcript",
+        [
+            "what's the weather",
+            "turn on the lights",
+            "set an alarm for 7 am",
+            "stop the timer",
+            "play music",
+            # Multi-word stop phrases should NOT be misclassified as noise.
+            "never mind",
+            "thanks a lot for the help",
+        ],
+    )
+    def test_classifies_as_real(self, transcript):
+        assert looks_like_noise_initial_transcript(transcript) is False

--- a/tests/test_schedule_service.py
+++ b/tests/test_schedule_service.py
@@ -663,6 +663,72 @@ async def test_dismiss_alarm_occurrence_clears_active_modal(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_dismiss_alarm_survives_reschedule_all(schedule_service):
+    """Dismissed occurrence must stay dismissed even when set_ooo_skip_dates triggers
+    a full reschedule (the calendar OOO sync runs periodically and was clobbering the
+    dismissal by recomputing next_fire from scratch)."""
+    svc = schedule_service
+    event = await svc.create_alarm(time_of_day="08:00", days=[0, 1, 2, 3, 4, 5, 6])
+    original_fire = event.next_fire_dt()
+    await svc.dismiss_alarm_occurrence(event.event_id)
+    after_dismiss = svc._events[event.event_id].next_fire_dt()
+    assert after_dismiss > original_fire
+    # Simulate calendar OOO sync running between dismiss and the original fire time.
+    await svc.set_ooo_skip_dates(set())
+    after_reschedule = svc._events[event.event_id].next_fire_dt()
+    assert after_reschedule.date() == after_dismiss.date()
+    # Dismissed date is still tracked
+    assert original_fire.date().isoformat() in svc._dismissed_dates[event.event_id]
+
+
+@pytest.mark.anyio
+async def test_dismiss_alarm_survives_restart(tmp_path):
+    """Restarting the service must not clear a recorded dismissal."""
+    storage_path = tmp_path / "schedules.json"
+    svc = ScheduleService(
+        storage_path=storage_path,
+        hostname="pulse-test",
+        on_state_changed=None,
+        on_active_event=None,
+        ha_client=None,
+    )
+    await svc.start()
+    try:
+        event = await svc.create_alarm(time_of_day="08:00", days=[0, 1, 2, 3, 4, 5, 6])
+        original_fire = event.next_fire_dt()
+        await svc.dismiss_alarm_occurrence(event.event_id)
+        after_dismiss = svc._events[event.event_id].next_fire_dt()
+    finally:
+        await svc.stop()
+
+    svc2 = ScheduleService(
+        storage_path=storage_path,
+        hostname="pulse-test",
+        on_state_changed=None,
+        on_active_event=None,
+        ha_client=None,
+    )
+    await svc2.start()
+    try:
+        reloaded = svc2._events[event.event_id]
+        # next_fire is recomputed on load, so verify it's still past the dismissed date.
+        assert reloaded.next_fire_dt().date() == after_dismiss.date()
+        assert original_fire.date().isoformat() in svc2._dismissed_dates[event.event_id]
+    finally:
+        await svc2.stop()
+
+
+@pytest.mark.anyio
+async def test_delete_alarm_clears_dismissed_dates(schedule_service):
+    svc = schedule_service
+    event = await svc.create_alarm(time_of_day="08:00", days=[0, 1, 2, 3, 4, 5, 6])
+    await svc.dismiss_alarm_occurrence(event.event_id)
+    assert event.event_id in svc._dismissed_dates
+    await svc.delete_event(event.event_id)
+    assert event.event_id not in svc._dismissed_dates
+
+
+@pytest.mark.anyio
 async def test_extend_timer(schedule_service):
     svc = schedule_service
     event = await svc.create_timer(duration_seconds=60, label="Extend me")


### PR DESCRIPTION
## Summary

Two morning-time bugs in the assistant:

1. **Dismissing an alarm 5-10 min before fire still let it ring.** The dismiss handler updated `next_fire`, but `_reschedule_all_alarms_locked` (which runs every time the calendar OOO sync produces a snapshot) recomputed `next_fire` from scratch using `time_of_day` + `repeat_days`, silently restoring today's fire time. `_load_events` did the same thing on every assistant restart. Fix: record the dismissed date per-alarm in `_dismissed_dates`, treat it as an extra `skip_dates` entry in `_compute_alarm_fire`, and persist/load/prune it so the dismissal sticks across both periodic reschedules and restarts.

2. **False wakes spoke a response even when no real speech followed.** A spurious wake-word would chime, the recorder would pick up silence, STT would return a Whisper hallucination (`"uh"`, `"you"`, `"thanks for watching"`, …), and the LLM/HA pipeline would speak a generic "I'm here, how can I help?" reply. Fix: new `looks_like_noise_initial_transcript` helper, applied right after STT in both the Pulse and Home-Assistant pipelines so the run finalizes silently. The wake chime still plays at wake detect — we can't know it's noise until after listening.

Includes a small drive-by mypy fix in `calendar_sync.py` (widen `_collect_reminders` parameter to `Component`) — the recent icalendar 6 bump broke the strict `Calendar` annotation and was blocking the pre-commit mypy hook.

## Test plan

- [x] `uv run pytest -q` (full suite, green)
- [x] New `test_dismiss_alarm_survives_reschedule_all` reproduces the exact dismiss-then-OOO-recompute scenario
- [x] New `test_dismiss_alarm_survives_restart` covers the restart path
- [x] New `test_delete_alarm_clears_dismissed_dates` confirms cleanup
- [x] New parametric `TestLooksLikeNoiseInitialTranscript` covers noise + real-request transcripts
- [ ] Real-world: set a daily alarm, dismiss the pre-alarm modal 5-10 min before fire, leave assistant running across a calendar OOO sync, confirm alarm does not ring
- [ ] Real-world: trigger a false wake (or just say nothing after the chime), confirm no spoken response

🤖 Generated with [Claude Code](https://claude.com/claude-code)