### PR TITLE
feat(watchdog): health-aware hardware watchdog + wire up dmesg watcher

### DIFF
--- a/bin/pulse-net-check.sh
+++ b/bin/pulse-net-check.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Health check for the watchdog(8) daemon (test-binary).
+#
+# Exits non-zero when the default gateway is unreachable, which is the
+# signature of the "soft hang" failure mode we have observed on Pulse devices:
+# systemd stays alive (so it keeps petting the kernel watchdog) but networking
+# is wedged and the device is effectively dead until a manual power-cycle.
+#
+# When this script keeps failing for longer than watchdog.conf's retry-timeout,
+# the watchdog daemon stops petting /dev/watchdog and the BCM2835 hardware
+# timer resets the board — recovery in minutes instead of hours, with no
+# reliance on a clean reboot path (which may itself be wedged).
+#
+# Kept deliberately lean: the daemon runs this every `interval` seconds.
+set -uo pipefail
+
+# Default gateway, derived at runtime so this works on any network.
+gw=$(ip route show default 2>/dev/null | awk '/default/{print $3; exit}')
+
+# No default route at all is itself an unhealthy state.
+[ -z "$gw" ] && exit 1
+
+# A single quick ping; -W is the per-packet timeout in seconds.
+ping -c1 -W3 "$gw" >/dev/null 2>&1 || exit 1
+
+exit 0

--- a/config/apt/manual-packages.txt
+++ b/config/apt/manual-packages.txt
@@ -258,6 +258,7 @@ uxplay
 v4l-utils
 vim-common
 vim-tiny
+watchdog
 whiptail
 wireless-tools
 wireplumber

--- a/config/system/watchdog/disable-runtime-watchdog.conf
+++ b/config/system/watchdog/disable-runtime-watchdog.conf
@@ -1,0 +1,9 @@
+# Pulse OS — hand /dev/watchdog to the watchdog(8) daemon.
+#
+# systemd's RuntimeWatchdogSec makes PID 1 pet the hardware watchdog, but that
+# only detects a total PID 1 / kernel hang — NOT a wedged network, which is the
+# failure mode we actually hit. The two cannot share /dev/watchdog, so we
+# disable systemd's runtime watchdog and let watchdog.service own the device
+# with a real health check (see watchdog.conf).
+[Manager]
+RuntimeWatchdogSec=0

--- a/config/system/watchdog/watchdog.conf
+++ b/config/system/watchdog/watchdog.conf
@@ -22,6 +22,7 @@ test-timeout = 8
 # only force recovery after this many seconds of CONTINUOUS failure (~3 min).
 retry-timeout = 180
 
-# Lock the daemon in RAM so it stays responsive under memory pressure.
+# realtime=yes locks the daemon into RAM (mlockall) and runs it at a realtime
+# scheduling priority, so it keeps petting the watchdog even under heavy load.
 realtime = yes
 priority = 1

--- a/config/system/watchdog/watchdog.conf
+++ b/config/system/watchdog/watchdog.conf
@@ -1,0 +1,27 @@
+# Pulse OS — health-aware hardware watchdog (managed by setup.sh).
+#
+# The watchdog daemon owns /dev/watchdog and keeps petting the BCM2835 hardware
+# timer ONLY while the health check passes. If the device suffers a silent
+# network-wedge hang (systemd alive, connectivity dead, nothing logged), the
+# check below fails, the daemon stops petting, and the board hardware-resets.
+#
+# This complements bin/pulse-hw-watchdog.sh, which reacts to *logged* fatal
+# kernel events (e.g. brcmfmac firmware crash). This one catches the silent
+# case that leaves no kernel message behind.
+
+watchdog-device = /dev/watchdog
+
+# Run the health check this often (seconds). Must be < the hardware timeout.
+interval = 10
+
+# Gateway-reachability check. Returns non-zero when the network is wedged.
+test-binary = /usr/local/sbin/pulse-net-check.sh
+test-timeout = 8
+
+# Tolerate transient blips (e.g. a Wi-Fi roam reconnect, which takes seconds):
+# only force recovery after this many seconds of CONTINUOUS failure (~3 min).
+retry-timeout = 180
+
+# Lock the daemon in RAM so it stays responsive under memory pressure.
+realtime = yes
+priority = 1

--- a/setup.sh
+++ b/setup.sh
@@ -1550,6 +1550,39 @@ restart_pulse_services() {
     fi
 }
 
+configure_watchdog() {
+    # Two complementary hardware watchdogs guard against the device hanging in
+    # a state that requires a manual power-cycle:
+    #
+    #   1. watchdog(8) daemon — proactive. Pets /dev/watchdog only while a
+    #      gateway-reachability health check passes, so a SILENT network-wedge
+    #      hang (systemd alive, nothing logged) forces a hardware reset.
+    #   2. pulse-hw-watchdog.service — reactive. Watches dmesg for *logged*
+    #      fatal events (brcmfmac firmware crash, USB HC death, GPU hang) and
+    #      reboots immediately.
+    log "Configuring hardware watchdogs…"
+
+    # --- 1. Health-aware watchdog daemon -----------------------------------
+    sudo install -m 0755 "$REPO_DIR/bin/pulse-net-check.sh" \
+        /usr/local/sbin/pulse-net-check.sh
+    sudo install -m 0644 "$REPO_DIR/config/system/watchdog/watchdog.conf" \
+        /etc/watchdog.conf
+    sudo mkdir -p /etc/systemd/system.conf.d
+    sudo install -m 0644 \
+        "$REPO_DIR/config/system/watchdog/disable-runtime-watchdog.conf" \
+        /etc/systemd/system.conf.d/disable-runtime-watchdog.conf
+    # Re-exec PID 1 so it releases /dev/watchdog (RuntimeWatchdogSec=0) before
+    # the daemon tries to claim it.
+    sudo systemctl daemon-reexec
+    sudo systemctl enable --now watchdog
+
+    # --- 2. Reactive dmesg watcher -----------------------------------------
+    sudo ln -sf "$REPO_DIR/config/system/pulse-hw-watchdog.service" \
+        /etc/systemd/system/pulse-hw-watchdog.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now pulse-hw-watchdog.service
+}
+
 main() {
     # Publish MQTT overlay refresh at the very start to prompt HA to reload overlay
     # This ensures the browser is ready to show the popup when we update it
@@ -1608,6 +1641,7 @@ main() {
     generate_sound_files
     link_home_files
     link_system_files
+    configure_watchdog
     configure_snapclient
     install_boot_splash
     enable_services

--- a/setup.sh
+++ b/setup.sh
@@ -1568,12 +1568,18 @@ configure_watchdog() {
     sudo install -m 0644 "$REPO_DIR/config/system/watchdog/watchdog.conf" \
         /etc/watchdog.conf
     sudo mkdir -p /etc/systemd/system.conf.d
-    sudo install -m 0644 \
+    local runtime_wd_dropin=/etc/systemd/system.conf.d/disable-runtime-watchdog.conf
+    if ! sudo cmp -s \
         "$REPO_DIR/config/system/watchdog/disable-runtime-watchdog.conf" \
-        /etc/systemd/system.conf.d/disable-runtime-watchdog.conf
-    # Re-exec PID 1 so it releases /dev/watchdog (RuntimeWatchdogSec=0) before
-    # the daemon tries to claim it.
-    sudo systemctl daemon-reexec
+        "$runtime_wd_dropin"; then
+        sudo install -m 0644 \
+            "$REPO_DIR/config/system/watchdog/disable-runtime-watchdog.conf" \
+            "$runtime_wd_dropin"
+        # Re-exec PID 1 so it picks up RuntimeWatchdogSec=0 and releases
+        # /dev/watchdog for the daemon. Only when the drop-in actually changed,
+        # since daemon-reexec is disruptive on a routine setup.sh re-run.
+        sudo systemctl daemon-reexec
+    fi
     sudo systemctl enable --now watchdog
 
     # --- 2. Reactive dmesg watcher -----------------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -1565,13 +1565,25 @@ configure_watchdog() {
     # --- 1. Health-aware watchdog daemon -----------------------------------
     sudo install -m 0755 "$REPO_DIR/bin/pulse-net-check.sh" \
         /usr/local/sbin/pulse-net-check.sh
-    sudo install -m 0644 "$REPO_DIR/config/system/watchdog/watchdog.conf" \
-        /etc/watchdog.conf
+
+    # Only (re)install watchdog.conf when it changed, and track that so we can
+    # restart the daemon — `enable --now` starts a stopped service but will NOT
+    # restart an already-running one, so on a routine setup.sh re-run an updated
+    # config would otherwise not take effect until a reboot. (cmp stderr is
+    # silenced for the first-run case where the target doesn't exist yet.)
+    local watchdog_conf_changed=false
+    if ! sudo cmp -s "$REPO_DIR/config/system/watchdog/watchdog.conf" \
+        /etc/watchdog.conf 2>/dev/null; then
+        sudo install -m 0644 "$REPO_DIR/config/system/watchdog/watchdog.conf" \
+            /etc/watchdog.conf
+        watchdog_conf_changed=true
+    fi
+
     sudo mkdir -p /etc/systemd/system.conf.d
     local runtime_wd_dropin=/etc/systemd/system.conf.d/disable-runtime-watchdog.conf
     if ! sudo cmp -s \
         "$REPO_DIR/config/system/watchdog/disable-runtime-watchdog.conf" \
-        "$runtime_wd_dropin"; then
+        "$runtime_wd_dropin" 2>/dev/null; then
         sudo install -m 0644 \
             "$REPO_DIR/config/system/watchdog/disable-runtime-watchdog.conf" \
             "$runtime_wd_dropin"
@@ -1580,7 +1592,11 @@ configure_watchdog() {
         # since daemon-reexec is disruptive on a routine setup.sh re-run.
         sudo systemctl daemon-reexec
     fi
+
     sudo systemctl enable --now watchdog
+    if [ "$watchdog_conf_changed" = true ]; then
+        sudo systemctl restart watchdog
+    fi
 
     # --- 2. Reactive dmesg watcher -----------------------------------------
     sudo ln -sf "$REPO_DIR/config/system/pulse-hw-watchdog.service" \


### PR DESCRIPTION
## Problem

Pulse devices can hard-hang in a **"soft" state**: systemd stays alive (so it keeps petting the kernel watchdog via `RuntimeWatchdogSec`) while networking is wedged and **nothing is logged** — leaving the device dead until a manual power-cycle.

Observed on `pulse-kitchen` (2026-06-28): hung ~07:20 EDT, completely silent for ~2.5h, recovered only by manual reboot. Across 72k log lines that weekend there were **zero** undervoltage / thermal / OOM / panic / brcmfmac / SDIO lines — the freeze left no trace.

The existing `pulse-hw-watchdog.service` only reacts to *logged* fatal kernel events, so it can't catch this silent case — **and it was never linked or enabled by `setup.sh` anyway** (orphaned).

## Changes

- **Health-aware `watchdog`(8) daemon** with a gateway-reachability test-binary (`bin/pulse-net-check.sh`). It pets `/dev/watchdog` only while the check passes, so a silent network-wedge hang makes the daemon stop petting and the **BCM2835 hardware timer resets the board** — no reliance on a clean reboot path that may itself be wedged.
- **Disable systemd `RuntimeWatchdogSec`** (drop-in) so the daemon can own `/dev/watchdog` (the two can't share it).
- **Wire up the orphaned `pulse-hw-watchdog.service`** so logged fatal events (brcmfmac firmware crash, USB HC death, GPU hang) still get a fast reactive reboot.

Recovery from a wedged device drops from hours to ~3 minutes (`retry-timeout = 180`, tolerant of transient Wi-Fi roams).

## Files

| File | Change |
|---|---|
| `config/apt/manual-packages.txt` | add `watchdog` |
| `bin/pulse-net-check.sh` | gateway health check (test-binary) |
| `config/system/watchdog/watchdog.conf` | daemon config |
| `config/system/watchdog/disable-runtime-watchdog.conf` | `RuntimeWatchdogSec=0` |
| `setup.sh` | new `configure_watchdog()`, called from `main()` |

## Validation

Deployed and validated live on `pulse-kitchen`: `watchdog.service` active, `wdctl` shows it petting (KEEPALIVEPING, Timeleft cycling), health check passes, box healthy.

## Notes for review

- **Always-on** (no `PULSE_*` opt-out flag) — treated as core reliability. Happy to gate behind a flag if preferred.
- Enabling `pulse-hw-watchdog.service` is a behavior change (it was previously never running on any device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)