### PR TITLE
ci(review): retry Claude review on transient SDK error (#892)

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -149,8 +149,14 @@ jobs:
               || echo "Warning: Failed to minimize issue comment ${NODE_ID}"
           done
 
-      - name: Claude Code Review
+      # claude-code-action#892: the action intermittently exits 0 while its run
+      # ended with is_error=true, so the review/approval silently never happens
+      # (and the job's continue-on-error hides it as a green check). We run it,
+      # detect that failure mode, and retry once before giving up.
+      - name: Claude Code Review (attempt 1)
+        id: review1
         if: steps.skip-check.outputs.skip != 'true' && steps.docs-check.outputs.docs_only != 'true'
+        continue-on-error: true
         uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -169,3 +175,61 @@ jobs:
               gh pr review ${{ github.event.pull_request.number || github.event.issue.number }} --repo ${{ github.repository }} --approve --body "Reviewed by Claude — no issues found."
             Do not consider the review complete until you have either left blocking comments OR run
             the approve command above. Silence is not acceptable.
+
+      - name: Check whether the review completed
+        id: review_check
+        if: steps.skip-check.outputs.skip != 'true' && steps.docs-check.outputs.docs_only != 'true'
+        env:
+          EXEC_FILE: ${{ steps.review1.outputs.execution_file }}
+        run: |
+          # `jq -s 'flatten'` normalises both possible output shapes (a JSON
+          # array, or JSON-lines) into a flat stream of message objects, then we
+          # read the final result's is_error.
+          ok=false
+          if [ -n "$EXEC_FILE" ] && [ -f "$EXEC_FILE" ]; then
+            echo "::group::execution_file tail"; tail -c 1500 "$EXEC_FILE" 2>/dev/null || true; echo; echo "::endgroup::"
+            if [ "$(jq -s 'flatten | map(select(.type=="result")) | last | .is_error' "$EXEC_FILE" 2>/dev/null)" = "false" ]; then
+              ok=true
+            fi
+          fi
+          echo "ok=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" = true ]; then
+            echo "Claude review completed on attempt 1."
+          else
+            echo "::warning::Claude review attempt 1 did not complete (claude-code-action#892); retrying."
+          fi
+
+      - name: Claude Code Review (attempt 2, retry)
+        id: review2
+        if: steps.skip-check.outputs.skip != 'true' && steps.docs-check.outputs.docs_only != 'true' && steps.review_check.outputs.ok != 'true'
+        continue-on-error: true
+        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc  # v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          claude_args: |
+            --model claude-opus-4-5-20251101
+            --allowedTools "Bash(gh:*)"
+          prompt: |
+            Review PR #${{ github.event.pull_request.number || github.event.issue.number }} in ${{ github.repository }} for code quality,
+            security issues, potential bugs, and best practices.
+
+            If you find issues, leave inline review comments describing them and DO NOT approve.
+
+            If everything looks good and you have no blocking concerns, you MUST explicitly approve
+            the PR by running:
+              gh pr review ${{ github.event.pull_request.number || github.event.issue.number }} --repo ${{ github.repository }} --approve --body "Reviewed by Claude — no issues found."
+            Do not consider the review complete until you have either left blocking comments OR run
+            the approve command above. Silence is not acceptable.
+
+      - name: Report final review status
+        if: steps.skip-check.outputs.skip != 'true' && steps.docs-check.outputs.docs_only != 'true' && steps.review_check.outputs.ok != 'true'
+        env:
+          EXEC_FILE: ${{ steps.review2.outputs.execution_file }}
+        run: |
+          if [ -n "$EXEC_FILE" ] && [ -f "$EXEC_FILE" ] && \
+             [ "$(jq -s 'flatten | map(select(.type=="result")) | last | .is_error' "$EXEC_FILE" 2>/dev/null)" = "false" ]; then
+            echo "Claude review completed on retry."
+          else
+            echo "::warning::Claude review errored on both attempts (claude-code-action#892). Re-run this job to retry."
+          fi

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: Check if review should be skipped
         id: skip-check
         run: |
-          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+          if [ "${{ github.actor }}" = "dependabot[bot]" ] || \
+             [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Skipping Claude review for dependabot PR"
           elif [ "${{ github.event_name }}" = "pull_request" ] && \
@@ -55,7 +56,7 @@ jobs:
       - name: Generate GitHub App token
         if: steps.skip-check.outputs.skip != 'true'
         id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -157,7 +158,7 @@ jobs:
         id: review1
         if: steps.skip-check.outputs.skip != 'true' && steps.docs-check.outputs.docs_only != 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc  # v1
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
@@ -203,7 +204,7 @@ jobs:
         id: review2
         if: steps.skip-check.outputs.skip != 'true' && steps.docs-check.outputs.docs_only != 'true' && steps.review_check.outputs.ok != 'true'
         continue-on-error: true
-        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc  # v1
+        uses: anthropics/claude-code-action@a92e7c70a4da9793dc164451d829089dc057a464  # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The Claude Code Review auto-approver intermittently fails to approve clean PRs. Root cause: `anthropics/claude-code-action` sometimes exits 0 while its run ended with `is_error: true` ([claude-code-action#892](https://github.com/anthropics/claude-code-action/issues/892), still open — no fixed release). When that happens the action never runs `gh pr review --approve`, **and** the job's `continue-on-error: true` reports the `claude` check as green. Net effect: the PR silently never gets approved.

Observed on weirdtangent/pulse-os#193: first run errored at 3 turns (`is_error: true`), a manual re-run succeeded (15 turns + approval). So it's **transient** — a retry fixes it.

## Fix

- Run the action (attempt 1), then inspect its `execution_file` output — the final `result` message's `is_error` — to detect the silent failure (parsed robustly for either a JSON array or JSON-lines).
- If it didn't complete, **retry once**.
- A final step emits a `::warning::` if both attempts error, so a maintainer knows to re-run instead of assuming silence == approved.

Purely additive and regression-proof: if detection ever misfires, the worst case is the retry runs an extra time (or not) — never worse than today.

## Validation

This PR's own review run exercises the new workflow. The `execution_file` tail is logged in the "Check whether the review completed" step to confirm the parsed format. Once green here, the **identical** workflow will be propagated to the other 6 repos to fix the drift and make all 7 consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)