### PR TITLE
feat(network): pin wifi to 2.4GHz and harden watchdog health check

### DIFF
--- a/bin/pulse-net-check.sh
+++ b/bin/pulse-net-check.sh
@@ -1,26 +1,63 @@
 #!/usr/bin/env bash
 # Health check for the watchdog(8) daemon (test-binary).
 #
-# Exits non-zero when the default gateway is unreachable, which is the
-# signature of the "soft hang" failure mode we have observed on Pulse devices:
-# systemd stays alive (so it keeps petting the kernel watchdog) but networking
-# is wedged and the device is effectively dead until a manual power-cycle.
+# Returns 0 (healthy) only when the device can complete a real TCP round-trip to
+# at least one upstream host. A bare ICMP ping to the default gateway is NOT
+# sufficient: the Pi's brcmfmac SDIO firmware keeps answering gateway pings even
+# when the actual datapath is wedged. Observed 2026-06-30 on pulse-kitchen — the
+# device went dark to all real traffic for ~9 min (no logs shipped, app dead)
+# while the gateway stayed "reachable", so the old gateway-ping check never
+# tripped and the board never self-reset. A TCP connect exercises the full TX/RX
+# path through the firmware, so a wedge fails it.
 #
-# When this script keeps failing for longer than watchdog.conf's retry-timeout,
-# the watchdog daemon stops petting /dev/watchdog and the BCM2835 hardware
-# timer resets the board — recovery in minutes instead of hours, with no
-# reliance on a clean reboot path (which may itself be wedged).
+# Targets default to the system's configured DNS servers (always-on infra the
+# device already depends on, reachable only over the real datapath). The
+# loopback stub (127.0.0.0/8, e.g. systemd-resolved) is excluded so it can never
+# return a false "healthy" with the network down. Override or extend by setting
+#   TARGETS=( "host:port" ... )
+# in /etc/default/pulse-net-check.
+#
+# We report unhealthy only when ALL targets fail, so a single host going down
+# for maintenance does not cause a needless reboot. When this keeps failing past
+# watchdog.conf's retry-timeout, the daemon stops petting /dev/watchdog and the
+# BCM2835 hardware timer resets the board — recovery in minutes, not hours.
 #
 # Kept deliberately lean: the daemon runs this every `interval` seconds.
 set -uo pipefail
 
-# Default gateway, derived at runtime so this works on any network.
-gw=$(ip route show default 2>/dev/null | awk '/default/{print $3; exit}')
-
 # No default route at all is itself an unhealthy state.
-[ -z "$gw" ] && exit 1
+ip route show default 2>/dev/null | grep -q . || exit 1
 
-# A single quick ping; -W is the per-packet timeout in seconds.
-ping -c1 -W3 "$gw" >/dev/null 2>&1 || exit 1
+# Default targets: the configured (non-loopback) DNS servers, on TCP/53.
+declare -a TARGETS=()
+while read -r ip; do
+    [ -n "$ip" ] && TARGETS+=( "${ip}:53" )
+done < <(
+    {
+        resolvectl dns 2>/dev/null
+        awk '/^nameserver/{print $2}' /etc/resolv.conf 2>/dev/null
+    } | grep -oE '([0-9]{1,3}\.){3}[0-9]{1,3}' | grep -vE '^127\.' | sort -u
+)
 
-exit 0
+# Allow site overrides / extra targets (may replace or append to TARGETS).
+# shellcheck disable=SC1091
+[ -r /etc/default/pulse-net-check ] && . /etc/default/pulse-net-check
+
+# Last resort: if no usable target was found, fall back to the gateway on TCP/53
+# (still a real round-trip, unlike an ICMP echo).
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+    gw=$(ip route show default 2>/dev/null | awk '/default/{print $3; exit}')
+    [ -n "$gw" ] && TARGETS+=( "${gw}:53" )
+fi
+[ "${#TARGETS[@]}" -eq 0 ] && exit 1
+
+# Healthy as soon as any single target accepts a TCP connection.
+for hp in "${TARGETS[@]}"; do
+    h=${hp%:*}; p=${hp##*:}
+    if timeout 3 bash -c "exec 3<>/dev/tcp/${h}/${p}" 2>/dev/null; then
+        exec 3>&- 2>/dev/null || true
+        exit 0
+    fi
+done
+
+exit 1

--- a/setup.sh
+++ b/setup.sh
@@ -1569,24 +1569,30 @@ configure_wifi_band() {
         return 0
     }
 
+    # Best-effort throughout: NetworkManager may not be up yet (or D-Bus may be
+    # transiently busy) during provisioning, and band pinning must never abort
+    # the whole setup run under `set -euo pipefail` — so every nmcli call is
+    # non-fatal and we just skip/retry on the next run.
+
     # First Wi-Fi connection profile (these devices have exactly one).
     local con
     con=$(nmcli -t -f NAME,TYPE connection show 2>/dev/null \
-        | awk -F: '$2=="802-11-wireless" || $2=="wifi" {print $1; exit}')
+        | awk -F: '$2=="802-11-wireless" || $2=="wifi" {print $1; exit}' || true)
     if [ -z "$con" ]; then
-        log "No Wi-Fi connection profile found; skipping band pin."
+        log "No Wi-Fi connection profile found (NM down?); skipping band pin."
         return 0
     fi
 
     local current
-    current=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null)
+    current=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
     if [ "$current" = "bg" ]; then
         log "Wi-Fi band already pinned to 2.4 GHz on '$con'."
         return 0
     fi
 
     log "Pinning Wi-Fi to 2.4 GHz (band=bg) on '$con' — applies on next reboot."
-    sudo nmcli connection modify "$con" 802-11-wireless.band bg
+    sudo nmcli connection modify "$con" 802-11-wireless.band bg \
+        || log "Warning: failed to pin Wi-Fi band; will retry on next setup run."
 }
 
 configure_watchdog() {

--- a/setup.sh
+++ b/setup.sh
@@ -1550,13 +1550,54 @@ restart_pulse_services() {
     fi
 }
 
+configure_wifi_band() {
+    # Pin Wi-Fi to the 2.4 GHz band (NetworkManager `band=bg`).
+    #
+    # The Pi's brcmfmac SDIO stack intermittently wedges the whole network — and
+    # sometimes the entire board — when it roams onto a 5 GHz BSSID. Observed
+    # twice on pulse-kitchen (2026-06-28 and 2026-06-30): a 5 GHz roam, then a
+    # silent hang needing a manual power-cycle. 2.4 GHz on these boards is far
+    # more stable and is plenty for the device's workload, so we lock the radio
+    # to it and remove the roam trigger entirely.
+    #
+    # Idempotent and deliberately NON-disruptive: we only update the stored
+    # connection profile and never bounce wlan0 here — re-associating is exactly
+    # what triggers the wedge, so the change is left to take effect on the next
+    # reboot.
+    command -v nmcli >/dev/null 2>&1 || {
+        log "nmcli not found; skipping Wi-Fi band pin."
+        return 0
+    }
+
+    # First Wi-Fi connection profile (these devices have exactly one).
+    local con
+    con=$(nmcli -t -f NAME,TYPE connection show 2>/dev/null \
+        | awk -F: '$2=="802-11-wireless" || $2=="wifi" {print $1; exit}')
+    if [ -z "$con" ]; then
+        log "No Wi-Fi connection profile found; skipping band pin."
+        return 0
+    fi
+
+    local current
+    current=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null)
+    if [ "$current" = "bg" ]; then
+        log "Wi-Fi band already pinned to 2.4 GHz on '$con'."
+        return 0
+    fi
+
+    log "Pinning Wi-Fi to 2.4 GHz (band=bg) on '$con' — applies on next reboot."
+    sudo nmcli connection modify "$con" 802-11-wireless.band bg
+}
+
 configure_watchdog() {
     # Two complementary hardware watchdogs guard against the device hanging in
     # a state that requires a manual power-cycle:
     #
-    #   1. watchdog(8) daemon — proactive. Pets /dev/watchdog only while a
-    #      gateway-reachability health check passes, so a SILENT network-wedge
-    #      hang (systemd alive, nothing logged) forces a hardware reset.
+    #   1. watchdog(8) daemon — proactive. Pets /dev/watchdog only while an
+    #      upstream-reachability health check passes (a real TCP round-trip, not
+    #      just a gateway ping the wedged firmware can still answer), so a SILENT
+    #      network-wedge hang (systemd alive, nothing logged) forces a hardware
+    #      reset.
     #   2. pulse-hw-watchdog.service — reactive. Watches dmesg for *logged*
     #      fatal events (brcmfmac firmware crash, USB HC death, GPU hang) and
     #      reboots immediately.
@@ -1663,6 +1704,7 @@ main() {
     generate_sound_files
     link_home_files
     link_system_files
+    configure_wifi_band
     configure_watchdog
     configure_snapclient
     install_boot_splash


### PR DESCRIPTION
## Why

The brcmfmac SDIO stack on these Pis intermittently wedges the whole network — and sometimes the entire board — when it roams onto a **5 GHz BSSID**. Seen twice on pulse-kitchen:

- **2026-06-28**: 5 GHz roam → silent hang, ~2.5 h offline until a manual power-cycle.
- **2026-06-30**: 5 GHz roam (`be:eb:d6` @ 5720 MHz) → dark to all traffic for ~9 min, manual reboot.

Power-save-off (shipped earlier) stopped the minute-to-minute flapping but not the roam-triggered wedge. And the existing watchdog **never fired** during the 06-30 hang — proven on the device: the daemon kept petting `/dev/watchdog` the whole time because its gateway ICMP check kept passing while real traffic was dead.

## What

**1. `configure_wifi_band()` — pin the radio to 2.4 GHz (`band=bg`).**
Removes the roam trigger entirely. 2.4 GHz on these boards is far more stable and is plenty for the workload (kitchen's 2.4 BSSIDs were actually *stronger* than the 5 GHz ones it kept wedging on). Idempotent and **non-disruptive**: only updates the stored connection, never bounces wlan0 (re-associating is what triggers the wedge), so it applies on the next reboot.

**2. `pulse-net-check.sh` — real TCP round-trip instead of gateway ICMP.**
The firmware answers gateway pings even when the datapath is wedged, so the old check gave a false "healthy" straight through the 06-30 hang. Now it does a TCP connect to upstream infra (defaults to the configured DNS servers; loopback excluded so the resolved stub can't fake a pass; override via `/etc/default/pulse-net-check`). Unhealthy only when **all** targets fail, to avoid needless reboots from one host's maintenance.

## Validation

- Both behaviors deployed and verified live on pulse-kitchen (band locked → associates on 2.4 GHz ch6; new net-check returns healthy when infra reachable, non-zero on an unreachable target).
- `bash -n` clean on both files; net-check target derivation + loopback exclusion unit-checked.
- ⚠️ **Persistence of the `nmcli` band write across reboot will be confirmed on the first rollout device** (reboot, re-check `band=bg`) before trusting it fleet-wide. If `nmcli` writeback doesn't survive netplan regen, this switches to a netplan-file edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)