### PR TITLE
feat(wifi): codify power-save-off into setup.sh

### DIFF
--- a/config/system/NetworkManager/wifi-powersave-off.conf
+++ b/config/system/NetworkManager/wifi-powersave-off.conf
@@ -1,0 +1,9 @@
+# Disable Wi-Fi power-save on the Pi's brcmfmac radio.
+#
+# brcmfmac power-save causes association flapping (frequent
+# DISCONNECTED/ASSOC-REJECT churn) and leaves the device intermittently
+# unreachable because the radio sleeps between beacons. Turning it off is a
+# generic reliability win on these boards. NetworkManager applies this default
+# to every Wi-Fi connection (value 2 = disable power-save).
+[connection]
+wifi.powersave = 2

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -229,5 +229,22 @@ When the guard declines a reboot, you'll see `pulse-safe-reboot` entries in sysl
 
 If you prefer not to schedule a reboot at 03:00 every day, leave `PULSE_DAILY_REBOOT_ENABLED="false"` (the default) or set it explicitly to `false` and rerun `./setup.sh` to disable the timer.
 
-Send PRs with any other gotchas so future builders don't have to rediscover them.
+## Wi-Fi keeps dropping, or the device wedges until a power-cycle
 
+**Problem**: The device periodically loses Wi-Fi, becomes intermittently unreachable over SSH, or goes completely dark (no logs, no network) and only comes back after pulling power. Logs may show `wpa_supplicant` `DISCONNECTED`/`ASSOC-REJECT` churn, or simply stop entirely with no error.
+
+**Cause**: The Pi's onboard `brcmfmac` Wi-Fi has two failure modes here:
+
+1. **Power-save flapping** — the radio sleeps between beacons, causing association churn and making the device intermittently unreachable.
+2. **5 GHz roam wedge** — the SDIO firmware can wedge the whole network stack (and occasionally hang the board) when it roams onto a 5 GHz BSSID. The hang is *silent* — systemd stays alive but networking is dead, so nothing is logged.
+
+**Solution**: `setup.sh` (`configure_wifi`) applies two generic mitigations automatically on every run:
+
+1. Installs `/etc/NetworkManager/conf.d/wifi-powersave-off.conf` (`wifi.powersave = 2`) to disable power-save.
+2. Pins the connection to 2.4 GHz (`band=bg`), which is far more stable on these boards and removes the roam trigger.
+
+Both are non-disruptive (they never bounce `wlan0`); the band pin takes effect on the next reboot. Verify with `iw dev wlan0 get power_save` (should read `off`) and `iw dev wlan0 link` (frequency should be 2.4 GHz, i.e. 2412–2472 MHz).
+
+As a backstop, the `watchdog(8)` daemon (see `configure_watchdog`) runs `pulse-net-check.sh`, which does a real TCP round-trip to an upstream host — not just a gateway ping the wedged firmware can still answer — so a silent wedge forces a hardware reset within a few minutes instead of waiting for a manual power-cycle.
+
+Send PRs with any other gotchas so future builders don't have to rediscover them.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,7 +243,7 @@ If you prefer not to schedule a reboot at 03:00 every day, leave `PULSE_DAILY_RE
 1. Installs `/etc/NetworkManager/conf.d/wifi-powersave-off.conf` (`wifi.powersave = 2`) to disable power-save.
 2. Pins the connection to 2.4 GHz (`band=bg`), which is far more stable on these boards and removes the roam trigger.
 
-Both are non-disruptive (they never bounce `wlan0`); the band pin takes effect on the next reboot. Verify with `iw dev wlan0 get power_save` (should read `off`) and `iw dev wlan0 link` (frequency should be 2.4 GHz, i.e. 2412–2472 MHz).
+Both are non-disruptive (they never bounce the Wi-Fi interface); the band pin takes effect on the next reboot. Verify with `iw dev wlan0 get power_save` (should read `off`) and `iw dev wlan0 link` (frequency should be 2.4 GHz, i.e. 2412–2472 MHz). On Raspberry Pi OS the interface is `wlan0`; if predictable names are enabled, substitute your interface (find it with `iw dev`).
 
 As a backstop, the `watchdog(8)` daemon (see `configure_watchdog`) runs `pulse-net-check.sh`, which does a real TCP round-trip to an upstream host — not just a gateway ping the wedged firmware can still answer — so a silent wedge forces a hardware reset within a few minutes instead of waiting for a manual power-cycle.
 

--- a/setup.sh
+++ b/setup.sh
@@ -1550,20 +1550,36 @@ restart_pulse_services() {
     fi
 }
 
-configure_wifi_band() {
-    # Pin Wi-Fi to the 2.4 GHz band (NetworkManager `band=bg`).
+configure_wifi() {
+    # Wi-Fi reliability hardening for the Pi's brcmfmac SDIO stack, which can
+    # wedge the whole network — and sometimes the entire board — until a manual
+    # power-cycle. Two independent, generic measures:
     #
-    # The Pi's brcmfmac SDIO stack intermittently wedges the whole network — and
-    # sometimes the entire board — when it roams onto a 5 GHz BSSID. Observed
-    # twice on pulse-kitchen (2026-06-28 and 2026-06-30): a 5 GHz roam, then a
-    # silent hang needing a manual power-cycle. 2.4 GHz on these boards is far
-    # more stable and is plenty for the device's workload, so we lock the radio
-    # to it and remove the roam trigger entirely.
+    #   1. Disable Wi-Fi power-save — brcmfmac power-save causes association
+    #      flapping and leaves the device intermittently unreachable (the radio
+    #      sleeps between beacons).
+    #   2. Pin the radio to 2.4 GHz (band=bg) — the silent wedge is
+    #      overwhelmingly triggered by roaming onto a 5 GHz BSSID. Observed twice
+    #      on pulse-kitchen (2026-06-28 and 2026-06-30): a 5 GHz roam, then a
+    #      hang needing a power-cycle. 2.4 GHz on these boards is far more stable
+    #      and is plenty for the workload, so we remove the roam trigger.
     #
-    # Idempotent and deliberately NON-disruptive: we only update the stored
-    # connection profile and never bounce wlan0 here — re-associating is exactly
-    # what triggers the wedge, so the change is left to take effect on the next
-    # reboot.
+    # Everything here is idempotent and deliberately NON-disruptive: config is
+    # updated and power-save is toggled at runtime, but wlan0 is never bounced
+    # (re-associating is exactly what triggers the wedge). The band pin takes
+    # effect on the next reboot. Safe to re-run on every app upgrade.
+
+    # --- 1. Disable Wi-Fi power-save (NetworkManager global drop-in) --------
+    sudo mkdir -p /etc/NetworkManager/conf.d
+    sudo install -m 0644 \
+        "$REPO_DIR/config/system/NetworkManager/wifi-powersave-off.conf" \
+        /etc/NetworkManager/conf.d/wifi-powersave-off.conf
+    # Reload NM config so the new default is picked up, and turn power-save off
+    # on the live interface now without re-associating. Both best-effort.
+    sudo nmcli general reload conf 2>/dev/null || true
+    sudo iw dev wlan0 set power_save off 2>/dev/null || true
+
+    # --- 2. Pin Wi-Fi to the 2.4 GHz band (band=bg) ------------------------
     command -v nmcli >/dev/null 2>&1 || {
         log "nmcli not found; skipping Wi-Fi band pin."
         return 0
@@ -1710,7 +1726,7 @@ main() {
     generate_sound_files
     link_home_files
     link_system_files
-    configure_wifi_band
+    configure_wifi
     configure_watchdog
     configure_snapclient
     install_boot_splash

--- a/setup.sh
+++ b/setup.sh
@@ -1565,19 +1565,27 @@ configure_wifi() {
     #      and is plenty for the workload, so we remove the roam trigger.
     #
     # Everything here is idempotent and deliberately NON-disruptive: config is
-    # updated and power-save is toggled at runtime, but wlan0 is never bounced
-    # (re-associating is exactly what triggers the wedge). The band pin takes
-    # effect on the next reboot. Safe to re-run on every app upgrade.
+    # updated and power-save is toggled at runtime, but the Wi-Fi interface is
+    # never bounced (re-associating is exactly what triggers the wedge). The band
+    # pin takes effect on the next reboot. Safe to re-run on every app upgrade.
 
     # --- 1. Disable Wi-Fi power-save (NetworkManager global drop-in) --------
+    # The drop-in is the durable, interface-agnostic mechanism (NM applies it to
+    # every Wi-Fi connection); the runtime `iw` toggle below just makes it take
+    # effect now without a reconnect.
     sudo mkdir -p /etc/NetworkManager/conf.d
     sudo install -m 0644 \
         "$REPO_DIR/config/system/NetworkManager/wifi-powersave-off.conf" \
         /etc/NetworkManager/conf.d/wifi-powersave-off.conf
-    # Reload NM config so the new default is picked up, and turn power-save off
-    # on the live interface now without re-associating. Both best-effort.
     sudo nmcli general reload conf 2>/dev/null || true
-    sudo iw dev wlan0 set power_save off 2>/dev/null || true
+    # Turn power-save off on the live Wi-Fi interface now (best-effort). Derive
+    # the interface name rather than assuming wlan0, in case predictable names
+    # (wlp*) are in use.
+    local wif
+    wif=$(iw dev 2>/dev/null | awk '/Interface/{print $2; exit}' || true)
+    if [ -n "$wif" ]; then
+        sudo iw dev "$wif" set power_save off 2>/dev/null || true
+    fi
 
     # --- 2. Pin Wi-Fi to the 2.4 GHz band (band=bg) ------------------------
     command -v nmcli >/dev/null 2>&1 || {


### PR DESCRIPTION
## Why

Disabling brcmfmac Wi-Fi power-save is a **generic** reliability win on these Pis — power-save causes association flapping and leaves the device intermittently unreachable (the radio sleeps between beacons). It was the original fix for pulse-kitchen's flapping, but it only ever existed as a **live, per-device** change and was never in the repo, so a freshly provisioned device would come up with power-save back ON.

This bakes it into the app so every device gets it automatically on the next `setup.sh` run (which runs after every app upgrade) — closing the gap left by #195 (band pin + TCP watchdog check).

## What

- **`config/system/NetworkManager/wifi-powersave-off.conf`** — NM global drop-in (`wifi.powersave = 2`).
- **`configure_wifi_band` → `configure_wifi`** — the Wi-Fi setup step now does both power-save-off *and* the 2.4 GHz band pin. It installs the drop-in, `nmcli general reload conf`, and `iw dev wlan0 set power_save off` to apply on the live interface **without bouncing wlan0**. Idempotent and non-disruptive — safe to re-run on every upgrade.
- **`docs/troubleshooting.md`** — new "Wi-Fi keeps dropping / device wedges until a power-cycle" entry documenting both failure modes and all three mitigations, so it's also discoverable as an FAQ.

## Validation

- `bash -n` clean; clean rename (no stale `configure_wifi_band` refs).
- Both behaviors already verified live across all four pulse devices: power-save now `off`, still associated on 2.4 GHz, watchdog active with the working check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)