### PR TITLE
feat(wifi): per-device band policy — pin camera kiosks to 5 GHz

### DIFF
--- a/bin/pulse-wifi-band-fallback.sh
+++ b/bin/pulse-wifi-band-fallback.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Boot-time safety net for 5 GHz-pinned kiosks (see configure_wifi / the
+# wifi-band-policy file).
+#
+# A device pinned to a single 5 GHz BSSID (band=a) has no fallback if that AP is
+# down, moved to a DFS channel it can't join, or replaced — it would boot
+# stranded, offline. This one-shot catches that: if a band=a device can't reach
+# any upstream within the timeout, it reverts to 2.4 GHz (band=bg, BSSID
+# cleared) and reboots, so the kiosk comes back online (streaming will buffer,
+# but online beats stranded).
+#
+# Self-limiting: it only acts when band=a, so once it has reverted to bg it does
+# nothing on subsequent boots — no reboot loop, even during a real network
+# outage. configure_wifi re-pins band=a on the next app upgrade (setup.sh run),
+# so recovery is automatic once the AP/BSSID is back.
+#
+# Health is judged by pulse-net-check.sh (a real TCP round-trip), NOT a gateway
+# ping — the wedged brcmfmac firmware answers gateway pings while the datapath
+# is dead, which would mask a genuine failure.
+set -uo pipefail
+
+# First Wi-Fi connection profile (these devices have exactly one).
+con=$(nmcli -t -f NAME,TYPE connection show 2>/dev/null \
+    | awk -F: '$2=="802-11-wireless" || $2=="wifi" {print $1; exit}' || true)
+[ -n "$con" ] || exit 0
+
+band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
+[ "$band" = "a" ] || exit 0   # only guard 5 GHz-pinned devices
+
+# Give the pinned association up to ~150s to come up and reach upstream.
+for _ in $(seq 1 30); do
+    if /usr/local/sbin/pulse-net-check.sh; then
+        exit 0    # healthy on the pinned 5 GHz BSSID — nothing to do
+    fi
+    sleep 5
+done
+
+logger -t pulse-wifi-band-fallback \
+    "5 GHz pin on '$con' unreachable after boot; reverting to band=bg and rebooting"
+nmcli connection modify "$con" 802-11-wireless.band bg 802-11-wireless.bssid "" \
+    || logger -t pulse-wifi-band-fallback "Warning: failed to revert band; rebooting anyway"
+systemctl reboot

--- a/bin/pulse-wifi-band-fallback.sh
+++ b/bin/pulse-wifi-band-fallback.sh
@@ -38,5 +38,18 @@ done
 logger -t pulse-wifi-band-fallback \
     "5 GHz pin on '$con' unreachable after boot; reverting to band=bg and rebooting"
 nmcli connection modify "$con" 802-11-wireless.band bg 802-11-wireless.bssid "" \
-    || logger -t pulse-wifi-band-fallback "Warning: failed to revert band; rebooting anyway"
-systemctl reboot
+    || logger -t pulse-wifi-band-fallback "Warning: nmcli revert reported failure."
+
+# Only reboot if the revert actually took. If the band is still 'a' (nmcli
+# failed, D-Bus wedged, etc.), rebooting would re-enter this exact path on the
+# next boot — band=a, unreachable, revert fails, reboot — an endless reboot
+# loop. In that case leave the device up (stranded but stable) and let the next
+# setup.sh run re-attempt the revert.
+new_band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
+if [ "$new_band" = "bg" ]; then
+    systemctl reboot
+else
+    logger -t pulse-wifi-band-fallback \
+        "Band still '$new_band' after revert attempt; NOT rebooting to avoid a reboot loop — setup.sh will retry."
+    exit 1
+fi

--- a/config/system/pulse-wifi-band-fallback.service
+++ b/config/system/pulse-wifi-band-fallback.service
@@ -7,6 +7,11 @@ ConditionPathExists=/opt/pulse-os/bin/pulse-wifi-band-fallback.sh
 
 [Service]
 Type=oneshot
+# The script polls upstream for up to ~150s before reverting the pin. That
+# exceeds systemd's default TimeoutStartSec (90s), which would kill the oneshot
+# mid-poll and leave the 5 GHz pin in place — defeating the safety net. Give it
+# ample margin over the poll loop plus net-check/reboot overhead.
+TimeoutStartSec=300
 ExecStart=/opt/pulse-os/bin/pulse-wifi-band-fallback.sh
 
 [Install]

--- a/config/system/pulse-wifi-band-fallback.service
+++ b/config/system/pulse-wifi-band-fallback.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Pulse Wi-Fi band fallback (revert an unreachable 5 GHz pin to 2.4 GHz at boot)
+After=NetworkManager.service network.target
+Wants=NetworkManager.service
+# Only meaningful on boot; the script no-ops unless the device is 5 GHz-pinned.
+ConditionPathExists=/opt/pulse-os/bin/pulse-wifi-band-fallback.sh
+
+[Service]
+Type=oneshot
+ExecStart=/opt/pulse-os/bin/pulse-wifi-band-fallback.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/config/wifi-band-policy
+++ b/config/wifi-band-policy
@@ -1,0 +1,30 @@
+# Per-device Wi-Fi band policy, consumed by configure_wifi() in setup.sh.
+#
+# Background: the Pi's brcmfmac SDIO Wi-Fi stack can wedge the board when it
+# ROAMS onto a 5 GHz BSSID (see configure_wifi). The blanket mitigation is to
+# pin devices to 2.4 GHz. But 2.4 GHz is half-duplex and congested, so a live
+# camera stream (go2rtc) buffers badly on the kiosks that display one. For those
+# devices we instead pin a SINGLE strong 5 GHz BSSID: locking the BSSID removes
+# the roam trigger (a stationary kiosk never needs to roam) while restoring the
+# ~6x throughput and low jitter the stream needs.
+#
+# Format — one device per line:
+#   <location>   <band>   [bssid]
+#     location : the value from /etc/pulse-location (hostname is pulse-<location>)
+#     band     : "a" (5 GHz, BSSID pin REQUIRED) or "bg" (2.4 GHz)
+#     bssid    : AP MAC to lock to; mandatory when band=a, ignored for bg
+#
+# Anything not listed here defaults to "bg" (2.4 GHz) — the wedge-safe baseline.
+# Comments (#) and blank lines are ignored; whitespace-separated fields.
+#
+# NOTE: band=a entries hardcode a physical AP's BSSID. Pick a NON-DFS channel on
+# that AP (UNII-1 36-48 / UNII-3 149-165) — a DFS channel's periodic CAC / radar
+# vacate makes a BSSID-locked client drop with no fallback, and cold-boot
+# association to a DFS "No-IR" channel is unreliable. If you swap/replace that
+# AP, update the BSSID here; otherwise the boot-time fallback (see
+# pulse-wifi-band-fallback.service) reverts the device to 2.4 GHz so it stays
+# online (streaming will just buffer until this is corrected).
+
+office        a    9A:2A:6F:BE:EB:D6   # camera kiosk — AP on ch149 (non-DFS)
+great-room    a    9A:2A:6F:A2:57:22   # camera kiosk — AP on ch36  (non-DFS)
+# kitchen / bedroom: unlisted -> 2.4 GHz (kitchen is the wedge-prone unit)

--- a/setup.sh
+++ b/setup.sh
@@ -1638,8 +1638,13 @@ configure_wifi() {
     cur_band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
     cur_bssid=$(nmcli -g 802-11-wireless.bssid connection show "$con" 2>/dev/null || echo "")
     cur_bssid=${cur_bssid//\\/}   # nmcli may escape the ':' separators
+    # "Already correct" means band matches AND the BSSID pin matches the policy:
+    # for band=a the BSSID must equal the wanted one; for band=bg it must be
+    # empty — otherwise a stale BSSID left over from a previous 5 GHz pin would
+    # keep the device BSSID-locked and unable to roam/fall back.
     if [ "$cur_band" = "$want_band" ] \
-        && { [ "$want_band" != "a" ] || [ "${cur_bssid^^}" = "${want_bssid^^}" ]; }; then
+        && { { [ "$want_band" = "a" ] && [ "${cur_bssid^^}" = "${want_bssid^^}" ]; } \
+             || { [ "$want_band" != "a" ] && [ -z "$cur_bssid" ]; }; }; then
         log "Wi-Fi band already '$want_band'${want_bssid:+ pinned to $want_bssid} on '$con'."
     elif [ "$want_band" = "a" ]; then
         log "Pinning Wi-Fi to 5 GHz BSSID $want_bssid on '$con' — applies on next reboot."

--- a/setup.sh
+++ b/setup.sh
@@ -1558,11 +1558,15 @@ configure_wifi() {
     #   1. Disable Wi-Fi power-save — brcmfmac power-save causes association
     #      flapping and leaves the device intermittently unreachable (the radio
     #      sleeps between beacons).
-    #   2. Pin the radio to 2.4 GHz (band=bg) — the silent wedge is
-    #      overwhelmingly triggered by roaming onto a 5 GHz BSSID. Observed twice
-    #      on pulse-kitchen (2026-06-28 and 2026-06-30): a 5 GHz roam, then a
-    #      hang needing a power-cycle. 2.4 GHz on these boards is far more stable
-    #      and is plenty for the workload, so we remove the roam trigger.
+    #   2. Pin the Wi-Fi band per config/wifi-band-policy — the silent wedge is
+    #      overwhelmingly triggered by roaming onto a 5 GHz BSSID (observed on
+    #      pulse-kitchen 2026-06-28 and -06-30: a 5 GHz roam, then a hang needing
+    #      a power-cycle). Default is 2.4 GHz (band=bg); camera-kiosk devices
+    #      instead LOCK a single strong 5 GHz BSSID, which removes the roam
+    #      trigger (a stationary kiosk never needs to roam) while giving the
+    #      go2rtc stream the ~6x bandwidth and low jitter it needs. A boot-time
+    #      guard (pulse-wifi-band-fallback.service) reverts a device to 2.4 GHz
+    #      if its pinned BSSID is ever unreachable, so it can't strand.
     #
     # Everything here is idempotent and deliberately NON-disruptive: config is
     # updated and power-save is toggled at runtime, but the Wi-Fi interface is
@@ -1587,11 +1591,34 @@ configure_wifi() {
         sudo iw dev "$wif" set power_save off 2>/dev/null || true
     fi
 
-    # --- 2. Pin Wi-Fi to the 2.4 GHz band (band=bg) ------------------------
+    # --- 2. Pin the Wi-Fi band per the device policy -----------------------
     command -v nmcli >/dev/null 2>&1 || {
         log "nmcli not found; skipping Wi-Fi band pin."
         return 0
     }
+
+    # Resolve this device's desired band/bssid from config/wifi-band-policy.
+    # Default is bg (2.4 GHz); a "band a" entry must carry a BSSID to lock.
+    local location="${1:-}"
+    [ -n "$location" ] || location=$(cat "$LOCATION_FILE" 2>/dev/null || true)
+    local want_band="bg" want_bssid="" pline=""
+    if [ -n "$location" ] && [ -r "$REPO_DIR/config/wifi-band-policy" ]; then
+        pline=$(awk -v loc="$location" \
+            '$1 !~ /^#/ && $1==loc {print $2, $3; exit}' \
+            "$REPO_DIR/config/wifi-band-policy" 2>/dev/null || true)
+        if [ -n "$pline" ]; then
+            want_band=${pline%% *}
+            want_bssid=${pline#* }
+            { [ "$want_bssid" = "$pline" ] || [ "${want_bssid:0:1}" = "#" ]; } \
+                && want_bssid=""
+        fi
+    fi
+    if [ "$want_band" = "a" ] && [ -z "$want_bssid" ]; then
+        # Never enable roaming 5 GHz (band=a with no BSSID) — that is the wedge
+        # trigger this whole function exists to avoid.
+        log "Policy for '$location' requests 5 GHz without a BSSID; staying on 2.4 GHz."
+        want_band="bg"
+    fi
 
     # Best-effort throughout: NetworkManager may not be up yet (or D-Bus may be
     # transiently busy) during provisioning, and band pinning must never abort
@@ -1607,16 +1634,36 @@ configure_wifi() {
         return 0
     fi
 
-    local current
-    current=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
-    if [ "$current" = "bg" ]; then
-        log "Wi-Fi band already pinned to 2.4 GHz on '$con'."
-        return 0
+    local cur_band cur_bssid
+    cur_band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
+    cur_bssid=$(nmcli -g 802-11-wireless.bssid connection show "$con" 2>/dev/null || echo "")
+    cur_bssid=${cur_bssid//\\/}   # nmcli may escape the ':' separators
+    if [ "$cur_band" = "$want_band" ] \
+        && { [ "$want_band" != "a" ] || [ "${cur_bssid^^}" = "${want_bssid^^}" ]; }; then
+        log "Wi-Fi band already '$want_band'${want_bssid:+ pinned to $want_bssid} on '$con'."
+    elif [ "$want_band" = "a" ]; then
+        log "Pinning Wi-Fi to 5 GHz BSSID $want_bssid on '$con' — applies on next reboot."
+        sudo nmcli connection modify "$con" \
+            802-11-wireless.band a 802-11-wireless.bssid "$want_bssid" \
+            || log "Warning: failed to pin 5 GHz BSSID; will retry on next setup run."
+    else
+        log "Pinning Wi-Fi to 2.4 GHz (band=bg) on '$con' — applies on next reboot."
+        sudo nmcli connection modify "$con" \
+            802-11-wireless.band bg 802-11-wireless.bssid "" \
+            || log "Warning: failed to pin Wi-Fi band; will retry on next setup run."
     fi
 
-    log "Pinning Wi-Fi to 2.4 GHz (band=bg) on '$con' — applies on next reboot."
-    sudo nmcli connection modify "$con" 802-11-wireless.band bg \
-        || log "Warning: failed to pin Wi-Fi band; will retry on next setup run."
+    # --- 3. Boot-time fallback for 5 GHz-pinned devices --------------------
+    # Guard that reverts an unreachable 5 GHz pin to 2.4 GHz at boot so a
+    # pinned-AP outage can never strand a kiosk. `enable` (not --now): it must
+    # run at boot, not during setup (the band change only takes effect on
+    # reboot). Also retire the ad-hoc self-heal drop-in from manual rollouts.
+    sudo rm -f /etc/cron.d/pulse-wifi-selfheal /usr/local/sbin/pulse-wifi-selfheal.sh
+    sudo ln -sf "$REPO_DIR/config/system/pulse-wifi-band-fallback.service" \
+        /etc/systemd/system/pulse-wifi-band-fallback.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable pulse-wifi-band-fallback.service 2>/dev/null \
+        || log "Warning: could not enable pulse-wifi-band-fallback.service."
 }
 
 configure_watchdog() {
@@ -1734,7 +1781,7 @@ main() {
     generate_sound_files
     link_home_files
     link_system_files
-    configure_wifi
+    configure_wifi "$location"
     configure_watchdog
     configure_snapclient
     install_boot_splash


### PR DESCRIPTION
## Problem

PR #195 pinned the whole fleet to 2.4 GHz (`band=bg`) to stop the brcmfmac roam-wedge. That stopped the hangs but broke the live go2rtc camera view on kiosks that display one — 2.4 GHz is half-duplex and congested, so the stream buffers badly.

## Change

Make the Wi-Fi band per-device via `config/wifi-band-policy`:

- Default stays `bg` (2.4 GHz) — the wedge-safe baseline.
- Camera kiosks lock a single strong 5 GHz BSSID. Locking the BSSID keeps the roam trigger gone (a wall-mounted kiosk never needs to roam) while restoring the bandwidth + low jitter the stream needs.
- Must be a non-DFS channel (UNII-1 36–48 / UNII-3 149–165). A DFS channel's periodic CAC / radar-vacate drops a BSSID-locked client with no fallback, and cold-boot association to a DFS "No-IR" channel is unreliable — verified live.

### Safety net — `pulse-wifi-band-fallback.service`
A boot-time one-shot: if a `band=a` device cannot reach any upstream (via the existing `pulse-net-check.sh` TCP probe) within ~150 s, it reverts to `band=bg` and reboots, so a pinned-AP outage cannot strand a kiosk. Self-limiting — it only acts when `band=a`, so no reboot loop even in a real outage; `configure_wifi` re-pins on the next app upgrade once the AP is back.

## Testing
- `bash -n` clean on `setup.sh` and the fallback script.
- Unit-tested policy parsing (band=a with BSSID, bg, unknown-location default).
- Live-validated on two kiosks: pinned non-DFS 5 GHz BSSID associates quickly at full rate; the fallback correctly reverted an earlier DFS attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)