### PR TITLE
fix(update): preserve machine-local wifi-band-policy across OTA git clean

### DIFF
--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -2162,6 +2162,13 @@ class KioskMqttListener:
                     "--exclude=pulse.conf.*",
                     "--exclude=pulse-devices.conf",
                     "--exclude=pulse-mcp.conf",
+                    # Machine-local files must be excluded here even when
+                    # .gitignore covers them: this clean runs BEFORE git pull,
+                    # so it consults the OLD checkout's .gitignore — an update
+                    # crossing the commit that gitignored a file would delete
+                    # it (this wiped every device's Wi-Fi band policy once,
+                    # knocking the fleet back to unpinned 2.4 GHz).
+                    "--exclude=config/wifi-band-policy",
                 ],
                 repo_dir,
             ),

--- a/uv.lock
+++ b/uv.lock
@@ -444,15 +444,15 @@ wheels = [
 
 [[package]]
 name = "icalendar"
-version = "7.1.3"
+version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/86/16051e4f00db105d76bfd79f87cc5685c55d562d335f97c71bf128914c56/icalendar-7.1.3.tar.gz", hash = "sha256:eb03a0e215f30db689a72c49f18f998aabf17522eb0858a293c393510850727c", size = 472734, upload-time = "2026-06-15T14:06:13.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/6c/3a20edd47656272f2d4016f6680f5bec6e2eb5ec7a23db97ebd1c15c384b/icalendar-7.2.0.tar.gz", hash = "sha256:32dacc396101825b82f9f1bbdf691c02be613130d5ab7a457e553fcd20959fdd", size = 489932, upload-time = "2026-06-23T06:48:16.492Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/57/aa44e7af1244856d92a700dca5089777a334fecd328f82d5faa5c2696e2e/icalendar-7.1.3-py3-none-any.whl", hash = "sha256:690f30aa50a76cbf854db5ad52654705db9c5cd0e1b152222f5d4b7854b60667", size = 475481, upload-time = "2026-06-15T14:06:11.605Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a5/21a77abb12e68a986d56fdacbfbdda0606a71766662b8d19cd85d49f78dc/icalendar-7.2.0-py3-none-any.whl", hash = "sha256:77922b6be57dfcc2e94f93063d2fd7e948ada9b5bdf7b08bebbc684b1b66c7c4", size = 500620, upload-time = "2026-06-23T06:48:14.861Z" },
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ requires-dist = [
     { name = "astral", specifier = "==3.2" },
     { name = "black", marker = "extra == 'dev'", specifier = "==26.3.1" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "icalendar", specifier = "==7.1.3" },
+    { name = "icalendar", specifier = "==7.2.0" },
     { name = "openlocationcode", specifier = "==1.0.1" },
     { name = "packaging", specifier = "==26.2" },
     { name = "paho-mqtt", specifier = "==2.1.0" },


### PR DESCRIPTION
## Problem

The OTA update flow in `kiosk-mqtt-listener.py` runs `git clean -fd` **before** `git pull`, so the clean evaluates ignore rules against the *old* checkout. When an update crosses the commit that converted `config/wifi-band-policy` to a machine-local, gitignored file (#199), the clean/checkout sequence deletes the deployed policy file. The subsequent `setup.sh` run then sees no policy and resets the device to the unpinned 2.4 GHz default — silently undoing the per-device band policy on every device that takes the update.

## Fix

- Add `--exclude=config/wifi-band-policy` to the `git clean` step, alongside the other machine-local configs (`pulse.conf`, `pulse-devices.conf`, `pulse-mcp.conf`), with a comment explaining why the exclude is required even though the file is gitignored at HEAD.
- Also sync `uv.lock` with `pyproject.toml` (icalendar 7.2.0 from #192 was never locked), since the stale lock made every uv-managed pre-commit hook run dirty the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)