### PR TITLE
feat(wifi): support optional BSSID lock for 2.4 GHz policy entries

### DIFF
--- a/bin/pulse-wifi-band-fallback.sh
+++ b/bin/pulse-wifi-band-fallback.sh
@@ -1,18 +1,19 @@
 #!/usr/bin/env bash
-# Boot-time safety net for 5 GHz-pinned kiosks (see configure_wifi / the
+# Boot-time safety net for BSSID-pinned kiosks (see configure_wifi / the
 # wifi-band-policy file).
 #
-# A device pinned to a single 5 GHz BSSID (band=a) has no fallback if that AP is
-# down, moved to a DFS channel it can't join, or replaced — it would boot
-# stranded, offline. This one-shot catches that: if a band=a device can't reach
-# any upstream within the timeout, it reverts to 2.4 GHz (band=bg, BSSID
+# A device pinned to a single BSSID has no fallback if that AP is down, moved
+# to a DFS channel it can't join, or replaced — it would boot stranded,
+# offline. This one-shot catches that: if a pinned device can't reach any
+# upstream within the timeout, it reverts to unpinned 2.4 GHz (band=bg, BSSID
 # cleared) and reboots, so the kiosk comes back online (streaming will buffer,
 # but online beats stranded).
 #
-# Self-limiting: it only acts when band=a, so once it has reverted to bg it does
-# nothing on subsequent boots — no reboot loop, even during a real network
-# outage. configure_wifi re-pins band=a on the next app upgrade (setup.sh run),
-# so recovery is automatic once the AP/BSSID is back.
+# Self-limiting: it only acts when a pin is present (band=a, or band=bg with a
+# BSSID lock), so once it has reverted to unpinned bg it does nothing on
+# subsequent boots — no reboot loop, even during a real network outage.
+# configure_wifi re-applies the policy pin on the next app upgrade (setup.sh
+# run), so recovery is automatic once the AP/BSSID is back.
 #
 # Health is judged by pulse-net-check.sh (a real TCP round-trip), NOT a gateway
 # ping — the wedged brcmfmac firmware answers gateway pings while the datapath
@@ -25,31 +26,37 @@ con=$(nmcli -t -f NAME,TYPE connection show 2>/dev/null \
 [ -n "$con" ] || exit 0
 
 band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
-[ "$band" = "a" ] || exit 0   # only guard 5 GHz-pinned devices
+bssid=$(nmcli -g 802-11-wireless.bssid connection show "$con" 2>/dev/null || echo "")
+# Only guard pinned devices: 5 GHz (band=a), or 2.4 GHz locked to one BSSID.
+# Unpinned bg is already the fallback state — nothing to revert to.
+if [ "$band" != "a" ] && [ -z "$bssid" ]; then
+    exit 0
+fi
 
 # Give the pinned association up to ~150s to come up and reach upstream.
 for _ in $(seq 1 30); do
     if /usr/local/sbin/pulse-net-check.sh; then
-        exit 0    # healthy on the pinned 5 GHz BSSID — nothing to do
+        exit 0    # healthy on the pin — nothing to do
     fi
     sleep 5
 done
 
 logger -t pulse-wifi-band-fallback \
-    "5 GHz pin on '$con' unreachable after boot; reverting to band=bg and rebooting"
+    "Pin (band=$band${bssid:+, bssid $bssid}) on '$con' unreachable after boot; reverting to unpinned bg and rebooting"
 nmcli connection modify "$con" 802-11-wireless.band bg 802-11-wireless.bssid "" \
     || logger -t pulse-wifi-band-fallback "Warning: nmcli revert reported failure."
 
-# Only reboot if the revert actually took. If the band is still 'a' (nmcli
+# Only reboot if the revert actually took. If the pin is still in place (nmcli
 # failed, D-Bus wedged, etc.), rebooting would re-enter this exact path on the
-# next boot — band=a, unreachable, revert fails, reboot — an endless reboot
+# next boot — pinned, unreachable, revert fails, reboot — an endless reboot
 # loop. In that case leave the device up (stranded but stable) and let the next
 # setup.sh run re-attempt the revert.
 new_band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
-if [ "$new_band" = "bg" ]; then
+new_bssid=$(nmcli -g 802-11-wireless.bssid connection show "$con" 2>/dev/null || echo "")
+if [ "$new_band" = "bg" ] && [ -z "$new_bssid" ]; then
     systemctl reboot
 else
     logger -t pulse-wifi-band-fallback \
-        "Band still '$new_band' after revert attempt; NOT rebooting to avoid a reboot loop — setup.sh will retry."
+        "Still pinned (band=$new_band${new_bssid:+, bssid $new_bssid}) after revert attempt; NOT rebooting to avoid a reboot loop — setup.sh will retry."
     exit 1
 fi

--- a/config/wifi-band-policy.sample
+++ b/config/wifi-band-policy.sample
@@ -32,7 +32,10 @@
 #   <location>   <band>   [bssid]
 #     location : the value from /etc/pulse-location (hostname is pulse-<location>)
 #     band     : "a" (5 GHz, BSSID pin REQUIRED) or "bg" (2.4 GHz)
-#     bssid    : AP MAC to lock to; mandatory when band=a, ignored for bg
+#     bssid    : AP MAC to lock to; mandatory when band=a, OPTIONAL for bg —
+#                pin a bg device that hears several APs at similar strength,
+#                where roam scans cause periodic multi-second stalls but the
+#                device must stay on 2.4 GHz (e.g. a wedge-prone unit)
 #
 # Anything not listed here defaults to "bg" (2.4 GHz).
 # Comments (#) and blank lines are ignored; whitespace-separated fields.
@@ -50,3 +53,4 @@
 # living-room   a    XX:XX:XX:XX:XX:XX   # camera kiosk on a non-DFS 5 GHz channel
 # den           a    XX:XX:XX:XX:XX:XX   # BT speaker polling was starving 2.4 GHz
 # porch         bg                       # explicit 2.4 GHz (same as unlisted)
+# pantry        bg   XX:XX:XX:XX:XX:XX   # 2.4 GHz locked to one AP: stops roam-scan stalls

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -243,7 +243,7 @@ If you prefer not to schedule a reboot at 03:00 every day, leave `PULSE_DAILY_RE
 1. Installs `/etc/NetworkManager/conf.d/wifi-powersave-off.conf` (`wifi.powersave = 2`) to disable power-save.
 2. Pins the connection to 2.4 GHz (`band=bg`), which is far more stable on these boards and removes the roam trigger.
 
-Both are non-disruptive (they never bounce the Wi-Fi interface); the band pin takes effect on the next reboot. Verify with `iw dev wlan0 get power_save` (should read `off`) and `iw dev wlan0 link` (frequency should be 2.4 GHz, i.e. 2412–2472 MHz). On Raspberry Pi OS the interface is `wlan0`; if predictable names are enabled, substitute your interface (find it with `iw dev`).
+Both are non-disruptive (they never bounce the Wi-Fi interface); the band pin takes effect on the next reboot. If a 2.4 GHz device still sees periodic multi-second stalls (snapcast time-sync timeouts every 60-90s with no disconnect), the cause is usually wpa_supplicant's full-spectrum roam scans — pin the device to its strongest AP with a `bg <bssid>` entry in `config/wifi-band-policy` (see the sample file), which disables roam scanning entirely. Verify with `iw dev wlan0 get power_save` (should read `off`) and `iw dev wlan0 link` (frequency should be 2.4 GHz, i.e. 2412–2472 MHz). On Raspberry Pi OS the interface is `wlan0`; if predictable names are enabled, substitute your interface (find it with `iw dev`).
 
 As a backstop, the `watchdog(8)` daemon (see `configure_watchdog`) runs `pulse-net-check.sh`, which does a real TCP round-trip to an upstream host — not just a gateway ping the wedged firmware can still answer — so a silent wedge forces a hardware reset within a few minutes instead of waiting for a manual power-cycle.
 

--- a/setup.sh
+++ b/setup.sh
@@ -1601,6 +1601,10 @@ configure_wifi() {
     # a machine-local, untracked file (see config/wifi-band-policy.sample; it
     # holds AP BSSIDs, which are geolocatable and must never be committed).
     # Default is bg (2.4 GHz); a "band a" entry must carry a BSSID to lock.
+    # A "band bg" entry MAY carry a BSSID: locking 2.4 GHz to one AP disables
+    # wpa_supplicant's periodic full-spectrum roam scans (~5 s off-channel),
+    # which stall the datapath and starve snapclient on devices that hear
+    # several APs at similar strength.
     local location="${1:-}"
     [ -n "$location" ] || location=$(cat "$LOCATION_FILE" 2>/dev/null || true)
     local want_band="bg" want_bssid="" pline=""
@@ -1640,24 +1644,19 @@ configure_wifi() {
     cur_band=$(nmcli -g 802-11-wireless.band connection show "$con" 2>/dev/null || echo "")
     cur_bssid=$(nmcli -g 802-11-wireless.bssid connection show "$con" 2>/dev/null || echo "")
     cur_bssid=${cur_bssid//\\/}   # nmcli may escape the ':' separators
-    # "Already correct" means band matches AND the BSSID pin matches the policy:
-    # for band=a the BSSID must equal the wanted one; for band=bg it must be
-    # empty — otherwise a stale BSSID left over from a previous 5 GHz pin would
-    # keep the device BSSID-locked and unable to roam/fall back.
-    if [ "$cur_band" = "$want_band" ] \
-        && { { [ "$want_band" = "a" ] && [ "${cur_bssid^^}" = "${want_bssid^^}" ]; } \
-             || { [ "$want_band" != "a" ] && [ -z "$cur_bssid" ]; }; }; then
+    # "Already correct" means band matches AND the BSSID pin matches the
+    # policy exactly (empty matches empty) — otherwise a stale BSSID left over
+    # from a previous pin would keep the device locked to an AP the policy no
+    # longer names, unable to roam/fall back.
+    if [ "$cur_band" = "$want_band" ] && [ "${cur_bssid^^}" = "${want_bssid^^}" ]; then
         log "Wi-Fi band already '$want_band'${want_bssid:+ pinned to $want_bssid} on '$con'."
-    elif [ "$want_band" = "a" ]; then
-        log "Pinning Wi-Fi to 5 GHz BSSID $want_bssid on '$con' — applies on next reboot."
-        sudo nmcli connection modify "$con" \
-            802-11-wireless.band a 802-11-wireless.bssid "$want_bssid" \
-            || log "Warning: failed to pin 5 GHz BSSID; will retry on next setup run."
     else
-        log "Pinning Wi-Fi to 2.4 GHz (band=bg) on '$con' — applies on next reboot."
+        local band_desc="2.4 GHz (band=bg)"
+        [ "$want_band" = "a" ] && band_desc="5 GHz"
+        log "Pinning Wi-Fi to $band_desc${want_bssid:+ BSSID $want_bssid} on '$con' — applies on next reboot."
         sudo nmcli connection modify "$con" \
-            802-11-wireless.band bg 802-11-wireless.bssid "" \
-            || log "Warning: failed to pin Wi-Fi band; will retry on next setup run."
+            802-11-wireless.band "$want_band" 802-11-wireless.bssid "$want_bssid" \
+            || log "Warning: failed to pin Wi-Fi band/BSSID; will retry on next setup run."
     fi
 
     # --- 3. Boot-time fallback for 5 GHz-pinned devices --------------------


### PR DESCRIPTION
## Problem

A device that hears several APs at similar strength runs wpa_supplicant's periodic full-spectrum roam scans (~5 s off-channel every 60-90 s). These stall the Wi-Fi datapath long enough to starve latency-sensitive clients (snapcast's 2 s time-sync timeout, dashboard image loads) — even when the band is already pinned to 2.4 GHz. BSSID-locking disables roam scanning, but `configure_wifi` treated any BSSID on a `bg` entry as stale state and actively cleared it, so a 2.4 GHz BSSID pin could not survive a setup run. This matters for devices that must stay on 2.4 GHz (the wedge-prone unit) but suffer roam-scan stalls.

## Changes

- **`configure_wifi`**: a `bg` policy entry may now carry an optional BSSID. Desired state is simply `(band, bssid) == policy` for both bands; the modify branch collapses to a single call.
- **`pulse-wifi-band-fallback`**: now guards *any* pinned device (`band=a`, or `band=bg` with a BSSID) instead of only 5 GHz pins, reverting to unpinned bg + reboot if the pinned AP is unreachable at boot. A stranded 2.4 GHz pin previously had no safety net. Still self-limiting (acts only while a pin is present) and still refuses to reboot if the revert didn't take.
- **Docs**: sample policy file and troubleshooting FAQ describe the `bg <bssid>` form and when to use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)