### PR TITLE
feat: auto-recover snapclient when connected but silent

### DIFF
--- a/bin/pulse-audio-watchdog.py
+++ b/bin/pulse-audio-watchdog.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Auto-recover the Snapcast client when it is connected but producing no audio.
+
+Background
+----------
+``snapclient`` streams through PipeWire/Pulse (``--player pulse``). It resolves
+the ``default`` sink once, when its player connects. If that sink later
+disappears and is re-created with a new index -- e.g. a USB DAC re-enumerates,
+or PipeWire restarts -- the player connection goes stale and snapclient can sit
+there "connected" to the server while feeding audio to a sink that no longer
+exists. The process never crashes, so ``Restart=always`` in the unit does not
+help, and the room goes silent until someone restarts the service by hand.
+
+This watchdog closes that gap. Every POLL_INTERVAL seconds it asks the snapserver
+whether *this* client is supposed to be playing (stream ``playing`` + client
+connected + not muted). If it is, but there is no local snapclient sink-input
+feeding audio, it waits SILENT_GRACE seconds (to rule out a normal
+stream-startup gap) and then restarts ``pulse-snapclient.service``.
+
+It is deliberately fail-safe: if the snapserver status cannot be fetched, or the
+stream is idle, or the client is muted/disconnected, it does nothing. It only
+ever acts on the specific "server is playing but we are silent" condition.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+
+# ── Tunables (override via environment / EnvironmentFile) ────────────────────
+POLL_INTERVAL = float(os.environ.get("AUDIO_WATCHDOG_POLL_INTERVAL", "10"))
+# Seconds the "server playing but locally silent" state must persist before we
+# act. Must comfortably exceed snapclient's own reconnect/stream-startup time so
+# we never fight a client that is about to recover on its own.
+SILENT_GRACE = float(os.environ.get("AUDIO_WATCHDOG_SILENT_GRACE", "20"))
+# Minimum seconds between restarts, so a client that is slow to come back never
+# gets thrashed.
+COOLDOWN = float(os.environ.get("AUDIO_WATCHDOG_COOLDOWN", "60"))
+# Let the system settle before judging anything (boot, first login, PipeWire up).
+START_GRACE = float(os.environ.get("AUDIO_WATCHDOG_START_GRACE", "45"))
+
+SNAP_UNIT = "pulse-snapclient.service"
+LOG_TAG = "pulse-audio-watchdog"
+
+
+def log(msg: str) -> None:
+    try:
+        subprocess.run(["logger", "-t", LOG_TAG, msg], check=False)
+    except Exception:
+        pass
+    print(f"[{LOG_TAG}] {msg}", file=sys.stderr, flush=True)
+
+
+def snap_host_id() -> str:
+    hid = os.environ.get("SNAPCLIENT_HOST_ID", "").strip()
+    if hid:
+        return hid
+    # pulse-snapclient.sh defaults --hostID to the short hostname.
+    return socket.gethostname().split(".")[0]
+
+
+def server_status_url() -> str | None:
+    host = os.environ.get("SNAPCAST_HOST", "").strip()
+    if not host:
+        return None
+    port = os.environ.get("SNAPCAST_HTTP_PORT", "1780").strip() or "1780"
+    return f"http://{host}:{port}/jsonrpc"
+
+
+def snapclient_active() -> bool:
+    rc = subprocess.run(["systemctl", "is-active", "--quiet", SNAP_UNIT], check=False).returncode
+    return rc == 0
+
+
+def fetch_server_status(url: str) -> dict | None:
+    payload = json.dumps({"id": 1, "jsonrpc": "2.0", "method": "Server.GetStatus"}).encode()
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return json.loads(resp.read().decode())
+    except Exception:
+        return None
+
+
+def server_wants_audio(status: dict, host_id: str) -> bool:
+    """True iff this client should currently be producing sound.
+
+    That means: the client is present + connected + not muted, and the stream
+    its group is bound to is actively ``playing``.
+    """
+    try:
+        server = status["result"]["server"]
+    except (KeyError, TypeError):
+        return False
+
+    stream_status = {s.get("id"): s.get("status") for s in server.get("streams", [])}
+
+    for group in server.get("groups", []):
+        for client in group.get("clients", []):
+            if client.get("host", {}).get("name") != host_id:
+                continue
+            if not client.get("connected"):
+                return False
+            if client.get("config", {}).get("volume", {}).get("muted"):
+                return False
+            return stream_status.get(group.get("stream_id")) == "playing"
+    return False
+
+
+def snapclient_is_feeding() -> bool | None:
+    """True if snapclient has a live sink-input, False if not, None if unknown.
+
+    None means we could not query PipeWire -- treat as "don't act".
+    """
+    try:
+        out = subprocess.run(
+            ["pactl", "list", "sink-inputs"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    text = out.stdout
+    return ('application.process.binary = "snapclient"' in text) or ('application.name = "Snapcast"' in text)
+
+
+def restart_snapclient() -> None:
+    log(f"restarting {SNAP_UNIT}: server reports this client playing but no local audio")
+    subprocess.run(["systemctl", "restart", SNAP_UNIT], check=False)
+
+
+def main() -> int:
+    url = server_status_url()
+    if not url:
+        log("SNAPCAST_HOST not set; audio watchdog has nothing to watch. Exiting.")
+        return 0
+
+    host_id = snap_host_id()
+    log(
+        f"started (host_id={host_id}, server={url}, poll={POLL_INTERVAL}s, grace={SILENT_GRACE}s, cooldown={COOLDOWN}s)"
+    )
+    time.sleep(START_GRACE)
+
+    silent_since: float | None = None
+    last_restart = 0.0
+
+    while True:
+        now = time.monotonic()
+        try:
+            if not snapclient_active():
+                silent_since = None  # not our job while the unit is stopped
+            else:
+                status = fetch_server_status(url)
+                if status is None or not server_wants_audio(status, host_id):
+                    # Server unreachable, stream idle, muted, or disconnected:
+                    # nothing to recover.
+                    silent_since = None
+                else:
+                    feeding = snapclient_is_feeding()
+                    if feeding is None or feeding:
+                        # Producing audio (or we can't tell) -> healthy.
+                        silent_since = None
+                    else:
+                        if silent_since is None:
+                            silent_since = now
+                            log("server reports this client playing but no local snapclient audio; watching…")
+                        elif (now - silent_since) >= SILENT_GRACE and (now - last_restart) >= COOLDOWN:
+                            restart_snapclient()
+                            last_restart = now
+                            silent_since = None
+        except Exception as exc:  # never let the loop die on a transient error
+            log(f"unexpected error in watch loop: {exc}")
+            silent_since = None
+
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/pulse-audio-watchdog.py
+++ b/bin/pulse-audio-watchdog.py
@@ -52,6 +52,8 @@ def log(msg: str) -> None:
     try:
         subprocess.run(["logger", "-t", LOG_TAG, msg], check=False)
     except Exception:
+        # Best-effort syslog only; logging must never take down the watchdog.
+        # The stderr/journal write below still happens regardless.
         pass
     print(f"[{LOG_TAG}] {msg}", file=sys.stderr, flush=True)
 

--- a/config/system/pulse-audio-watchdog.service
+++ b/config/system/pulse-audio-watchdog.service
@@ -11,8 +11,11 @@ EnvironmentFile=-/etc/default/pulse-snapclient
 # reach the pulse user's PipeWire socket to see sink-inputs.
 Environment=XDG_RUNTIME_DIR=/run/user/1000
 Environment=PULSE_SERVER=unix:/run/user/1000/pulse/native
+# on-failure (not always): main() exits 0 when there is nothing to watch
+# (e.g. SNAPCAST_HOST unset); that is a deliberate clean stop, not a crash to
+# restart-loop over. Real crashes still exit non-zero and get restarted.
 ExecStart=/usr/bin/python3 /opt/pulse-os/bin/pulse-audio-watchdog.py
-Restart=always
+Restart=on-failure
 RestartSec=10
 
 [Install]

--- a/config/system/pulse-audio-watchdog.service
+++ b/config/system/pulse-audio-watchdog.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Pulse Audio Watchdog (auto-recover snapclient when silent)
+After=pulse-snapclient.service
+Wants=pulse-snapclient.service
+
+[Service]
+Type=simple
+# SNAPCAST_HOST / SNAPCAST_HTTP_PORT / SNAPCLIENT_HOST_ID come from here.
+EnvironmentFile=-/etc/default/pulse-snapclient
+# Runs as root so it can restart the system snapclient unit, but still needs to
+# reach the pulse user's PipeWire socket to see sink-inputs.
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+Environment=PULSE_SERVER=unix:/run/user/1000/pulse/native
+ExecStart=/usr/bin/python3 /opt/pulse-os/bin/pulse-audio-watchdog.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -266,6 +266,7 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_SNAPCAST_HOST` | *(empty)* | Snapserver host. |
 | `PULSE_SNAPCAST_PORT` | `1704` | Snapserver PCM stream port. |
 | `PULSE_SNAPCAST_CONTROL_PORT` | `1705` | Snapserver control port. |
+| `PULSE_SNAPCAST_HTTP_PORT` | `1780` | Snapserver JSON-RPC/HTTP port, used by the audio watchdog to check whether this client should be playing. |
 | `PULSE_SNAPCLIENT_SOUNDCARD` | `default` | Soundcard argument passed to snapclient. |
 | `PULSE_SNAPCLIENT_LATENCY_MS` | *(empty)* | Optional latency override (milliseconds). |
 | `PULSE_SNAPCLIENT_EXTRA_ARGS` | `--player pulse` | Extra CLI flags for snapclient. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,6 +120,8 @@ ls -1 /sys/class/drm | grep DSI   # expect card0-DSI-2
    ```
 3. Verify with `pactl list sink-inputs | grep -B3 snapclient` while Music Assistant plays; you should now see a `snapclient` sink input and the speakers will output the stream.
 
+> **Auto-recovery:** A related failure looks identical from the couch but is not a PipeWire-not-running problem: snapclient resolves the `default` sink once, when its player connects, so if that sink later disappears and is re-created with a new index — a USB DAC re-enumerating, or PipeWire restarting — snapclient keeps "connected" to the server while feeding a sink that no longer exists, and the room goes silent. Because the process never crashes, `Restart=always` can't catch it. `pulse-audio-watchdog.service` handles this case: it asks the snapserver (over `SNAPCAST_HTTP_PORT`, default `1780`) whether this client should be playing and, if so but there is no local `snapclient` sink input for ~20s, it restarts `pulse-snapclient.service`. It never acts while the stream is idle, the client is muted/disconnected, or the server is unreachable. Watch it with `journalctl -u pulse-audio-watchdog.service -f`. It is enabled automatically whenever the Snapcast client is enabled.
+
 ## Duplicate Music Assistant players or blank Now Playing
 
 **Problem**: Music Assistant shows two players for the same Pulse (for example `media_player.pulse_office` and `media_player.pulse_office_2`), and the default Now Playing entity points at the unavailable one so the overlay/MQTT sensor never updates.

--- a/setup.sh
+++ b/setup.sh
@@ -666,6 +666,7 @@ configure_snapclient() {
 SNAPCAST_HOST="${PULSE_SNAPCAST_HOST}"
 SNAPCAST_PORT="${PULSE_SNAPCAST_PORT:-1704}"
 SNAPCAST_CONTROL_PORT="${PULSE_SNAPCAST_CONTROL_PORT:-1705}"
+SNAPCAST_HTTP_PORT="${PULSE_SNAPCAST_HTTP_PORT:-1780}"
 SNAPCLIENT_SOUNDCARD="${PULSE_SNAPCLIENT_SOUNDCARD:-default}"
 SNAPCLIENT_LATENCY_MS="${PULSE_SNAPCLIENT_LATENCY_MS:-}"
 SNAPCLIENT_EXTRA_ARGS="${PULSE_SNAPCLIENT_EXTRA_ARGS:---player pulse}"
@@ -821,6 +822,9 @@ link_system_files() {
     sudo ln -sf "$REPO_DIR/config/system/pulse-snapclient.service" \
         /etc/systemd/system/pulse-snapclient.service
 
+    sudo ln -sf "$REPO_DIR/config/system/pulse-audio-watchdog.service" \
+        /etc/systemd/system/pulse-audio-watchdog.service
+
     write_backlight_conf
 
     log "Linking systemd/user files…"
@@ -964,9 +968,12 @@ enable_services() {
     if [ "$PULSE_SNAPCLIENT" = "true" ] && [ -n "${PULSE_SNAPCAST_HOST:-}" ]; then
         log "Enabling Snapcast client..."
         sudo systemctl enable --now pulse-snapclient.service
+        log "Enabling audio watchdog (snapclient silent-recovery)..."
+        sudo systemctl enable --now pulse-audio-watchdog.service
     else
         log "Snapcast client disabled; stopping service..."
         sudo systemctl disable --now pulse-snapclient.service 2>/dev/null || true
+        sudo systemctl disable --now pulse-audio-watchdog.service 2>/dev/null || true
     fi
 
     log "Enabling user services (user-global)…"


### PR DESCRIPTION
## Problem

`snapclient` streams through PipeWire/Pulse (`--player pulse`) and resolves the
`default` sink **once**, when its player connects. If that sink later disappears
and is re-created with a new index — a USB DAC re-enumerating, or PipeWire
restarting — snapclient keeps reporting "connected" to the server while feeding
audio to a sink that no longer exists, and the room goes silent.

Because the process never crashes, `Restart=always` on the unit can't catch it.
The server shows the client connected + the stream `playing`, `pactl list
sink-inputs` is empty, and the only fix was a manual `systemctl restart
pulse-snapclient.service`.

## Fix

Add **`pulse-audio-watchdog.service`** — a small root daemon
(`bin/pulse-audio-watchdog.py`) that every ~10s asks the snapserver (JSON-RPC
over the new `SNAPCAST_HTTP_PORT`, default `1780`) whether *this* client should
be playing (stream `playing` + client connected + not muted). If it should, but
there is no local `snapclient` sink-input for ~20s, it restarts
`pulse-snapclient.service`.

It is deliberately **fail-safe** — it never acts while the stream is idle, the
client is muted/disconnected, or the server is unreachable — and has a cooldown
so a slow-to-recover client is never thrashed.

- Runs as root so it can restart the system unit, with the pulse user's
  PipeWire socket passed in via `PULSE_SERVER`/`XDG_RUNTIME_DIR`.
- Wired into `setup.sh`: linked in `link_system_files`, enabled in
  `enable_services` gated on `PULSE_SNAPCLIENT` (disabled when snapclient is).
- Documented in `docs/troubleshooting.md` and `docs/config-reference.md`.

## Testing

- **Decision logic** — 7 unit cases (playing/idle/muted/disconnected/wrong-host/
  unknown-stream/malformed) all pass.
- **Live integration** on a kiosk — HTTP status fetch, JSON client matching, and
  `pactl` sink-input parsing all return correct values as root against the
  running pulse session.
- **Loop/threshold/cooldown** — drove the real `main()` loop with the restart
  action stubbed: fires exactly once after the grace period and respects the
  cooldown.
- `ruff`, `black`, `mypy`, and the full `pytest` suite (1876 passed) are green.