### PR TITLE
fix(logging): emit RFC 5424 nil (-) for empty APP-NAME/PROCID

### DIFF
--- a/config/system/syslog-ng/remote-log.conf.template
+++ b/config/system/syslog-ng/remote-log.conf.template
@@ -1,7 +1,11 @@
 @version: 4.7
 
 template t_ietf {
-    template("<${PRI}>1 ${ISODATE} ${HOST} ${PROGRAM} ${PID} - - ${MSGHDR}${MSG}\n");
+    # RFC 5424 requires NILVALUE ("-") for empty APP-NAME/PROCID. Kernel
+    # messages (and other PID-less logs) have an empty ${PID}; emitting it
+    # raw produces a malformed frame that Alloy's strict RFC 5424 parser
+    # drops, silently losing all kern-facility logs (e.g. undervoltage).
+    template("<${PRI}>1 ${ISODATE} ${HOST} $(if ('${PROGRAM}' eq '') '-' '${PROGRAM}') $(if ('${PID}' eq '') '-' '${PID}') - - ${MSGHDR}${MSG}\n");
 };
 
 filter f_pulse_drop_syslogng_stats {
@@ -24,4 +28,3 @@ log {
     filter(f_pulse_drop_syslogng_stats);
     destination(d_remote);
 };
-


### PR DESCRIPTION
## Problem

`kern`-facility logs from pulse devices stopped reaching Loki — including **undervoltage / throttling warnings**, exactly the events you want visible. Kitchen's last kern log in Loki was a burst ~20 days ago; nothing since, and no kernel boot logs after reboots either.

## Root cause

Pulse devices forward syslog **directly to Alloy** (`loki.source.syslog`, strict RFC 5424) using this hand-rolled template:

```
template("<${PRI}>1 ${ISODATE} ${HOST} ${PROGRAM} ${PID} - - ${MSGHDR}${MSG}\n");
```

Kernel messages (and any PID-less log) have an **empty `${PID}`**, so the frame carries an empty PROCID instead of the RFC 5424 `NILVALUE` (`-`). Alloy's parser rejects the malformed frame and drops it. Messages **with** a PID (most `daemon`, etc.) parse fine, which is why only `kern` disappeared. unifi/shelly are unaffected because they route via the NAS `syslog-ng` (`d_alloy`, native `syslog()` driver), which emits proper nil fields.

This regressed when pulse was switched to direct-to-Alloy forwarding.

## Fix

Wrap `${PROGRAM}` and `${PID}` in `$(if ... '-' ...)` so empty fields render as `-`. Framing and all other output are byte-for-byte unchanged for messages that already forwarded.

## Validation

- `syslog-ng --syntax-only` passes on-device (syslog-ng 4.x).
- Deployed to all four devices (kitchen, bedroom, great-room, office): previously-dropped PID-less messages now reach Loki. Before the fix an identical probe never arrived; after, it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)