### PR TITLE
Add optional scrolling stock ticker to the overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Pulse Display Assistant is a Raspberry Pi kiosk OS purpose-built for Home Assi
 
 - Hardened Chromium kiosk with watchdogs, self-healing restarts, and MQTT “home/update/reboot” buttons targeted at photo-frame style Lovelace dashboards.
 - Overlay timeline that keeps alarms, timers, reminders, calendar events, now-playing info, and badge-driven info cards in sync with the backend scheduler.
+- Optional scrolling stock ticker across the bottom of the overlay — major indices plus any symbols you configure, fetched on-device from Yahoo (or a licensed Finnhub key), with per-device toggle, adaptive polling, and name/ticker/auto labels. See [config-reference](docs/config-reference.md#stock-ticker).
 - Full alarm/timer/reminder scheduler (manual UI, MQTT, or voice shortcuts) plus remote completion/delay actions from the overlay itself.
 - Local ICS/WebCal polling with RRULE expansion for recurring events, multi-`VALARM` support, “declined” attendee detection, on-screen calendar cards, and auto-suppressed pop-ups for meetings you said “No” to.
 - Optional Wyoming voice stack (wake word, Whisper STT, Piper TTS) with shortcut intents for news/weather/sports and LLM routing between 6 providers: OpenAI, Gemini, Anthropic Claude, Groq, Mistral AI, and OpenRouter.

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1263,8 +1263,9 @@ body {
 
 /* --- Stock ticker bar (bottom, scrolling marquee over the HA dashboard) --- */
 .overlay-root--ticker {
-  /* Reserve space so the ticker never covers the bottom grid cells (e.g. the clock). */
-  padding-bottom: calc(3vh + 5.5vh);
+  /* Reserve at least the ticker's own height (which has a 34px min-height) plus breathing
+     room, so it never covers the bottom grid cells (e.g. the clock) on short viewports. */
+  padding-bottom: calc(max(5.5vh, 44px) + 2.5vh);
 }
 
 .pulse-ticker {

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1260,3 +1260,88 @@ body {
   padding: 0.3rem 0.6rem;
   white-space: nowrap;
 }
+
+/* --- Stock ticker bar (bottom, scrolling marquee over the HA dashboard) --- */
+.overlay-root--ticker {
+  /* Reserve space so the ticker never covers the bottom grid cells (e.g. the clock). */
+  padding-bottom: calc(3vh + 5.5vh);
+}
+
+.pulse-ticker {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 5vh;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  z-index: 40;
+  pointer-events: none;
+  /* Match the overlay cards / now-playing box, biased opaque for legibility over photos. */
+  background: var(--overlay-alert-bg, rgba(0, 0, 0, 0.65));
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  color: var(--overlay-text-color, #ffffff);
+  font-size: 2.6vh;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.pulse-ticker__track {
+  display: inline-flex;
+  align-items: center;
+  will-change: transform;
+  /* Duration + wall-clock phase are refined by overlay.js; this is the pre-JS fallback. */
+  animation: pulse-ticker-scroll var(--pulse-ticker-duration, 60s) linear infinite;
+}
+
+@keyframes pulse-ticker-scroll {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    /* Item set is duplicated in markup, so -50% of the track = exactly one full set. */
+    transform: translateX(-50%);
+  }
+}
+
+.pulse-ticker__item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5ch;
+  padding: 0 2.2ch;
+}
+
+.pulse-ticker__label {
+  font-weight: 600;
+  opacity: 0.92;
+}
+
+.pulse-ticker__price {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.pulse-ticker__change {
+  font-variant-numeric: tabular-nums;
+}
+
+.pulse-ticker__item--up .pulse-ticker__change {
+  color: #4caf50;
+}
+
+.pulse-ticker__item--down .pulse-ticker__change {
+  color: #ff5c5c;
+}
+
+.pulse-ticker__ah {
+  opacity: 0.6;
+  font-size: 0.82em;
+}
+
+.pulse-ticker__emoji {
+  font-size: 1.05em;
+}

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -13,6 +13,31 @@ window.PulseOverlay.initialize = function() {
     return;
   }
 
+  // --- Stock ticker marquee ---
+  // Constant px/sec speed (independent of symbol count) plus a wall-clock animation
+  // phase, so the scroll resumes seamlessly across the photo-card's periodic iframe
+  // reloads instead of jumping back to the start each time.
+  const tickerTrack = root.querySelector('[data-ticker-track]');
+  if (tickerTrack) {
+    const speed = parseFloat(tickerTrack.getAttribute('data-speed')) || 60; // px/sec
+    const applyTickerMotion = () => {
+      // The item set is duplicated in markup, so half the scroll width is one full set.
+      const half = tickerTrack.scrollWidth / 2;
+      if (half > 0) {
+        const duration = half / speed; // seconds for one full set to scroll past
+        tickerTrack.style.animationDuration = duration + 's';
+        const phase = (Date.now() / 1000) % duration;
+        tickerTrack.style.animationDelay = '-' + phase + 's';
+      }
+    };
+    applyTickerMotion();
+    // Web-font / emoji load can shift the measured width slightly; re-measure once settled.
+    if (document.fonts && document.fonts.ready && typeof document.fonts.ready.then === 'function') {
+      document.fonts.ready.then(applyTickerMotion).catch(() => {});
+    }
+    window.setTimeout(applyTickerMotion, 250);
+  }
+
   // Clean up previous event listeners to prevent duplicates
   if (window.PulseOverlay.clockInterval) {
     clearInterval(window.PulseOverlay.clockInterval);

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -34,6 +34,7 @@ from pulse.overlay import (
     parse_clock_config,
 )
 from pulse.overlay_server import OverlayHttpServer, OverlayServerConfig
+from pulse.stock_ticker import StockTicker, is_us_market_hours, parse_symbols
 from pulse.utils import parse_bool, sanitize_hostname_for_entity_id
 
 
@@ -91,6 +92,13 @@ class OverlayConfig:
     clock_24h: bool
     font_family: str
     auth_token: str | None
+    ticker_enabled: bool
+    ticker_symbols: tuple[str, ...]
+    ticker_interval: int
+    ticker_interval_closed: int
+    ticker_afterhours: bool
+    ticker_speed: int
+    ticker_emoji: bool
 
 
 @dataclass(frozen=True)
@@ -452,6 +460,13 @@ def load_config() -> EnvConfig:
         clock_24h=parse_bool(os.environ.get("PULSE_OVERLAY_CLOCK_24H"), False),
         font_family=overlay_font_stack,
         auth_token=(os.environ.get("PULSE_OVERLAY_AUTH_TOKEN") or "").strip() or None,
+        ticker_enabled=parse_bool(os.environ.get("PULSE_TICKER_ENABLED"), False),
+        ticker_symbols=tuple(parse_symbols(os.environ.get("PULSE_TICKER_SYMBOLS")) or ["^SPX", "^DJI", "^NDX"]),
+        ticker_interval=max(15, int(os.environ.get("PULSE_TICKER_INTERVAL", "60") or "60")),
+        ticker_interval_closed=max(60, int(os.environ.get("PULSE_TICKER_INTERVAL_CLOSED", "900") or "900")),
+        ticker_afterhours=parse_bool(os.environ.get("PULSE_TICKER_AFTERHOURS"), True),
+        ticker_speed=max(10, int(os.environ.get("PULSE_TICKER_SPEED", "60") or "60")),
+        ticker_emoji=parse_bool(os.environ.get("PULSE_TICKER_EMOJI"), True),
     )
 
     version_source_url = os.environ.get("PULSE_VERSION_SOURCE_URL", DEFAULT_VERSION_SOURCE_URL)
@@ -665,6 +680,10 @@ class KioskMqttListener:
         self._telemetry_lock = threading.Lock()
         self._telemetry_thread: threading.Thread | None = None
         self._telemetry_stop_event = threading.Event()
+        self._ticker_lock = threading.Lock()
+        self._ticker_thread: threading.Thread | None = None
+        self._ticker_stop_event = threading.Event()
+        self._stock_ticker: StockTicker | None = None
         self._watchdog_thread: threading.Thread | None = None
         self._watchdog_stop_event = threading.Event()
         self._last_mqtt_ok: float = time.monotonic()
@@ -707,6 +726,12 @@ class KioskMqttListener:
 
         if self.overlay_config.enabled:
             self.overlay_state = OverlayStateManager(self.overlay_config.clocks)
+            if self.overlay_config.ticker_enabled and self.overlay_config.ticker_symbols:
+                self._stock_ticker = StockTicker(
+                    self.overlay_config.ticker_symbols,
+                    afterhours=self.overlay_config.ticker_afterhours,
+                    log=self.log,
+                )
             self._overlay_theme = OverlayTheme(
                 ambient_background=self.overlay_config.ambient_background,
                 alert_background=self.overlay_config.alert_background,
@@ -714,6 +739,9 @@ class KioskMqttListener:
                 accent_color=self.overlay_config.accent_color,
                 show_notification_bar=self.overlay_config.show_notification_bar,
                 font_family=self._current_font_stack,
+                show_ticker=self.overlay_config.ticker_enabled,
+                ticker_scroll_speed=self.overlay_config.ticker_speed,
+                ticker_emoji=self.overlay_config.ticker_emoji,
             )
             self._overlay_topic_handlers = {
                 self.assistant_topics.schedules_state: self._handle_overlay_schedule_state,
@@ -792,6 +820,48 @@ class KioskMqttListener:
             self._telemetry_stop_event.set()
             self._telemetry_thread.join(timeout=self.config.telemetry_interval_seconds * 2)
             self._telemetry_thread = None
+
+    def start_ticker(self) -> None:
+        if not self._stock_ticker or not self.overlay_state:
+            return
+        with self._ticker_lock:
+            if self._ticker_thread and self._ticker_thread.is_alive():
+                return
+            self._ticker_stop_event.clear()
+            thread = threading.Thread(target=self._ticker_loop, name="pulse-ticker", daemon=True)
+            self._ticker_thread = thread
+            thread.start()
+
+    def stop_ticker(self) -> None:
+        with self._ticker_lock:
+            if not self._ticker_thread:
+                return
+            self._ticker_stop_event.set()
+            self._ticker_thread.join(timeout=self.overlay_config.ticker_interval)
+            self._ticker_thread = None
+        if self._stock_ticker:
+            self._stock_ticker.close()
+
+    def _ticker_loop(self) -> None:
+        ticker = self._stock_ticker
+        state = self.overlay_state
+        if not ticker or not state:
+            return
+        while not self._ticker_stop_event.is_set():
+            try:
+                quotes = ticker.fetch()
+                state.set_ticker([quote.as_dict() for quote in quotes])
+            except Exception as exc:  # nosec B110 - never let a fetch error kill the loop
+                self.log(f"ticker: fetch loop error: {exc}")
+            # Poll fast while US markets are open, slow otherwise. Non-US symbols still
+            # refresh on the closed-market cadence — see PULSE_TICKER_INTERVAL_CLOSED.
+            interval = (
+                self.overlay_config.ticker_interval
+                if is_us_market_hours()
+                else self.overlay_config.ticker_interval_closed
+            )
+            if self._ticker_stop_event.wait(interval):
+                break
 
     def _start_watchdog(self) -> None:
         if self._watchdog_thread and self._watchdog_thread.is_alive():
@@ -1047,6 +1117,9 @@ class KioskMqttListener:
             accent_color=self.overlay_config.accent_color,
             show_notification_bar=self.overlay_config.show_notification_bar,
             font_family=new_stack,
+            show_ticker=self.overlay_config.ticker_enabled,
+            ticker_scroll_speed=self.overlay_config.ticker_speed,
+            ticker_emoji=self.overlay_config.ticker_emoji,
         )
         if self._overlay_http:
             self._overlay_http.theme = self._overlay_theme
@@ -1933,6 +2006,7 @@ class KioskMqttListener:
         self.publish_update_button_availability(client, self.is_update_available())
         self.start_update_checker(client)
         self.start_telemetry()
+        self.start_ticker()
         if self.overlay_state:
             self._emit_overlay_refresh(self.overlay_state.snapshot().version, "boot", client=client)
             if self._overlay_http:
@@ -2230,6 +2304,7 @@ def main():
     listener = KioskMqttListener(config)
     atexit.register(listener.stop_update_checker)
     atexit.register(listener.stop_telemetry)
+    atexit.register(listener.stop_ticker)
     atexit.register(listener.stop_overlay_server)
     atexit.register(listener._stop_watchdog)
 

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -448,8 +448,8 @@ def load_config() -> EnvConfig:
         default_label=friendly_name,
         log=log,
     )
-    ticker_label_raw = (os.environ.get("PULSE_TICKER_LABEL") or "name").strip().lower()
-    ticker_label_mode = "ticker" if ticker_label_raw == "ticker" else "name"
+    ticker_label_raw = (os.environ.get("PULSE_TICKER_LABEL") or "auto").strip().lower()
+    ticker_label_mode = ticker_label_raw if ticker_label_raw in {"name", "ticker", "auto"} else "auto"
     overlay_config = OverlayConfig(
         enabled=overlay_enabled,
         bind_address=overlay_bind,

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -833,35 +833,38 @@ class KioskMqttListener:
             thread.start()
 
     def stop_ticker(self) -> None:
+        # Only signal + join here. The worker owns its httpx client and closes it in its
+        # own finally, so we never close the client from another thread mid-fetch.
         with self._ticker_lock:
             if not self._ticker_thread:
                 return
             self._ticker_stop_event.set()
             self._ticker_thread.join(timeout=self.overlay_config.ticker_interval)
             self._ticker_thread = None
-        if self._stock_ticker:
-            self._stock_ticker.close()
 
     def _ticker_loop(self) -> None:
         ticker = self._stock_ticker
         state = self.overlay_state
         if not ticker or not state:
             return
-        while not self._ticker_stop_event.is_set():
-            try:
-                quotes = ticker.fetch()
-                state.set_ticker([quote.as_dict() for quote in quotes])
-            except Exception as exc:  # nosec B110 - never let a fetch error kill the loop
-                self.log(f"ticker: fetch loop error: {exc}")
-            # Poll fast while US markets are open, slow otherwise. Non-US symbols still
-            # refresh on the closed-market cadence — see PULSE_TICKER_INTERVAL_CLOSED.
-            interval = (
-                self.overlay_config.ticker_interval
-                if is_us_market_hours()
-                else self.overlay_config.ticker_interval_closed
-            )
-            if self._ticker_stop_event.wait(interval):
-                break
+        try:
+            while not self._ticker_stop_event.is_set():
+                try:
+                    quotes = ticker.fetch()
+                    state.set_ticker([quote.as_dict() for quote in quotes])
+                except Exception as exc:  # nosec B110 - never let a fetch error kill the loop
+                    self.log(f"ticker: fetch loop error: {exc}")
+                # Poll fast while US markets are open, slow otherwise. Non-US symbols still
+                # refresh on the closed-market cadence — see PULSE_TICKER_INTERVAL_CLOSED.
+                interval = (
+                    self.overlay_config.ticker_interval
+                    if is_us_market_hours()
+                    else self.overlay_config.ticker_interval_closed
+                )
+                if self._ticker_stop_event.wait(interval):
+                    break
+        finally:
+            ticker.close()
 
     def _start_watchdog(self) -> None:
         if self._watchdog_thread and self._watchdog_thread.is_alive():

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -855,11 +855,18 @@ class KioskMqttListener:
         state = self.overlay_state
         if not ticker or not state:
             return
+        first_fetch = True
         try:
             while not self._ticker_stop_event.is_set():
                 try:
                     quotes = ticker.fetch()
                     state.set_ticker([quote.as_dict() for quote in quotes])
+                    if first_fetch and quotes:
+                        # Nudge the overlay once so the bar appears promptly after boot,
+                        # instead of waiting for the card's next poll. Subsequent updates
+                        # ride the card's normal poll (set_ticker intentionally doesn't bump).
+                        first_fetch = False
+                        self._emit_overlay_refresh(state.snapshot().version, "ticker-init")
                 except Exception as exc:  # nosec B110 - never let a fetch error kill the loop
                     self.log(f"ticker: fetch loop error: {exc}")
                 # Poll fast while US markets are open, slow otherwise. Non-US symbols still
@@ -2020,9 +2027,12 @@ class KioskMqttListener:
         self.start_telemetry()
         self.start_ticker()
         if self.overlay_state:
-            self._emit_overlay_refresh(self.overlay_state.snapshot().version, "boot", client=client)
+            # Start the HTTP server BEFORE announcing the boot refresh, otherwise the
+            # photo-card re-fetches /overlay against a not-yet-listening port, fails, and
+            # hides the overlay until its next poll (up to ~2 min). Server first, then emit.
             if self._overlay_http:
                 self._overlay_http.start()
+            self._emit_overlay_refresh(self.overlay_state.snapshot().version, "boot", client=client)
         self._start_watchdog()
         from pulse.systemd_notify import ready as sd_ready
 

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -855,18 +855,17 @@ class KioskMqttListener:
         state = self.overlay_state
         if not ticker or not state:
             return
-        first_fetch = True
         try:
             while not self._ticker_stop_event.is_set():
                 try:
                     quotes = ticker.fetch()
-                    state.set_ticker([quote.as_dict() for quote in quotes])
-                    if first_fetch and quotes:
-                        # Nudge the overlay once so the bar appears promptly after boot,
-                        # instead of waiting for the card's next poll. Subsequent updates
-                        # ride the card's normal poll (set_ticker intentionally doesn't bump).
-                        first_fetch = False
-                        self._emit_overlay_refresh(state.snapshot().version, "ticker-init")
+                    change = state.set_ticker([quote.as_dict() for quote in quotes])
+                    # set_ticker bumps the version only when the symbol set changes (e.g. the
+                    # bar first populates after boot), so this emit actually moves the refresh
+                    # sensor and the photo-card refetches — instead of re-publishing the same
+                    # version, which the card ignores. Price-only updates don't bump/emit.
+                    if change.changed:
+                        self._emit_overlay_refresh(change.version, change.reason)
                 except Exception as exc:  # nosec B110 - never let a fetch error kill the loop
                     self.log(f"ticker: fetch loop error: {exc}")
                 # Poll fast while US markets are open, slow otherwise. Non-US symbols still

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -35,7 +35,7 @@ from pulse.overlay import (
 )
 from pulse.overlay_server import OverlayHttpServer, OverlayServerConfig
 from pulse.stock_ticker import StockTicker, is_us_market_hours, parse_symbols
-from pulse.utils import parse_bool, sanitize_hostname_for_entity_id
+from pulse.utils import parse_bool, parse_int, sanitize_hostname_for_entity_id
 
 
 @dataclass(frozen=True)
@@ -466,10 +466,10 @@ def load_config() -> EnvConfig:
         auth_token=(os.environ.get("PULSE_OVERLAY_AUTH_TOKEN") or "").strip() or None,
         ticker_enabled=parse_bool(os.environ.get("PULSE_TICKER_ENABLED"), False),
         ticker_symbols=tuple(parse_symbols(os.environ.get("PULSE_TICKER_SYMBOLS")) or ["^SPX", "^DJI", "^NDX"]),
-        ticker_interval=max(15, int(os.environ.get("PULSE_TICKER_INTERVAL", "60") or "60")),
-        ticker_interval_closed=max(60, int(os.environ.get("PULSE_TICKER_INTERVAL_CLOSED", "900") or "900")),
+        ticker_interval=max(15, parse_int(os.environ.get("PULSE_TICKER_INTERVAL"), 60)),
+        ticker_interval_closed=max(60, parse_int(os.environ.get("PULSE_TICKER_INTERVAL_CLOSED"), 900)),
         ticker_afterhours=parse_bool(os.environ.get("PULSE_TICKER_AFTERHOURS"), True),
-        ticker_speed=max(10, int(os.environ.get("PULSE_TICKER_SPEED", "60") or "60")),
+        ticker_speed=max(10, parse_int(os.environ.get("PULSE_TICKER_SPEED"), 60)),
         ticker_emoji=parse_bool(os.environ.get("PULSE_TICKER_EMOJI"), True),
         ticker_label_mode=ticker_label_mode,
         ticker_api_key=(os.environ.get("PULSE_TICKER_API_KEY") or "").strip() or None,

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -99,6 +99,7 @@ class OverlayConfig:
     ticker_afterhours: bool
     ticker_speed: int
     ticker_emoji: bool
+    ticker_label_mode: str
     ticker_api_key: str | None
 
 
@@ -447,6 +448,8 @@ def load_config() -> EnvConfig:
         default_label=friendly_name,
         log=log,
     )
+    ticker_label_raw = (os.environ.get("PULSE_TICKER_LABEL") or "name").strip().lower()
+    ticker_label_mode = "ticker" if ticker_label_raw == "ticker" else "name"
     overlay_config = OverlayConfig(
         enabled=overlay_enabled,
         bind_address=overlay_bind,
@@ -468,6 +471,7 @@ def load_config() -> EnvConfig:
         ticker_afterhours=parse_bool(os.environ.get("PULSE_TICKER_AFTERHOURS"), True),
         ticker_speed=max(10, int(os.environ.get("PULSE_TICKER_SPEED", "60") or "60")),
         ticker_emoji=parse_bool(os.environ.get("PULSE_TICKER_EMOJI"), True),
+        ticker_label_mode=ticker_label_mode,
         ticker_api_key=(os.environ.get("PULSE_TICKER_API_KEY") or "").strip() or None,
     )
 
@@ -745,6 +749,7 @@ class KioskMqttListener:
                 show_ticker=self.overlay_config.ticker_enabled,
                 ticker_scroll_speed=self.overlay_config.ticker_speed,
                 ticker_emoji=self.overlay_config.ticker_emoji,
+                ticker_label_mode=self.overlay_config.ticker_label_mode,
             )
             self._overlay_topic_handlers = {
                 self.assistant_topics.schedules_state: self._handle_overlay_schedule_state,
@@ -1126,6 +1131,7 @@ class KioskMqttListener:
             show_ticker=self.overlay_config.ticker_enabled,
             ticker_scroll_speed=self.overlay_config.ticker_speed,
             ticker_emoji=self.overlay_config.ticker_emoji,
+            ticker_label_mode=self.overlay_config.ticker_label_mode,
         )
         if self._overlay_http:
             self._overlay_http.theme = self._overlay_theme

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -99,6 +99,7 @@ class OverlayConfig:
     ticker_afterhours: bool
     ticker_speed: int
     ticker_emoji: bool
+    ticker_api_key: str | None
 
 
 @dataclass(frozen=True)
@@ -467,6 +468,7 @@ def load_config() -> EnvConfig:
         ticker_afterhours=parse_bool(os.environ.get("PULSE_TICKER_AFTERHOURS"), True),
         ticker_speed=max(10, int(os.environ.get("PULSE_TICKER_SPEED", "60") or "60")),
         ticker_emoji=parse_bool(os.environ.get("PULSE_TICKER_EMOJI"), True),
+        ticker_api_key=(os.environ.get("PULSE_TICKER_API_KEY") or "").strip() or None,
     )
 
     version_source_url = os.environ.get("PULSE_VERSION_SOURCE_URL", DEFAULT_VERSION_SOURCE_URL)
@@ -730,6 +732,7 @@ class KioskMqttListener:
                 self._stock_ticker = StockTicker(
                     self.overlay_config.ticker_symbols,
                     afterhours=self.overlay_config.ticker_afterhours,
+                    api_key=self.overlay_config.ticker_api_key,
                     log=self.log,
                 )
             self._overlay_theme = OverlayTheme(

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -81,6 +81,7 @@ other symbols show their Yahoo short name.
 | `PULSE_TICKER_AFTERHOURS` | `true` | Append the post-market price (marked `AH`) when the provider reports one. |
 | `PULSE_TICKER_SPEED` | `60` | Scroll speed in pixels per second (min 10; higher = faster). |
 | `PULSE_TICKER_EMOJI` | `true` | Add an accent emoji for outsized moves (🚀 ≥ +10%, 🔥 ≥ +5%, 📉 ≤ -5%, 🧊 ≤ -10%). |
+| `PULSE_TICKER_LABEL` | `name` | Label before each price: `name` (friendly/company name, e.g. "S&P 500", "Apple Inc.") or `ticker` (the symbol, e.g. "SPX", "AAPL", "VTI" — compact, avoids long/truncated ETF names). |
 | `PULSE_TICKER_API_KEY` | _(unset)_ | Optional free [Finnhub](https://finnhub.io) API key. When set, Finnhub is the preferred (licensed) source for symbols it can price; Yahoo covers the rest. |
 
 Notes:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -49,11 +49,12 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 ## Stock ticker
 
 An optional scrolling ticker bar across the bottom of the overlay. Quotes are fetched
-on-device from Yahoo Finance (near-real-time, no API key) with a Stooq CSV fallback and
-a last-good cache, so the bar never goes blank on a transient upstream failure. Any
-symbol Yahoo lists works — including non-US indices (`^N225`, `^FTSE`, `^GDAXI`, `^HSI`,
-`^FCHI`, `^STOXX50E`) and foreign tickers with an exchange suffix (`SAP.DE`, `7203.T`).
-Friendly labels are built in for common indices; other symbols show their Yahoo short name.
+on-device from Yahoo Finance (near-real-time, no API key) using two independent endpoints
+(v7 quote, then v8 chart) plus a last-good cache, so the bar never goes blank on a
+transient upstream failure. Any symbol Yahoo lists works — including non-US indices
+(`^N225`, `^FTSE`, `^GDAXI`, `^HSI`, `^FCHI`, `^STOXX50E`) and foreign tickers with an
+exchange suffix (`SAP.DE`, `7203.T`). Friendly labels are built in for common indices;
+other symbols show their Yahoo short name.
 
 | Key | Default | Description |
 | --- | --- | --- |
@@ -71,10 +72,10 @@ Notes:
 - The fast/slow fetch cadence is keyed to US regular-session hours (holidays are not
   tracked — an extra harmless fast poll may occur). Data itself is global.
 - **DNS/ad-blocker allowlist:** the device fetches quotes from these hosts — if you run
-  Pi-hole/AdGuard or similar, make sure they resolve: `query1.finance.yahoo.com`,
-  `fc.yahoo.com` (cookie/crumb), and `stooq.com` (fallback). A blocked host shows up as
-  `ticker:` fetch warnings in the logs and a bar that only ever shows cached/last-good
-  values. See [troubleshooting.md](troubleshooting.md#stock-ticker).
+  Pi-hole/AdGuard or similar, make sure they resolve: `query1.finance.yahoo.com` (quote +
+  chart) and `fc.yahoo.com` (cookie/crumb). A blocked host shows up as `ticker:` fetch
+  warnings in the logs and a bar that only ever shows cached/last-good values. See
+  [troubleshooting.md](troubleshooting.md#stock-ticker).
 
 ## Telemetry & MQTT
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -66,6 +66,11 @@ other symbols show their Yahoo short name.
 > set `PULSE_TICKER_API_KEY` to a free [Finnhub](https://finnhub.io) key: Finnhub is then
 > the preferred provider for the symbols it can price (US equities/ETFs on the free tier),
 > and Yahoo fills in the rest (indices, which Finnhub's free tier doesn't cover).
+>
+> Note: after-hours prices (`AH`) come only from the Yahoo v7 path — Finnhub's free
+> `/quote` endpoint has no after-hours field, so symbols priced by Finnhub won't show an
+> `AH` value even with `PULSE_TICKER_AFTERHOURS=true`. Leave the key unset if after-hours
+> display matters more to you than a licensed source.
 
 | Key | Default | Description |
 | --- | --- | --- |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -46,6 +46,36 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_OVERLAY_CLOCK_24H` | `false` | Forces 24-hour clock labels when `true`. |
 | `PULSE_OVERLAY_AUTH_TOKEN` | _(unset)_ | Bearer token for overlay POST endpoints. When set, state-changing requests require `Authorization: Bearer <token>`. |
 
+## Stock ticker
+
+An optional scrolling ticker bar across the bottom of the overlay. Quotes are fetched
+on-device from Yahoo Finance (near-real-time, no API key) with a Stooq CSV fallback and
+a last-good cache, so the bar never goes blank on a transient upstream failure. Any
+symbol Yahoo lists works — including non-US indices (`^N225`, `^FTSE`, `^GDAXI`, `^HSI`,
+`^FCHI`, `^STOXX50E`) and foreign tickers with an exchange suffix (`SAP.DE`, `7203.T`).
+Friendly labels are built in for common indices; other symbols show their Yahoo short name.
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `PULSE_TICKER_ENABLED` | `false` | Master switch for the ticker bar (optional per device). |
+| `PULSE_TICKER_SYMBOLS` | `^SPX,^DJI,^NDX` | Comma-separated symbols to display (indices use a `^` prefix). |
+| `PULSE_TICKER_INTERVAL` | `60` | Seconds between fetches while US markets are open (min 15). |
+| `PULSE_TICKER_INTERVAL_CLOSED` | `900` | Seconds between fetches when US markets are closed (min 60). Non-US symbols refresh on this cadence during their own sessions — lower it if you mainly watch overseas markets. |
+| `PULSE_TICKER_AFTERHOURS` | `true` | Append the post-market price (marked `AH`) when the provider reports one. |
+| `PULSE_TICKER_SPEED` | `60` | Scroll speed in pixels per second (min 10; higher = faster). |
+| `PULSE_TICKER_EMOJI` | `true` | Add an accent emoji for outsized moves (🚀 ≥ +10%, 🔥 ≥ +5%, 📉 ≤ -5%, 🧊 ≤ -10%). |
+
+Notes:
+- Gains render green with a ▲, losses red with a ▼; the bar matches the overlay's
+  translucent card styling and is pinned to the bottom over whatever is on screen.
+- The fast/slow fetch cadence is keyed to US regular-session hours (holidays are not
+  tracked — an extra harmless fast poll may occur). Data itself is global.
+- **DNS/ad-blocker allowlist:** the device fetches quotes from these hosts — if you run
+  Pi-hole/AdGuard or similar, make sure they resolve: `query1.finance.yahoo.com`,
+  `fc.yahoo.com` (cookie/crumb), and `stooq.com` (fallback). A blocked host shows up as
+  `ticker:` fetch warnings in the logs and a bar that only ever shows cached/last-good
+  values. See [troubleshooting.md](troubleshooting.md#stock-ticker).
+
 ## Telemetry & MQTT
 
 | Key | Default | Description |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -81,7 +81,7 @@ other symbols show their Yahoo short name.
 | `PULSE_TICKER_AFTERHOURS` | `true` | Append the post-market price (marked `AH`) when the provider reports one. |
 | `PULSE_TICKER_SPEED` | `60` | Scroll speed in pixels per second (min 10; higher = faster). |
 | `PULSE_TICKER_EMOJI` | `true` | Add an accent emoji for outsized moves (🚀 ≥ +10%, 🔥 ≥ +5%, 📉 ≤ -5%, 🧊 ≤ -10%). |
-| `PULSE_TICKER_LABEL` | `name` | Label before each price: `name` (friendly/company name, e.g. "S&P 500", "Apple Inc.") or `ticker` (the symbol, e.g. "SPX", "AAPL", "VTI" — compact, avoids long/truncated ETF names). |
+| `PULSE_TICKER_LABEL` | `auto` | Label before each price: `auto` (friendly name for indices like "S&P 500", ticker symbol for everything else — avoids long/truncated ETF names), `name` (friendly name for all), or `ticker` (symbol for all). |
 | `PULSE_TICKER_API_KEY` | _(unset)_ | Optional free [Finnhub](https://finnhub.io) API key. When set, Finnhub is the preferred (licensed) source for symbols it can price; Yahoo covers the rest. |
 
 Notes:

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -56,6 +56,17 @@ transient upstream failure. Any symbol Yahoo lists works — including non-US in
 exchange suffix (`SAP.DE`, `7203.T`). Friendly labels are built in for common indices;
 other symbols show their Yahoo short name.
 
+> **Data source & usage.** The Yahoo endpoints are *unofficial and undocumented* — Yahoo
+> retired its free public Finance API years ago, and this module uses the same endpoints
+> the [`yfinance`](https://pypi.org/project/yfinance/) library does (obtaining Yahoo's
+> cookie + crumb transparently). That is appropriate for **personal, non-commercial,
+> low-volume home display** — which is what we do here (one request per device every
+> 60s/15min, cached, not redistributed) — but it is **not a licensed or ToS-sanctioned
+> use**, and Yahoo may change or block the endpoints at any time. For a licensed source,
+> set `PULSE_TICKER_API_KEY` to a free [Finnhub](https://finnhub.io) key: Finnhub is then
+> the preferred provider for the symbols it can price (US equities/ETFs on the free tier),
+> and Yahoo fills in the rest (indices, which Finnhub's free tier doesn't cover).
+
 | Key | Default | Description |
 | --- | --- | --- |
 | `PULSE_TICKER_ENABLED` | `false` | Master switch for the ticker bar (optional per device). |
@@ -65,6 +76,7 @@ other symbols show their Yahoo short name.
 | `PULSE_TICKER_AFTERHOURS` | `true` | Append the post-market price (marked `AH`) when the provider reports one. |
 | `PULSE_TICKER_SPEED` | `60` | Scroll speed in pixels per second (min 10; higher = faster). |
 | `PULSE_TICKER_EMOJI` | `true` | Add an accent emoji for outsized moves (🚀 ≥ +10%, 🔥 ≥ +5%, 📉 ≤ -5%, 🧊 ≤ -10%). |
+| `PULSE_TICKER_API_KEY` | _(unset)_ | Optional free [Finnhub](https://finnhub.io) API key. When set, Finnhub is the preferred (licensed) source for symbols it can price; Yahoo covers the rest. |
 
 Notes:
 - Gains render green with a ▲, losses red with a ▼; the bar matches the overlay's

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -249,4 +249,29 @@ Both are non-disruptive (they never bounce the Wi-Fi interface); the band pin ta
 
 As a backstop, the `watchdog(8)` daemon (see `configure_watchdog`) runs `pulse-net-check.sh`, which does a real TCP round-trip to an upstream host — not just a gateway ping the wedged firmware can still answer — so a silent wedge forces a hardware reset within a few minutes instead of waiting for a manual power-cycle.
 
+## Stock ticker
+
+**Problem**: The optional stock ticker bar (`PULSE_TICKER_ENABLED=true`) is missing, stuck
+on stale numbers, or the logs show repeated `ticker: yahoo ...`/`ticker: stooq ...` fetch
+warnings.
+
+**Cause**: The device fetches quotes directly from the internet, so a DNS-level ad-blocker
+(Pi-hole, AdGuard Home, NextDNS) or a firewall can silently block the provider hosts. Yahoo
+in particular is served from domains ad-blockers sometimes catch. When every provider is
+blocked, the fetcher falls back to its last-good cache, so the bar shows frozen values (or
+nothing on a fresh boot before the first successful fetch).
+
+**Solution**: Allowlist the quote hosts on your DNS filter / firewall:
+
+- `query1.finance.yahoo.com` — quote, crumb, and chart endpoints (primary source)
+- `fc.yahoo.com` — cookie/crumb seed for the Yahoo quote API
+- `stooq.com` — delayed CSV fallback
+
+Confirm resolution from the device with `nslookup query1.finance.yahoo.com` (it should not
+resolve to `0.0.0.0`/your Pi-hole), then check the fetcher directly:
+`cd /opt/pulse-os && uv run python pulse/stock_ticker.py ^SPX,^DJI,^NDX`. A healthy run prints
+quote dicts; blocked hosts print the matching `ticker:` warning. Note the fast/slow poll
+cadence is keyed to US market hours, so quotes only refresh every `PULSE_TICKER_INTERVAL_CLOSED`
+seconds (default 15 min) outside US trading — a "stale" bar overnight can be normal.
+
 Send PRs with any other gotchas so future builders don't have to rediscover them.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -255,17 +255,15 @@ As a backstop, the `watchdog(8)` daemon (see `configure_watchdog`) runs `pulse-n
 on stale numbers, or the logs show repeated `ticker: yahoo ...`/`ticker: stooq ...` fetch
 warnings.
 
-**Cause**: The device fetches quotes directly from the internet, so a DNS-level ad-blocker
-(Pi-hole, AdGuard Home, NextDNS) or a firewall can silently block the provider hosts. Yahoo
-in particular is served from domains ad-blockers sometimes catch. When every provider is
-blocked, the fetcher falls back to its last-good cache, so the bar shows frozen values (or
-nothing on a fresh boot before the first successful fetch).
+**Cause**: The device fetches quotes directly from Yahoo Finance, so a DNS-level ad-blocker
+(Pi-hole, AdGuard Home, NextDNS) or a firewall can silently block the provider hosts. When
+Yahoo is unreachable, the fetcher falls back to its last-good cache, so the bar shows frozen
+values (or nothing on a fresh boot before the first successful fetch).
 
 **Solution**: Allowlist the quote hosts on your DNS filter / firewall:
 
-- `query1.finance.yahoo.com` — quote, crumb, and chart endpoints (primary source)
+- `query1.finance.yahoo.com` — v7 quote, crumb, and v8 chart endpoints
 - `fc.yahoo.com` — cookie/crumb seed for the Yahoo quote API
-- `stooq.com` — delayed CSV fallback
 
 Confirm resolution from the device with `nslookup query1.finance.yahoo.com` (it should not
 resolve to `0.0.0.0`/your Pi-hole), then check the fetcher directly:
@@ -273,5 +271,9 @@ resolve to `0.0.0.0`/your Pi-hole), then check the fetcher directly:
 quote dicts; blocked hosts print the matching `ticker:` warning. Note the fast/slow poll
 cadence is keyed to US market hours, so quotes only refresh every `PULSE_TICKER_INTERVAL_CLOSED`
 seconds (default 15 min) outside US trading — a "stale" bar overnight can be normal.
+
+> Quotes come from Yahoo via two independent endpoints (v7 quote, then a no-auth v8 chart
+> fallback) plus the cache. Stooq was considered as a non-Yahoo source but now gates its CSV
+> endpoints behind a JavaScript anti-bot challenge, so it is unusable from a headless client.
 
 Send PRs with any other gotchas so future builders don't have to rediscover them.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -264,6 +264,7 @@ values (or nothing on a fresh boot before the first successful fetch).
 
 - `query1.finance.yahoo.com` — v7 quote, crumb, and v8 chart endpoints
 - `fc.yahoo.com` — cookie/crumb seed for the Yahoo quote API
+- `finnhub.io` — only if you set `PULSE_TICKER_API_KEY` (licensed provider)
 
 Confirm resolution from the device with `nslookup query1.finance.yahoo.com` (it should not
 resolve to `0.0.0.0`/your Pi-hole), then check the fetcher directly:
@@ -273,7 +274,9 @@ cadence is keyed to US market hours, so quotes only refresh every `PULSE_TICKER_
 seconds (default 15 min) outside US trading — a "stale" bar overnight can be normal.
 
 > Quotes come from Yahoo via two independent endpoints (v7 quote, then a no-auth v8 chart
-> fallback) plus the cache. Stooq was considered as a non-Yahoo source but now gates its CSV
-> endpoints behind a JavaScript anti-bot challenge, so it is unusable from a headless client.
+> fallback) plus the cache. Setting `PULSE_TICKER_API_KEY` adds Finnhub as a preferred,
+> licensed source for the symbols it can price. Stooq was considered as a non-Yahoo source
+> but now gates its CSV endpoints behind a JavaScript anti-bot challenge, so it is unusable
+> from a headless client.
 
 Send PRs with any other gotchas so future builders don't have to rediscover them.

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -99,6 +99,40 @@ PULSE_OVERLAY_CLOCK_24H="false"
 # PULSE_OVERLAY_AUTH_TOKEN=""
 
 # ============================================================================
+# Stock ticker (optional scrolling bar across the bottom of the overlay)
+# ============================================================================
+# Quotes come from Yahoo Finance (near-real-time, no key), with a Stooq fallback
+# and a last-good cache so the bar never goes blank. Any symbol Yahoo lists works,
+# including non-US indices (^N225, ^FTSE, ^GDAXI, ^HSI, ...) and foreign tickers
+# with an exchange suffix (SAP.DE, 7203.T).
+
+# PULSE_TICKER_ENABLED — master switch for the ticker bar (default off; optional per device).
+PULSE_TICKER_ENABLED="false"
+
+# PULSE_TICKER_SYMBOLS — comma-separated symbols to show. Indices use a caret prefix.
+# Friendly labels are built in for common indices; add your own tickers freely.
+# Defaults to the three big US indices when unset.
+PULSE_TICKER_SYMBOLS="^SPX,^DJI,^NDX"
+
+# PULSE_TICKER_INTERVAL — seconds between fetches while US markets are open (min 15).
+PULSE_TICKER_INTERVAL="60"
+
+# PULSE_TICKER_INTERVAL_CLOSED — seconds between fetches when US markets are closed
+# (nights/weekends, min 60). Non-US symbols refresh on this cadence during their own
+# sessions, so lower it if you mainly watch overseas markets.
+PULSE_TICKER_INTERVAL_CLOSED="900"
+
+# PULSE_TICKER_AFTERHOURS — append the post-market price (marked "AH") when available.
+PULSE_TICKER_AFTERHOURS="true"
+
+# PULSE_TICKER_SPEED — scroll speed in pixels per second (min 10; higher = faster).
+PULSE_TICKER_SPEED="60"
+
+# PULSE_TICKER_EMOJI — add an accent emoji for outsized moves (🚀 >= +10%, 🔥 >= +5%,
+# 📉 <= -5%, 🧊 <= -10%). Set "false" for numbers only.
+PULSE_TICKER_EMOJI="true"
+
+# ============================================================================
 # Telemetry & MQTT
 # ============================================================================
 

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -139,10 +139,12 @@ PULSE_TICKER_SPEED="60"
 # 📉 <= -5%, 🧊 <= -10%). Set "false" for numbers only.
 PULSE_TICKER_EMOJI="true"
 
-# PULSE_TICKER_LABEL — what to show before each price: "name" for the friendly/company
-# name (e.g. "S&P 500", "Apple Inc.") or "ticker" for the symbol (e.g. "SPX", "AAPL",
-# "VTI"). "ticker" is more compact and avoids long/truncated ETF names.
-PULSE_TICKER_LABEL="name"
+# PULSE_TICKER_LABEL — what to show before each price:
+#   "auto"   — friendly name for indices (e.g. "S&P 500"), ticker symbol for everything
+#              else (e.g. "AAPL", "VTI"). Best of both; the default.
+#   "name"   — friendly/company name for all (long ETF names may be truncated by the source).
+#   "ticker" — the symbol for all (e.g. "SPX", "AAPL", "VTI"). Most compact.
+PULSE_TICKER_LABEL="auto"
 
 # PULSE_TICKER_API_KEY — optional free Finnhub API key (https://finnhub.io). When set,
 # Finnhub is the preferred, licensed source for symbols it can price; Yahoo covers the

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -101,10 +101,10 @@ PULSE_OVERLAY_CLOCK_24H="false"
 # ============================================================================
 # Stock ticker (optional scrolling bar across the bottom of the overlay)
 # ============================================================================
-# Quotes come from Yahoo Finance (near-real-time, no key), with a Stooq fallback
-# and a last-good cache so the bar never goes blank. Any symbol Yahoo lists works,
-# including non-US indices (^N225, ^FTSE, ^GDAXI, ^HSI, ...) and foreign tickers
-# with an exchange suffix (SAP.DE, 7203.T).
+# Quotes come from Yahoo Finance (near-real-time, no key) using two independent
+# endpoints plus a last-good cache, so the bar never goes blank. Any symbol Yahoo
+# lists works, including non-US indices (^N225, ^FTSE, ^GDAXI, ^HSI, ...) and foreign
+# tickers with an exchange suffix (SAP.DE, 7203.T).
 
 # PULSE_TICKER_ENABLED — master switch for the ticker bar (default off; optional per device).
 PULSE_TICKER_ENABLED="false"

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -139,6 +139,11 @@ PULSE_TICKER_SPEED="60"
 # 📉 <= -5%, 🧊 <= -10%). Set "false" for numbers only.
 PULSE_TICKER_EMOJI="true"
 
+# PULSE_TICKER_LABEL — what to show before each price: "name" for the friendly/company
+# name (e.g. "S&P 500", "Apple Inc.") or "ticker" for the symbol (e.g. "SPX", "AAPL",
+# "VTI"). "ticker" is more compact and avoids long/truncated ETF names.
+PULSE_TICKER_LABEL="name"
+
 # PULSE_TICKER_API_KEY — optional free Finnhub API key (https://finnhub.io). When set,
 # Finnhub is the preferred, licensed source for symbols it can price; Yahoo covers the
 # rest. Leave empty to use Yahoo only.

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -105,6 +105,13 @@ PULSE_OVERLAY_CLOCK_24H="false"
 # endpoints plus a last-good cache, so the bar never goes blank. Any symbol Yahoo
 # lists works, including non-US indices (^N225, ^FTSE, ^GDAXI, ^HSI, ...) and foreign
 # tickers with an exchange suffix (SAP.DE, 7203.T).
+#
+# Data-source note: the Yahoo endpoints are unofficial/undocumented (Yahoo has no free
+# public API) and are used the way the yfinance library does — fine for personal,
+# non-commercial home display, but not a licensed/ToS-sanctioned use. For a licensed
+# source, set PULSE_TICKER_API_KEY to a free Finnhub key (below); Finnhub is then
+# preferred for the symbols it can price (US equities/ETFs), with Yahoo filling in the
+# rest (e.g. indices, which Finnhub's free tier does not cover).
 
 # PULSE_TICKER_ENABLED — master switch for the ticker bar (default off; optional per device).
 PULSE_TICKER_ENABLED="false"
@@ -131,6 +138,11 @@ PULSE_TICKER_SPEED="60"
 # PULSE_TICKER_EMOJI — add an accent emoji for outsized moves (🚀 >= +10%, 🔥 >= +5%,
 # 📉 <= -5%, 🧊 <= -10%). Set "false" for numbers only.
 PULSE_TICKER_EMOJI="true"
+
+# PULSE_TICKER_API_KEY — optional free Finnhub API key (https://finnhub.io). When set,
+# Finnhub is the preferred, licensed source for symbols it can price; Yahoo covers the
+# rest. Leave empty to use Yahoo only.
+# PULSE_TICKER_API_KEY=""
 
 # ============================================================================
 # Telemetry & MQTT

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -553,7 +553,7 @@ class OverlayTheme:
     show_ticker: bool = False
     ticker_scroll_speed: int = 60  # pixels per second
     ticker_emoji: bool = True
-    ticker_label_mode: str = "name"  # "name" (friendly name) or "ticker" (symbol)
+    ticker_label_mode: str = "auto"  # "name" | "ticker" | "auto" (name for indices, symbol otherwise)
 
 
 CELL_ORDER = (
@@ -637,17 +637,20 @@ def _ticker_float(value: Any) -> float | None:
 
 def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     quotes = snapshot.ticker or ()
-    show_symbol = theme.ticker_label_mode == "ticker"
+    mode = theme.ticker_label_mode  # "name" | "ticker" | "auto"
     items: list[str] = []
     for quote in quotes:
         if not isinstance(quote, dict):
             continue
-        if show_symbol:
-            # Ticker-symbol mode: e.g. "^SPX" -> "SPX", "VTI" -> "VTI" (avoids long/truncated
-            # provider names). Fall back to the friendly name if a symbol is somehow missing.
-            raw_label = str(quote.get("symbol") or "").lstrip("^") or str(quote.get("label") or "")
+        symbol = str(quote.get("symbol") or "")
+        name = str(quote.get("label") or "")
+        # "auto": friendly name for indices (symbols with a caret prefix, e.g. ^SPX),
+        # ticker symbol for everything else (avoids long/truncated ETF/stock names).
+        use_symbol = mode == "ticker" or (mode == "auto" and not symbol.startswith("^"))
+        if use_symbol:
+            raw_label = symbol.lstrip("^") or name  # e.g. "^SPX" -> "SPX", "VTI" -> "VTI"
         else:
-            raw_label = str(quote.get("label") or quote.get("symbol") or "")
+            raw_label = name or symbol
         label = html_escape(raw_label).strip()
         if not label:
             continue

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -553,6 +553,7 @@ class OverlayTheme:
     show_ticker: bool = False
     ticker_scroll_speed: int = 60  # pixels per second
     ticker_emoji: bool = True
+    ticker_label_mode: str = "name"  # "name" (friendly name) or "ticker" (symbol)
 
 
 CELL_ORDER = (
@@ -636,11 +637,18 @@ def _ticker_float(value: Any) -> float | None:
 
 def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     quotes = snapshot.ticker or ()
+    show_symbol = theme.ticker_label_mode == "ticker"
     items: list[str] = []
     for quote in quotes:
         if not isinstance(quote, dict):
             continue
-        label = html_escape(str(quote.get("label") or quote.get("symbol") or "")).strip()
+        if show_symbol:
+            # Ticker-symbol mode: e.g. "^SPX" -> "SPX", "VTI" -> "VTI" (avoids long/truncated
+            # provider names). Fall back to the friendly name if a symbol is somehow missing.
+            raw_label = str(quote.get("symbol") or "").lstrip("^") or str(quote.get("label") or "")
+        else:
+            raw_label = str(quote.get("label") or quote.get("symbol") or "")
+        label = html_escape(raw_label).strip()
         if not label:
             continue
         price = _ticker_float(quote.get("price"))

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -83,6 +83,7 @@ class OverlaySnapshot:
     schedule_snapshot: dict[str, Any] | None
     earmuffs_enabled: bool
     update_available: bool
+    ticker: tuple[dict[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -170,6 +171,7 @@ class OverlayStateManager:
         self._timer_position_history: dict[str, str] = {}
         self._earmuffs_enabled = False
         self._update_available = False
+        self._ticker: tuple[dict[str, Any], ...] = ()
         self._version = 0
         self._last_reason = "init"
         self._last_updated = time.time()
@@ -436,6 +438,18 @@ class OverlayStateManager:
             self._signatures["earmuffs_enabled"] = signature
             return self._bump("earmuffs_enabled")
 
+    def set_ticker(self, quotes: Sequence[dict[str, Any]]) -> None:
+        """Store the latest stock quotes for the ticker bar.
+
+        Deliberately does NOT bump the overlay version: the photo-card reloads the
+        overlay iframe on its own poll (<=120s) and picks these up then. Bumping would
+        force an extra iframe reload (and a visible repaint) every fetch, which is not
+        worth it for an ambient ticker whose data is already delayed.
+        """
+        normalized = tuple(dict(item) for item in quotes if isinstance(item, dict))
+        with self._lock:
+            self._ticker = normalized
+
     def update_update_available(self, available: bool) -> OverlayChange:
         signature = str(available)
         with self._lock:
@@ -468,6 +482,7 @@ class OverlayStateManager:
                 schedule_snapshot=copy.deepcopy(self._schedule_snapshot),
                 earmuffs_enabled=self._earmuffs_enabled,
                 update_available=self._update_available,
+                ticker=tuple(dict(item) for item in self._ticker),
             )
 
     def _bump(self, reason: str) -> OverlayChange:
@@ -535,6 +550,9 @@ class OverlayTheme:
     accent_color: str
     show_notification_bar: bool = True
     font_family: str = DEFAULT_FONT_STACK
+    show_ticker: bool = False
+    ticker_scroll_speed: int = 60  # pixels per second
+    ticker_emoji: bool = True
 
 
 CELL_ORDER = (
@@ -589,6 +607,84 @@ def _pick_available_cell(occupied: set[str], preferred: Sequence[str], fallback:
     return fallback
 
 
+def _format_ticker_number(value: Any) -> str:
+    try:
+        return f"{float(value):,.2f}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _ticker_move_emoji(pct: float) -> str:
+    """A little accent for outsized moves (empty for ordinary days)."""
+    if pct >= 10:
+        return "🚀"
+    if pct >= 5:
+        return "🔥"
+    if pct <= -10:
+        return "🧊"
+    if pct <= -5:
+        return "📉"
+    return ""
+
+
+def _ticker_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
+    quotes = snapshot.ticker or ()
+    items: list[str] = []
+    for quote in quotes:
+        if not isinstance(quote, dict):
+            continue
+        label = html_escape(str(quote.get("label") or quote.get("symbol") or "")).strip()
+        if not label:
+            continue
+        price = _ticker_float(quote.get("price"))
+        change = _ticker_float(quote.get("change"))
+        pct = _ticker_float(quote.get("change_pct"))
+        if price is None or change is None or pct is None:
+            continue
+        raw_is_up = quote.get("is_up")
+        is_up = bool(raw_is_up) if raw_is_up is not None else change >= 0
+        direction = "up" if is_up else "down"
+        arrow = "▲" if is_up else "▼"
+        change_text = f"{arrow} {abs(change):,.2f} ({abs(pct):.2f}%)"
+        emoji_markup = ""
+        if theme.ticker_emoji:
+            emoji = _ticker_move_emoji(pct)
+            if emoji:
+                emoji_markup = f'<span class="pulse-ticker__emoji">{emoji}</span>'
+        after_hours_markup = ""
+        after_hours = quote.get("after_hours")
+        if after_hours is not None:
+            after_hours_markup = f'<span class="pulse-ticker__ah">AH {_format_ticker_number(after_hours)}</span>'
+        items.append(
+            f'<span class="pulse-ticker__item pulse-ticker__item--{direction}">'
+            f'<span class="pulse-ticker__label">{label}</span>'
+            f'<span class="pulse-ticker__price">{_format_ticker_number(price)}</span>'
+            f'<span class="pulse-ticker__change">{change_text}</span>'
+            f"{after_hours_markup}{emoji_markup}"
+            f"</span>"
+        )
+    if not items:
+        return ""
+    track_items = "".join(items)
+    speed = max(10, int(theme.ticker_scroll_speed or 60))
+    # The item set is duplicated so the marquee loops seamlessly. overlay.js measures the
+    # real track width to set a constant px/sec duration and a wall-clock animation phase,
+    # so the scroll survives the photo-card's periodic iframe reloads without jumping.
+    return (
+        '<div class="pulse-ticker" aria-hidden="true">'
+        f'<div class="pulse-ticker__track" data-ticker-track data-speed="{speed}">'
+        f"{track_items}{track_items}"
+        "</div></div>"
+    )
+
+
 def render_overlay_html(
     snapshot: OverlaySnapshot,
     theme: OverlayTheme,
@@ -637,13 +733,16 @@ def render_overlay_html(
 
     notification_html = _build_notification_bar(snapshot) if theme.show_notification_bar else ""
 
+    ticker_html = _build_ticker_bar(snapshot, theme) if theme.show_ticker else ""
+    root_class = "overlay-root overlay-root--ticker" if ticker_html else "overlay-root"
+
     stop_endpoint = stop_endpoint or "/overlay/stop"
     info_endpoint = info_endpoint or "/overlay/info-card"
     stop_endpoint_attr = html_escape(stop_endpoint, quote=True)
     info_endpoint_attr = html_escape(info_endpoint, quote=True)
     root_attrs = (
         f'id="pulse-overlay-root" '
-        f'class="overlay-root" '
+        f'class="{root_class}" '
         f'data-version="{snapshot.version}" '
         f'data-generated-at="{int(snapshot.generated_at * 1000)}" '
         f'data-clock-hour12="{"true" if clock_hour12 else "false"}" '
@@ -667,6 +766,7 @@ def render_overlay_html(
 <div class="overlay-grid">
 {grid_markup}
 </div>
+{ticker_html}
 </div>
 <script>
 {OVERLAY_JS}

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -189,6 +189,7 @@ class OverlayStateManager:
             "info_card": "",
             "earmuffs_enabled": "",
             "update_available": "",
+            "ticker": "",
         }
 
     @property
@@ -438,17 +439,23 @@ class OverlayStateManager:
             self._signatures["earmuffs_enabled"] = signature
             return self._bump("earmuffs_enabled")
 
-    def set_ticker(self, quotes: Sequence[dict[str, Any]]) -> None:
+    def set_ticker(self, quotes: Sequence[dict[str, Any]]) -> OverlayChange:
         """Store the latest stock quotes for the ticker bar.
 
-        Deliberately does NOT bump the overlay version: the photo-card reloads the
-        overlay iframe on its own poll (<=120s) and picks these up then. Bumping would
-        force an extra iframe reload (and a visible repaint) every fetch, which is not
-        worth it for an ambient ticker whose data is already delayed.
+        Bumps the overlay version (which nudges the photo-card to refetch) only when the
+        SET OF SYMBOLS changes — i.e. when the ticker first populates after boot, or the
+        configured symbols change — NOT on every price tick. That makes the bar appear
+        promptly at startup without reloading the overlay iframe on every poll; ordinary
+        price updates ride the card's normal refresh cadence.
         """
         normalized = tuple(dict(item) for item in quotes if isinstance(item, dict))
+        signature = ",".join(str(item.get("symbol", "")) for item in normalized)
         with self._lock:
             self._ticker = normalized
+            if signature == self._signatures["ticker"]:
+                return OverlayChange(False, self._version, "ticker")
+            self._signatures["ticker"] = signature
+            return self._bump("ticker")
 
     def update_update_available(self, available: bool) -> OverlayChange:
         signature = str(available)

--- a/pulse/stock_ticker.py
+++ b/pulse/stock_ticker.py
@@ -264,16 +264,24 @@ class StockTicker:
     # whatever it can price (or None). fetch() merges results across providers per symbol.
 
     def _fetch_finnhub(self, symbols: list[str]) -> list[TickerQuote] | None:
-        """Optional licensed provider: Finnhub /quote, one request per symbol."""
+        """Optional licensed provider: Finnhub /quote, one request per symbol.
+
+        The API key is sent via the X-Finnhub-Token header (never the query string), so it
+        can't leak into logs through an httpx error message that echoes the request URL.
+        Note: the free /quote endpoint has no after-hours field, so Finnhub-priced symbols
+        carry no `AH` value — after-hours display is a Yahoo-only enrichment (documented).
+        """
         if not self.api_key:
             return None
         client = self._get_client()
+        headers = {"X-Finnhub-Token": self.api_key}
         quotes: list[TickerQuote] = []
         for canonical in symbols:
             try:
                 response = client.get(
                     FINNHUB_QUOTE_URL,
-                    params={"symbol": self._finnhub_symbol(canonical), "token": self.api_key},
+                    params={"symbol": self._finnhub_symbol(canonical)},
+                    headers=headers,
                 )
                 if response.status_code in (401, 403):
                     self._log("ticker: finnhub auth failed — check PULSE_TICKER_API_KEY")
@@ -284,7 +292,7 @@ class StockTicker:
                 response.raise_for_status()
                 data = response.json()
             except (httpx.HTTPError, ValueError) as exc:
-                self._log(f"ticker: finnhub {canonical} failed ({exc})")
+                self._log(f"ticker: finnhub {canonical} failed ({_redact(str(exc), self.api_key)})")
                 continue
             price = _coerce_float(data.get("c"))
             change = _coerce_float(data.get("d"))
@@ -417,6 +425,13 @@ def _coerce_float(value: object) -> float | None:
     except (TypeError, ValueError):
         return None
     return result
+
+
+def _redact(message: str, secret: str | None) -> str:
+    """Never let the API key reach the logs, even if some layer echoes it."""
+    if secret and secret in message:
+        return message.replace(secret, "***")
+    return message
 
 
 if __name__ == "__main__":  # pragma: no cover - manual smoke test

--- a/pulse/stock_ticker.py
+++ b/pulse/stock_ticker.py
@@ -1,0 +1,398 @@
+"""Stock quote fetcher for the overlay ticker bar.
+
+Fetches quotes for a configured list of symbols (major indices plus any equities
+the user cares to watch) for display in the scrolling overlay ticker.
+
+Reliability model (chosen with the user):
+- Primary: Yahoo Finance v7 quote (one request for all symbols; carries daily
+  change, marketState, and after-hours price). Yahoo now gates this behind a
+  cookie + crumb, which this module obtains transparently and refreshes on expiry.
+- Fallback: Yahoo v8 chart, one request per symbol, needs no auth so it survives
+  crumb-flow breakage (gives price vs. previous close; no marketState/after-hours).
+- Fallback: Stooq's light CSV endpoint (delayed ~15 min, no key).
+- Last resort: the most recent successfully-fetched values, so the ticker never
+  goes blank when the providers hiccup.
+
+Runs synchronously in a background daemon thread (see kiosk-mqtt-listener.py),
+mirroring the httpx style used by pulse/assistant/info_sources.py.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import threading
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import httpx
+
+LOGGER = logging.getLogger("pulse.stock_ticker")
+
+YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
+YAHOO_CRUMB_URL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
+YAHOO_COOKIE_SEED_URL = "https://fc.yahoo.com/"
+YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/"
+STOOQ_QUOTE_URL = "https://stooq.com/q/l/"
+# Yahoo and Stooq both reject the default httpx User-Agent, so present a browser-like one.
+_USER_AGENT = "Mozilla/5.0 (X11; Linux aarch64) PulseOS-ticker/1.0"
+
+_MARKET_TZ = ZoneInfo("America/New_York")
+
+# Canonical (config) symbol -> (yahoo symbol, stooq symbol).
+# Index tickers differ per provider; plain equities (AAPL, MSFT, ...) pass through
+# unchanged (upper-case for Yahoo, lower-case for Stooq) via _yahoo_symbol/_stooq_symbol.
+_INDEX_MAP: dict[str, tuple[str, str]] = {
+    "^SPX": ("^GSPC", "^spx"),  # S&P 500
+    "^GSPC": ("^GSPC", "^spx"),
+    "^DJI": ("^DJI", "^dji"),  # Dow Jones Industrial Average
+    "^IXIC": ("^IXIC", "^ndq"),  # Nasdaq Composite
+    "^NDX": ("^NDX", "^ndx"),  # Nasdaq 100
+    "^RUT": ("^RUT", "^rut"),  # Russell 2000
+    "^VIX": ("^VIX", "^vix"),  # Volatility index
+    "^FTSE": ("^FTSE", "^ftm"),  # FTSE 100 (UK)
+    "^GDAXI": ("^GDAXI", "^dax"),  # DAX (Germany)
+    "^FCHI": ("^FCHI", "^cac"),  # CAC 40 (France)
+    "^STOXX50E": ("^STOXX50E", "^stx"),  # Euro Stoxx 50
+    "^N225": ("^N225", "^nkx"),  # Nikkei 225 (Japan)
+    "^HSI": ("^HSI", "^hsi"),  # Hang Seng (Hong Kong)
+}
+
+# Friendly display labels for common indices (fallback: provider short name or symbol).
+_LABELS: dict[str, str] = {
+    "^SPX": "S&P 500",
+    "^GSPC": "S&P 500",
+    "^DJI": "Dow",
+    "^IXIC": "Nasdaq",
+    "^NDX": "Nasdaq 100",
+    "^RUT": "Russell 2000",
+    "^VIX": "VIX",
+    "^FTSE": "FTSE 100",
+    "^GDAXI": "DAX",
+    "^FCHI": "CAC 40",
+    "^STOXX50E": "Euro Stoxx 50",
+    "^N225": "Nikkei 225",
+    "^HSI": "Hang Seng",
+}
+
+
+def is_us_market_hours(now: datetime | None = None) -> bool:
+    """Rough US equity regular-session check (Mon-Fri 09:30-16:00 ET, ignores holidays).
+
+    Used to pace the fetch cadence; being wrong on a holiday only means an extra
+    (harmless) fast poll, so exchange-holiday precision is not worth the dependency.
+    """
+    current = now.astimezone(_MARKET_TZ) if now else datetime.now(_MARKET_TZ)
+    if current.weekday() >= 5:  # Saturday/Sunday
+        return False
+    minutes = current.hour * 60 + current.minute
+    return 9 * 60 + 30 <= minutes <= 16 * 60
+
+
+@dataclass(frozen=True)
+class TickerQuote:
+    """A single quote for the ticker bar."""
+
+    symbol: str  # canonical symbol as configured
+    label: str  # display label
+    price: float
+    change: float
+    change_pct: float
+    is_up: bool
+    after_hours: float | None = None  # post-market price, when available
+    market_state: str = ""  # REGULAR / PRE / POST / CLOSED / DELAYED / ...
+
+    def as_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "symbol": self.symbol,
+            "label": self.label,
+            "price": round(self.price, 2),
+            "change": round(self.change, 2),
+            "change_pct": round(self.change_pct, 2),
+            "is_up": self.is_up,
+            "market_state": self.market_state,
+        }
+        if self.after_hours is not None:
+            payload["after_hours"] = round(self.after_hours, 2)
+        return payload
+
+
+def parse_symbols(spec: str | None) -> list[str]:
+    """Parse a comma/space/semicolon separated symbol list into canonical symbols."""
+    if not spec:
+        return []
+    raw = spec.replace(";", ",").replace(" ", ",")
+    seen: set[str] = set()
+    symbols: list[str] = []
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        canonical = token.upper()
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        symbols.append(canonical)
+    return symbols
+
+
+class StockTicker:
+    """Fetches quotes with Yahoo v7 -> Yahoo v8 -> Stooq -> last-good-cache fallback."""
+
+    def __init__(
+        self,
+        symbols: Sequence[str],
+        *,
+        afterhours: bool = True,
+        timeout: float = 10.0,
+        log: Callable[[str], None] | None = None,
+    ) -> None:
+        self.symbols = [s.strip().upper() for s in symbols if s and s.strip()]
+        self.afterhours = afterhours
+        self.timeout = timeout
+        self._log = log or LOGGER.info
+        self._lock = threading.Lock()
+        self._cache: tuple[TickerQuote, ...] = ()
+        self._client: httpx.Client | None = None
+        self._crumb: str | None = None
+
+    def close(self) -> None:
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+    # -- symbol mapping helpers ------------------------------------------------
+
+    def _yahoo_symbol(self, canonical: str) -> str:
+        mapped = _INDEX_MAP.get(canonical)
+        return mapped[0] if mapped else canonical
+
+    def _stooq_symbol(self, canonical: str) -> str:
+        mapped = _INDEX_MAP.get(canonical)
+        return mapped[1] if mapped else canonical.lower()
+
+    def _label(self, canonical: str, fallback: str | None) -> str:
+        return _LABELS.get(canonical) or (fallback or "").strip() or canonical.lstrip("^")
+
+    # -- public API ------------------------------------------------------------
+
+    def fetch(self) -> list[TickerQuote]:
+        """Return the freshest quotes available, never raising and never blank-on-hiccup."""
+        if not self.symbols:
+            return []
+        quotes = self._fetch_yahoo_quote() or self._fetch_yahoo_chart() or self._fetch_stooq()
+        if quotes:
+            with self._lock:
+                self._cache = tuple(quotes)
+            return quotes
+        with self._lock:
+            return list(self._cache)
+
+    # -- http client -----------------------------------------------------------
+
+    def _get_client(self) -> httpx.Client:
+        # A single reused client keeps the Yahoo cookie/crumb warm across polls.
+        # Only the ticker thread calls fetch(), so no cross-thread client sharing.
+        if self._client is None:
+            self._client = httpx.Client(
+                timeout=self.timeout,
+                headers={"User-Agent": _USER_AGENT},
+                follow_redirects=True,
+            )
+        return self._client
+
+    def _ensure_crumb(self, client: httpx.Client, *, force: bool = False) -> str | None:
+        if self._crumb and not force:
+            return self._crumb
+        try:
+            # Seed the cookie jar (this URL commonly 404s but still sets the A1/A3 cookie).
+            try:
+                client.get(YAHOO_COOKIE_SEED_URL)
+            except httpx.HTTPError:
+                pass
+            response = client.get(YAHOO_CRUMB_URL)
+            crumb = response.text.strip()
+            if response.status_code == 200 and crumb and "<" not in crumb:
+                self._crumb = crumb
+                return crumb
+            self._log(f"ticker: yahoo crumb unavailable (status {response.status_code})")
+        except httpx.HTTPError as exc:
+            self._log(f"ticker: yahoo crumb fetch failed ({exc})")
+        return None
+
+    # -- providers -------------------------------------------------------------
+
+    def _fetch_yahoo_quote(self) -> list[TickerQuote] | None:
+        """Primary: v7 quote (cookie + crumb), one request for all symbols."""
+        client = self._get_client()
+        crumb = self._ensure_crumb(client)
+        if not crumb:
+            return None
+        payload = self._yahoo_quote_request(client, crumb)
+        if payload is None:
+            # A stale crumb comes back as 401; refresh once and retry.
+            crumb = self._ensure_crumb(client, force=True)
+            if not crumb:
+                return None
+            payload = self._yahoo_quote_request(client, crumb)
+        if payload is None:
+            return None
+        results = (payload.get("quoteResponse") or {}).get("result") or []
+        if not results:
+            return None
+        by_symbol = {str(item.get("symbol", "")).upper(): item for item in results}
+        quotes: list[TickerQuote] = []
+        for canonical in self.symbols:
+            item = by_symbol.get(self._yahoo_symbol(canonical).upper())
+            if not item:
+                continue
+            price = item.get("regularMarketPrice")
+            change = item.get("regularMarketChange")
+            pct = item.get("regularMarketChangePercent")
+            if price is None or change is None or pct is None:
+                continue
+            market_state = str(item.get("marketState") or "")
+            after_hours = None
+            if self.afterhours and market_state in {"POST", "POSTPOST"}:
+                after_hours = _coerce_float(item.get("postMarketPrice"))
+            try:
+                quotes.append(
+                    TickerQuote(
+                        symbol=canonical,
+                        label=self._label(canonical, item.get("shortName")),
+                        price=float(price),
+                        change=float(change),
+                        change_pct=float(pct),
+                        is_up=float(change) >= 0,
+                        after_hours=after_hours,
+                        market_state=market_state,
+                    )
+                )
+            except (TypeError, ValueError):
+                continue
+        return quotes or None
+
+    def _yahoo_quote_request(self, client: httpx.Client, crumb: str) -> dict | None:
+        yahoo_symbols = [self._yahoo_symbol(s) for s in self.symbols]
+        try:
+            response = client.get(
+                YAHOO_QUOTE_URL,
+                params={"symbols": ",".join(yahoo_symbols), "crumb": crumb},
+            )
+            if response.status_code in (401, 403):
+                return None
+            response.raise_for_status()
+            return response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            self._log(f"ticker: yahoo quote failed ({exc})")
+            return None
+
+    def _fetch_yahoo_chart(self) -> list[TickerQuote] | None:
+        """Fallback: v8 chart, one request per symbol, no auth required."""
+        client = self._get_client()
+        quotes: list[TickerQuote] = []
+        for canonical in self.symbols:
+            meta = self._chart_meta(client, self._yahoo_symbol(canonical))
+            if not meta:
+                continue
+            price = _coerce_float(meta.get("regularMarketPrice"))
+            prev_close = _coerce_float(meta.get("chartPreviousClose"))
+            if price is None or not prev_close:
+                continue
+            change = price - prev_close
+            quotes.append(
+                TickerQuote(
+                    symbol=canonical,
+                    label=self._label(canonical, meta.get("shortName")),
+                    price=price,
+                    change=change,
+                    change_pct=change / prev_close * 100.0,
+                    is_up=change >= 0,
+                )
+            )
+        return quotes or None
+
+    def _chart_meta(self, client: httpx.Client, yahoo_symbol: str) -> dict | None:
+        try:
+            response = client.get(
+                f"{YAHOO_CHART_URL}{yahoo_symbol}",
+                params={"interval": "1d", "range": "1d"},
+            )
+            response.raise_for_status()
+            result = (response.json().get("chart") or {}).get("result") or []
+            if not result:
+                return None
+            return result[0].get("meta") or None
+        except (httpx.HTTPError, ValueError) as exc:
+            self._log(f"ticker: yahoo chart {yahoo_symbol} failed ({exc})")
+            return None
+
+    def _fetch_stooq(self) -> list[TickerQuote] | None:
+        # Stooq multi-quote uses '+'-separated symbols. Build the query manually so the
+        # '^' and '+' are not percent-encoded away by the client.
+        stooq_symbols = "+".join(self._stooq_symbol(s) for s in self.symbols)
+        url = f"{STOOQ_QUOTE_URL}?s={stooq_symbols}&f=sohlc&h&e=csv"
+        try:
+            client = self._get_client()
+            response = client.get(url)
+            response.raise_for_status()
+            text = response.text
+        except httpx.HTTPError as exc:
+            self._log(f"ticker: stooq fetch failed ({exc})")
+            return None
+        if "<" in text[:64]:  # Stooq serves an HTML 404 page when it blocks/rate-limits.
+            self._log("ticker: stooq returned non-CSV (blocked or bad symbols)")
+            return None
+        try:
+            rows = list(csv.DictReader(io.StringIO(text)))
+        except csv.Error as exc:
+            self._log(f"ticker: stooq parse failed ({exc})")
+            return None
+        by_symbol = {str(row.get("Symbol", "")).upper(): row for row in rows}
+        quotes: list[TickerQuote] = []
+        for canonical in self.symbols:
+            row = by_symbol.get(self._stooq_symbol(canonical).upper())
+            if not row:
+                continue
+            # Stooq's light CSV has no previous-close field, so approximate the move as
+            # close-vs-open. This is a delayed fallback only; Yahoo carries daily change.
+            open_price = _coerce_float(row.get("Open"))
+            close_price = _coerce_float(row.get("Close"))
+            if not open_price or not close_price or close_price <= 0:
+                continue
+            change = close_price - open_price
+            quotes.append(
+                TickerQuote(
+                    symbol=canonical,
+                    label=self._label(canonical, None),
+                    price=close_price,
+                    change=change,
+                    change_pct=change / open_price * 100.0,
+                    is_up=change >= 0,
+                    market_state="DELAYED",
+                )
+            )
+        return quotes or None
+
+
+def _coerce_float(value: object) -> float | None:
+    try:
+        result = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return result
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    requested = parse_symbols(",".join(sys.argv[1:])) or ["^SPX", "^DJI", "^NDX"]
+    ticker = StockTicker(requested)
+    for quote in ticker.fetch():
+        print(quote.as_dict())
+    print(f"market_hours={is_us_market_hours()}")
+    ticker.close()

--- a/pulse/stock_ticker.py
+++ b/pulse/stock_ticker.py
@@ -174,15 +174,21 @@ class StockTicker:
     # -- public API ------------------------------------------------------------
 
     def fetch(self) -> list[TickerQuote]:
-        """Return the freshest quotes available, never raising and never blank-on-hiccup."""
+        """Return the freshest quotes available, never raising and never blank-on-hiccup.
+
+        Newly fetched quotes are merged over the last-good cache per symbol, so a symbol
+        that a given response happens to omit keeps its previous value instead of
+        vanishing from the ticker until the next full fetch.
+        """
         if not self.symbols:
             return []
-        quotes = self._fetch_yahoo_quote() or self._fetch_yahoo_chart()
-        if quotes:
-            with self._lock:
-                self._cache = tuple(quotes)
-            return quotes
+        fetched = self._fetch_yahoo_quote() or self._fetch_yahoo_chart() or []
         with self._lock:
+            if fetched:
+                merged = {quote.symbol: quote for quote in self._cache}
+                merged.update({quote.symbol: quote for quote in fetched})
+                # Keep only currently-configured symbols, in configured order.
+                self._cache = tuple(merged[symbol] for symbol in self.symbols if symbol in merged)
             return list(self._cache)
 
     # -- http client -----------------------------------------------------------
@@ -206,6 +212,7 @@ class StockTicker:
             try:
                 client.get(YAHOO_COOKIE_SEED_URL)
             except httpx.HTTPError:
+                # Best-effort seed; the crumb request below sets cookies on its own too.
                 pass
             response = client.get(YAHOO_CRUMB_URL)
             crumb = response.text.strip()

--- a/pulse/stock_ticker.py
+++ b/pulse/stock_ticker.py
@@ -9,9 +9,13 @@ Reliability model (chosen with the user):
   cookie + crumb, which this module obtains transparently and refreshes on expiry.
 - Fallback: Yahoo v8 chart, one request per symbol, needs no auth so it survives
   crumb-flow breakage (gives price vs. previous close; no marketState/after-hours).
-- Fallback: Stooq's light CSV endpoint (delayed ~15 min, no key).
+  This is an independent request path from v7, so it also covers a v7 outage.
 - Last resort: the most recent successfully-fetched values, so the ticker never
   goes blank when the providers hiccup.
+
+(Stooq was evaluated as a non-Yahoo fallback but now puts its CSV endpoints behind
+a JavaScript proof-of-work anti-bot challenge, so it is unusable from a headless
+client and was dropped.)
 
 Runs synchronously in a background daemon thread (see kiosk-mqtt-listener.py),
 mirroring the httpx style used by pulse/assistant/info_sources.py.
@@ -19,8 +23,6 @@ mirroring the httpx style used by pulse/assistant/info_sources.py.
 
 from __future__ import annotations
 
-import csv
-import io
 import logging
 import threading
 from collections.abc import Callable, Sequence
@@ -36,29 +38,26 @@ YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
 YAHOO_CRUMB_URL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
 YAHOO_COOKIE_SEED_URL = "https://fc.yahoo.com/"
 YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/"
-STOOQ_QUOTE_URL = "https://stooq.com/q/l/"
-# Yahoo and Stooq both reject the default httpx User-Agent, so present a browser-like one.
+# Yahoo rejects the default httpx User-Agent, so present a browser-like one.
 _USER_AGENT = "Mozilla/5.0 (X11; Linux aarch64) PulseOS-ticker/1.0"
 
 _MARKET_TZ = ZoneInfo("America/New_York")
 
-# Canonical (config) symbol -> (yahoo symbol, stooq symbol).
-# Index tickers differ per provider; plain equities (AAPL, MSFT, ...) pass through
-# unchanged (upper-case for Yahoo, lower-case for Stooq) via _yahoo_symbol/_stooq_symbol.
-_INDEX_MAP: dict[str, tuple[str, str]] = {
-    "^SPX": ("^GSPC", "^spx"),  # S&P 500
-    "^GSPC": ("^GSPC", "^spx"),
-    "^DJI": ("^DJI", "^dji"),  # Dow Jones Industrial Average
-    "^IXIC": ("^IXIC", "^ndq"),  # Nasdaq Composite
-    "^NDX": ("^NDX", "^ndx"),  # Nasdaq 100
-    "^RUT": ("^RUT", "^rut"),  # Russell 2000
-    "^VIX": ("^VIX", "^vix"),  # Volatility index
-    "^FTSE": ("^FTSE", "^ftm"),  # FTSE 100 (UK)
-    "^GDAXI": ("^GDAXI", "^dax"),  # DAX (Germany)
-    "^FCHI": ("^FCHI", "^cac"),  # CAC 40 (France)
-    "^STOXX50E": ("^STOXX50E", "^stx"),  # Euro Stoxx 50
-    "^N225": ("^N225", "^nkx"),  # Nikkei 225 (Japan)
-    "^HSI": ("^HSI", "^hsi"),  # Hang Seng (Hong Kong)
+# Friendly (config) symbol -> Yahoo symbol, for indices whose tickers differ from what
+# a user would naturally type. Plain equities (AAPL, MSFT, ...) pass through unchanged.
+_YAHOO_SYMBOLS: dict[str, str] = {
+    "^SPX": "^GSPC",  # S&P 500
+    "^DJI": "^DJI",  # Dow Jones Industrial Average
+    "^IXIC": "^IXIC",  # Nasdaq Composite
+    "^NDX": "^NDX",  # Nasdaq 100
+    "^RUT": "^RUT",  # Russell 2000
+    "^VIX": "^VIX",  # Volatility index
+    "^FTSE": "^FTSE",  # FTSE 100 (UK)
+    "^GDAXI": "^GDAXI",  # DAX (Germany)
+    "^FCHI": "^FCHI",  # CAC 40 (France)
+    "^STOXX50E": "^STOXX50E",  # Euro Stoxx 50
+    "^N225": "^N225",  # Nikkei 225 (Japan)
+    "^HSI": "^HSI",  # Hang Seng (Hong Kong)
 }
 
 # Friendly display labels for common indices (fallback: provider short name or symbol).
@@ -167,12 +166,7 @@ class StockTicker:
     # -- symbol mapping helpers ------------------------------------------------
 
     def _yahoo_symbol(self, canonical: str) -> str:
-        mapped = _INDEX_MAP.get(canonical)
-        return mapped[0] if mapped else canonical
-
-    def _stooq_symbol(self, canonical: str) -> str:
-        mapped = _INDEX_MAP.get(canonical)
-        return mapped[1] if mapped else canonical.lower()
+        return _YAHOO_SYMBOLS.get(canonical, canonical)
 
     def _label(self, canonical: str, fallback: str | None) -> str:
         return _LABELS.get(canonical) or (fallback or "").strip() or canonical.lstrip("^")
@@ -183,7 +177,7 @@ class StockTicker:
         """Return the freshest quotes available, never raising and never blank-on-hiccup."""
         if not self.symbols:
             return []
-        quotes = self._fetch_yahoo_quote() or self._fetch_yahoo_chart() or self._fetch_stooq()
+        quotes = self._fetch_yahoo_quote() or self._fetch_yahoo_chart()
         if quotes:
             with self._lock:
                 self._cache = tuple(quotes)
@@ -329,53 +323,6 @@ class StockTicker:
         except (httpx.HTTPError, ValueError) as exc:
             self._log(f"ticker: yahoo chart {yahoo_symbol} failed ({exc})")
             return None
-
-    def _fetch_stooq(self) -> list[TickerQuote] | None:
-        # Stooq multi-quote uses '+'-separated symbols. Build the query manually so the
-        # '^' and '+' are not percent-encoded away by the client.
-        stooq_symbols = "+".join(self._stooq_symbol(s) for s in self.symbols)
-        url = f"{STOOQ_QUOTE_URL}?s={stooq_symbols}&f=sohlc&h&e=csv"
-        try:
-            client = self._get_client()
-            response = client.get(url)
-            response.raise_for_status()
-            text = response.text
-        except httpx.HTTPError as exc:
-            self._log(f"ticker: stooq fetch failed ({exc})")
-            return None
-        if "<" in text[:64]:  # Stooq serves an HTML 404 page when it blocks/rate-limits.
-            self._log("ticker: stooq returned non-CSV (blocked or bad symbols)")
-            return None
-        try:
-            rows = list(csv.DictReader(io.StringIO(text)))
-        except csv.Error as exc:
-            self._log(f"ticker: stooq parse failed ({exc})")
-            return None
-        by_symbol = {str(row.get("Symbol", "")).upper(): row for row in rows}
-        quotes: list[TickerQuote] = []
-        for canonical in self.symbols:
-            row = by_symbol.get(self._stooq_symbol(canonical).upper())
-            if not row:
-                continue
-            # Stooq's light CSV has no previous-close field, so approximate the move as
-            # close-vs-open. This is a delayed fallback only; Yahoo carries daily change.
-            open_price = _coerce_float(row.get("Open"))
-            close_price = _coerce_float(row.get("Close"))
-            if not open_price or not close_price or close_price <= 0:
-                continue
-            change = close_price - open_price
-            quotes.append(
-                TickerQuote(
-                    symbol=canonical,
-                    label=self._label(canonical, None),
-                    price=close_price,
-                    change=change,
-                    change_pct=change / open_price * 100.0,
-                    is_up=change >= 0,
-                    market_state="DELAYED",
-                )
-            )
-        return quotes or None
 
 
 def _coerce_float(value: object) -> float | None:

--- a/pulse/stock_ticker.py
+++ b/pulse/stock_ticker.py
@@ -3,19 +3,25 @@
 Fetches quotes for a configured list of symbols (major indices plus any equities
 the user cares to watch) for display in the scrolling overlay ticker.
 
-Reliability model (chosen with the user):
-- Primary: Yahoo Finance v7 quote (one request for all symbols; carries daily
-  change, marketState, and after-hours price). Yahoo now gates this behind a
-  cookie + crumb, which this module obtains transparently and refreshes on expiry.
-- Fallback: Yahoo v8 chart, one request per symbol, needs no auth so it survives
-  crumb-flow breakage (gives price vs. previous close; no marketState/after-hours).
-  This is an independent request path from v7, so it also covers a v7 outage.
-- Last resort: the most recent successfully-fetched values, so the ticker never
-  goes blank when the providers hiccup.
+Provider chain (per symbol, first source that answers wins for that symbol):
+- Optional: Finnhub (https://finnhub.io) when PULSE_TICKER_API_KEY is set. This is a
+  licensed API with an explicit free tier for personal use, so it is the preferred
+  source when configured. Free tier covers US equities/ETFs but generally not indices,
+  which is fine — anything Finnhub can't price falls through to Yahoo below.
+- Yahoo Finance v7 quote (one request for all remaining symbols; carries daily change,
+  marketState, and after-hours price). Yahoo gates this behind a cookie + crumb, which
+  this module obtains transparently and refreshes on expiry.
+- Yahoo v8 chart, one request per symbol, needs no auth so it survives crumb-flow
+  breakage (price vs. previous close; no marketState/after-hours).
+- Last resort: the most recent successfully-fetched values, so the ticker never goes
+  blank when the providers hiccup.
 
-(Stooq was evaluated as a non-Yahoo fallback but now puts its CSV endpoints behind
-a JavaScript proof-of-work anti-bot challenge, so it is unusable from a headless
-client and was dropped.)
+Data-source note: the Yahoo endpoints are unofficial/undocumented (Yahoo has no free
+public API) and are used here the same way the yfinance library does — appropriate for
+personal, non-commercial, low-volume home display, but not a licensed/ToS-sanctioned
+use. Set PULSE_TICKER_API_KEY to prefer Finnhub, which does provide a licensed free
+tier. (Stooq was evaluated but now gates its CSV endpoints behind a JavaScript anti-bot
+challenge, so it is unusable headless and was dropped.)
 
 Runs synchronously in a background daemon thread (see kiosk-mqtt-listener.py),
 mirroring the httpx style used by pulse/assistant/info_sources.py.
@@ -38,6 +44,7 @@ YAHOO_QUOTE_URL = "https://query1.finance.yahoo.com/v7/finance/quote"
 YAHOO_CRUMB_URL = "https://query1.finance.yahoo.com/v1/test/getcrumb"
 YAHOO_COOKIE_SEED_URL = "https://fc.yahoo.com/"
 YAHOO_CHART_URL = "https://query1.finance.yahoo.com/v8/finance/chart/"
+FINNHUB_QUOTE_URL = "https://finnhub.io/api/v1/quote"
 # Yahoo rejects the default httpx User-Agent, so present a browser-like one.
 _USER_AGENT = "Mozilla/5.0 (X11; Linux aarch64) PulseOS-ticker/1.0"
 
@@ -139,18 +146,20 @@ def parse_symbols(spec: str | None) -> list[str]:
 
 
 class StockTicker:
-    """Fetches quotes with Yahoo v7 -> Yahoo v8 -> Stooq -> last-good-cache fallback."""
+    """Fetches quotes via an optional Finnhub key, then Yahoo v7/v8, then last-good cache."""
 
     def __init__(
         self,
         symbols: Sequence[str],
         *,
         afterhours: bool = True,
+        api_key: str | None = None,
         timeout: float = 10.0,
         log: Callable[[str], None] | None = None,
     ) -> None:
         self.symbols = [s.strip().upper() for s in symbols if s and s.strip()]
         self.afterhours = afterhours
+        self.api_key = (api_key or "").strip() or None
         self.timeout = timeout
         self._log = log or LOGGER.info
         self._lock = threading.Lock()
@@ -168,25 +177,51 @@ class StockTicker:
     def _yahoo_symbol(self, canonical: str) -> str:
         return _YAHOO_SYMBOLS.get(canonical, canonical)
 
+    def _finnhub_symbol(self, canonical: str) -> str:
+        # Finnhub uses plain tickers for US equities/ETFs; indices (with a caret) are
+        # not on the free tier and simply return no data, so they fall through to Yahoo.
+        return canonical
+
     def _label(self, canonical: str, fallback: str | None) -> str:
         return _LABELS.get(canonical) or (fallback or "").strip() or canonical.lstrip("^")
+
+    def _provider_chain(self) -> list[Callable[[list[str]], list[TickerQuote] | None]]:
+        chain: list[Callable[[list[str]], list[TickerQuote] | None]] = []
+        if self.api_key:
+            chain.append(self._fetch_finnhub)
+        chain.append(self._fetch_yahoo_quote)
+        chain.append(self._fetch_yahoo_chart)
+        return chain
 
     # -- public API ------------------------------------------------------------
 
     def fetch(self) -> list[TickerQuote]:
         """Return the freshest quotes available, never raising and never blank-on-hiccup.
 
-        Newly fetched quotes are merged over the last-good cache per symbol, so a symbol
-        that a given response happens to omit keeps its previous value instead of
-        vanishing from the ticker until the next full fetch.
+        Each provider is asked only for the symbols still uncovered, so (e.g.) Finnhub
+        can price the equities while Yahoo fills in the indices it doesn't support. The
+        result is then merged over the last-good cache per symbol, so a symbol a round
+        happens to miss keeps its previous value instead of vanishing from the ticker.
         """
         if not self.symbols:
             return []
-        fetched = self._fetch_yahoo_quote() or self._fetch_yahoo_chart() or []
+        collected: dict[str, TickerQuote] = {}
+        remaining = list(self.symbols)
+        for provider in self._provider_chain():
+            if not remaining:
+                break
+            try:
+                found = provider(remaining) or []
+            except Exception as exc:  # nosec B112 - a bad provider must not stop the chain
+                self._log(f"ticker: provider {provider.__name__} errored ({exc})")
+                found = []
+            for quote in found:
+                collected[quote.symbol] = quote
+            remaining = [symbol for symbol in self.symbols if symbol not in collected]
         with self._lock:
-            if fetched:
+            if collected:
                 merged = {quote.symbol: quote for quote in self._cache}
-                merged.update({quote.symbol: quote for quote in fetched})
+                merged.update(collected)
                 # Keep only currently-configured symbols, in configured order.
                 self._cache = tuple(merged[symbol] for symbol in self.symbols if symbol in merged)
             return list(self._cache)
@@ -225,20 +260,64 @@ class StockTicker:
         return None
 
     # -- providers -------------------------------------------------------------
+    # Each provider takes the list of still-uncovered symbols and returns quotes for
+    # whatever it can price (or None). fetch() merges results across providers per symbol.
 
-    def _fetch_yahoo_quote(self) -> list[TickerQuote] | None:
-        """Primary: v7 quote (cookie + crumb), one request for all symbols."""
+    def _fetch_finnhub(self, symbols: list[str]) -> list[TickerQuote] | None:
+        """Optional licensed provider: Finnhub /quote, one request per symbol."""
+        if not self.api_key:
+            return None
+        client = self._get_client()
+        quotes: list[TickerQuote] = []
+        for canonical in symbols:
+            try:
+                response = client.get(
+                    FINNHUB_QUOTE_URL,
+                    params={"symbol": self._finnhub_symbol(canonical), "token": self.api_key},
+                )
+                if response.status_code in (401, 403):
+                    self._log("ticker: finnhub auth failed — check PULSE_TICKER_API_KEY")
+                    return quotes or None
+                if response.status_code == 429:
+                    self._log("ticker: finnhub rate-limited; leaving rest to Yahoo")
+                    return quotes or None
+                response.raise_for_status()
+                data = response.json()
+            except (httpx.HTTPError, ValueError) as exc:
+                self._log(f"ticker: finnhub {canonical} failed ({exc})")
+                continue
+            price = _coerce_float(data.get("c"))
+            change = _coerce_float(data.get("d"))
+            pct = _coerce_float(data.get("dp"))
+            # Finnhub returns c=0 (and null d/dp) for symbols it can't price, e.g. indices
+            # on the free tier — skip those so they fall through to Yahoo.
+            if not price or price <= 0 or change is None or pct is None:
+                continue
+            quotes.append(
+                TickerQuote(
+                    symbol=canonical,
+                    label=self._label(canonical, None),
+                    price=price,
+                    change=change,
+                    change_pct=pct,
+                    is_up=change >= 0,
+                )
+            )
+        return quotes or None
+
+    def _fetch_yahoo_quote(self, symbols: list[str]) -> list[TickerQuote] | None:
+        """v7 quote (cookie + crumb), one request for all requested symbols."""
         client = self._get_client()
         crumb = self._ensure_crumb(client)
         if not crumb:
             return None
-        payload = self._yahoo_quote_request(client, crumb)
+        payload = self._yahoo_quote_request(client, crumb, symbols)
         if payload is None:
             # A stale crumb comes back as 401; refresh once and retry.
             crumb = self._ensure_crumb(client, force=True)
             if not crumb:
                 return None
-            payload = self._yahoo_quote_request(client, crumb)
+            payload = self._yahoo_quote_request(client, crumb, symbols)
         if payload is None:
             return None
         results = (payload.get("quoteResponse") or {}).get("result") or []
@@ -246,7 +325,7 @@ class StockTicker:
             return None
         by_symbol = {str(item.get("symbol", "")).upper(): item for item in results}
         quotes: list[TickerQuote] = []
-        for canonical in self.symbols:
+        for canonical in symbols:
             item = by_symbol.get(self._yahoo_symbol(canonical).upper())
             if not item:
                 continue
@@ -276,8 +355,8 @@ class StockTicker:
                 continue
         return quotes or None
 
-    def _yahoo_quote_request(self, client: httpx.Client, crumb: str) -> dict | None:
-        yahoo_symbols = [self._yahoo_symbol(s) for s in self.symbols]
+    def _yahoo_quote_request(self, client: httpx.Client, crumb: str, symbols: list[str]) -> dict | None:
+        yahoo_symbols = [self._yahoo_symbol(s) for s in symbols]
         try:
             response = client.get(
                 YAHOO_QUOTE_URL,
@@ -291,11 +370,11 @@ class StockTicker:
             self._log(f"ticker: yahoo quote failed ({exc})")
             return None
 
-    def _fetch_yahoo_chart(self) -> list[TickerQuote] | None:
+    def _fetch_yahoo_chart(self, symbols: list[str]) -> list[TickerQuote] | None:
         """Fallback: v8 chart, one request per symbol, no auth required."""
         client = self._get_client()
         quotes: list[TickerQuote] = []
-        for canonical in self.symbols:
+        for canonical in symbols:
             meta = self._chart_meta(client, self._yahoo_symbol(canonical))
             if not meta:
                 continue
@@ -341,11 +420,12 @@ def _coerce_float(value: object) -> float | None:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    import os
     import sys
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     requested = parse_symbols(",".join(sys.argv[1:])) or ["^SPX", "^DJI", "^NDX"]
-    ticker = StockTicker(requested)
+    ticker = StockTicker(requested, api_key=os.environ.get("PULSE_TICKER_API_KEY"))
     for quote in ticker.fetch():
         print(quote.as_dict())
     print(f"market_hours={is_us_market_hours()}")

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -215,6 +215,31 @@ class OverlayRenderTests(unittest.TestCase):
         assert alarm_card is not None
         self.assertIn("alarms", alarm_card)
 
+    def test_set_ticker_bumps_only_on_symbol_change(self) -> None:
+        manager = OverlayStateManager()
+        v0 = manager.snapshot().version
+
+        def q(symbol, price):
+            return {"symbol": symbol, "label": symbol, "price": price, "change": 0.0, "change_pct": 0.0, "is_up": True}
+
+        # First population -> bump (so the card refetches and the bar appears).
+        c1 = manager.set_ticker([q("^SPX", 1.0)])
+        self.assertTrue(c1.changed)
+        v1 = manager.snapshot().version
+        self.assertGreater(v1, v0)
+
+        # Same symbols, new prices -> NO bump (avoids reloading the overlay every poll)...
+        c2 = manager.set_ticker([q("^SPX", 2.0)])
+        self.assertFalse(c2.changed)
+        self.assertEqual(manager.snapshot().version, v1)
+        # ...but the data is still updated for the next natural refresh.
+        self.assertEqual(manager.snapshot().ticker[0]["price"], 2.0)
+
+        # Symbol set changes -> bump again.
+        c3 = manager.set_ticker([q("^SPX", 2.0), q("AAPL", 3.0)])
+        self.assertTrue(c3.changed)
+        self.assertGreater(manager.snapshot().version, v1)
+
     def test_active_timer_card_uses_previous_position(self) -> None:
         snapshot = self._snapshot(
             timers=(),

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -58,6 +58,42 @@ class OverlayRenderTests(unittest.TestCase):
         self.assertIn('data-cell="bottom-left"', html)
         self.assertIn("Local", html)
 
+    def test_ticker_rendered_when_enabled(self) -> None:
+        theme = OverlayTheme(
+            ambient_background="rgba(0,0,0,0.32)",
+            alert_background="rgba(0,0,0,0.65)",
+            text_color="#FFFFFF",
+            accent_color="#88C0D0",
+            show_notification_bar=True,
+            show_ticker=True,
+        )
+        ticker = (
+            {
+                "symbol": "^SPX",
+                "label": "S&P 500",
+                "price": 7736.61,
+                "change": 13.06,
+                "change_pct": 12.5,  # outsized move -> emoji accent
+                "is_up": True,
+                "market_state": "POST",
+                "after_hours": 7740.0,
+            },
+        )
+        html = render_overlay_html(self._snapshot(ticker=ticker), theme)
+        self.assertIn('class="pulse-ticker"', html)
+        self.assertIn("overlay-root--ticker", html)
+        self.assertIn("data-ticker-track", html)
+        self.assertIn("S&amp;P 500", html)
+        self.assertIn("🚀", html)  # >= +10%
+        self.assertIn("AH 7,740.00", html)
+
+    def test_ticker_absent_when_disabled(self) -> None:
+        ticker = (
+            {"symbol": "^SPX", "label": "S&P 500", "price": 1.0, "change": 0.0, "change_pct": 0.0, "is_up": True},
+        )
+        html = render_overlay_html(self._snapshot(ticker=ticker), self.theme)  # theme.show_ticker defaults False
+        self.assertNotIn('class="pulse-ticker"', html)
+
     def test_only_first_clock_used_if_multiple_provided(self) -> None:
         # Even if multiple clocks are provided, only the first one is rendered
         clocks = (

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -87,6 +87,32 @@ class OverlayRenderTests(unittest.TestCase):
         self.assertIn("🚀", html)  # >= +10%
         self.assertIn("AH 7,740.00", html)
 
+    def test_ticker_label_mode_ticker_shows_symbol(self) -> None:
+        theme = OverlayTheme(
+            ambient_background="rgba(0,0,0,0.32)",
+            alert_background="rgba(0,0,0,0.65)",
+            text_color="#FFFFFF",
+            accent_color="#88C0D0",
+            show_ticker=True,
+            ticker_label_mode="ticker",
+        )
+        ticker = (
+            {"symbol": "^SPX", "label": "S&P 500", "price": 1.0, "change": 0.0, "change_pct": 0.0, "is_up": True},
+            {
+                "symbol": "VTI",
+                "label": "Vanguard Morningstar Total Stoc",
+                "price": 380.0,
+                "change": 0.6,
+                "change_pct": 0.16,
+                "is_up": True,
+            },
+        )
+        html = render_overlay_html(self._snapshot(ticker=ticker), theme)
+        self.assertIn(">SPX<", html)  # caret stripped
+        self.assertIn(">VTI<", html)  # symbol, not the long fund name
+        self.assertNotIn("Vanguard Morningstar", html)
+        self.assertNotIn("S&amp;P 500", html)
+
     def test_ticker_absent_when_disabled(self) -> None:
         ticker = (
             {"symbol": "^SPX", "label": "S&P 500", "price": 1.0, "change": 0.0, "change_pct": 0.0, "is_up": True},

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -113,6 +113,31 @@ class OverlayRenderTests(unittest.TestCase):
         self.assertNotIn("Vanguard Morningstar", html)
         self.assertNotIn("S&amp;P 500", html)
 
+    def test_ticker_label_mode_auto_names_indices_symbols_others(self) -> None:
+        theme = OverlayTheme(
+            ambient_background="rgba(0,0,0,0.32)",
+            alert_background="rgba(0,0,0,0.65)",
+            text_color="#FFFFFF",
+            accent_color="#88C0D0",
+            show_ticker=True,
+            ticker_label_mode="auto",
+        )
+        ticker = (
+            {"symbol": "^SPX", "label": "S&P 500", "price": 1.0, "change": 0.0, "change_pct": 0.0, "is_up": True},
+            {
+                "symbol": "VTI",
+                "label": "Vanguard Morningstar Total Stoc",
+                "price": 380.0,
+                "change": 0.6,
+                "change_pct": 0.16,
+                "is_up": True,
+            },
+        )
+        html = render_overlay_html(self._snapshot(ticker=ticker), theme)
+        self.assertIn("S&amp;P 500", html)  # index -> friendly name
+        self.assertIn(">VTI<", html)  # custom ticker -> symbol
+        self.assertNotIn("Vanguard Morningstar", html)
+
     def test_ticker_absent_when_disabled(self) -> None:
         ticker = (
             {"symbol": "^SPX", "label": "S&P 500", "price": 1.0, "change": 0.0, "change_pct": 0.0, "is_up": True},

--- a/tests/test_stock_ticker.py
+++ b/tests/test_stock_ticker.py
@@ -1,0 +1,202 @@
+"""Tests for pulse.stock_ticker (quote fetch, fallback chain, and cache guarantees)."""
+
+from __future__ import annotations
+
+import httpx
+import pulse.stock_ticker as st
+import pytest
+
+
+class _Router:
+    """A stateful httpx.MockTransport handler routing Yahoo endpoints for tests.
+
+    Toggle the flags between fetches to simulate provider outages and partial responses.
+    """
+
+    def __init__(self) -> None:
+        self.crumb_ok = True
+        self.quote_status = 200
+        self.quote_symbols = {"^GSPC", "AAPL"}  # which symbols v7 returns
+        self.chart_ok = True
+        self.market_state = "REGULAR"
+        self.post_price: float | None = None
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if "getcrumb" in url:
+            return httpx.Response(200 if self.crumb_ok else 500, text="CRUMB" if self.crumb_ok else "")
+        if "fc.yahoo.com" in url:
+            return httpx.Response(200, text="ok")
+        if "v7/finance/quote" in url:
+            if self.quote_status != 200:
+                return httpx.Response(self.quote_status, json={})
+            catalog = {
+                "^GSPC": {
+                    "symbol": "^GSPC",
+                    "shortName": "S&P 500",
+                    "regularMarketPrice": 100.0,
+                    "regularMarketChange": 1.5,
+                    "regularMarketChangePercent": 1.5,
+                    "marketState": self.market_state,
+                },
+                "AAPL": {
+                    "symbol": "AAPL",
+                    "shortName": "Apple Inc.",
+                    "regularMarketPrice": 200.0,
+                    "regularMarketChange": -2.0,
+                    "regularMarketChangePercent": -1.0,
+                    "marketState": self.market_state,
+                },
+            }
+            if self.post_price is not None:
+                catalog["AAPL"]["postMarketPrice"] = self.post_price
+            result = [catalog[s] for s in self.quote_symbols if s in catalog]
+            return httpx.Response(200, json={"quoteResponse": {"result": result}})
+        if "v8/finance/chart/" in url:
+            if not self.chart_ok:
+                return httpx.Response(500, json={})
+            symbol = url.split("/chart/")[1].split("?")[0]
+            return httpx.Response(
+                200,
+                json={
+                    "chart": {
+                        "result": [
+                            {
+                                "meta": {
+                                    "symbol": symbol,
+                                    "shortName": symbol,
+                                    "regularMarketPrice": 50.0,
+                                    "chartPreviousClose": 49.0,
+                                }
+                            }
+                        ]
+                    }
+                },
+            )
+        return httpx.Response(404)
+
+
+@pytest.fixture
+def router(monkeypatch) -> _Router:
+    r = _Router()
+    real_client = httpx.Client  # capture before patching to avoid self-recursion
+    monkeypatch.setattr(st.httpx, "Client", lambda *a, **k: real_client(transport=httpx.MockTransport(r)))
+    return r
+
+
+def _ticker(symbols=("^SPX", "AAPL"), **kwargs) -> st.StockTicker:
+    return st.StockTicker(list(symbols), **kwargs)
+
+
+class TestParseSymbols:
+    def test_parses_and_dedupes_and_uppercases(self):
+        assert st.parse_symbols("^spx, aapl ; msft,AAPL") == ["^SPX", "AAPL", "MSFT"]
+
+    def test_empty(self):
+        assert st.parse_symbols("") == []
+        assert st.parse_symbols(None) == []
+
+
+class TestFetch:
+    def test_v7_primary_success(self, router):
+        ticker = _ticker()
+        quotes = ticker.fetch()
+        by_symbol = {q.symbol: q for q in quotes}
+        assert set(by_symbol) == {"^SPX", "AAPL"}
+        assert by_symbol["^SPX"].label == "S&P 500"  # friendly label, not ^GSPC
+        assert by_symbol["^SPX"].price == 100.0 and by_symbol["^SPX"].is_up is True
+        assert by_symbol["AAPL"].is_up is False
+        ticker.close()
+
+    def test_v7_401_triggers_crumb_refresh_and_retry(self, router):
+        ticker = _ticker()
+        calls = {"n": 0}
+        real = ticker._yahoo_quote_request
+
+        def flaky(client, crumb):  # 401 on first attempt, real data on retry
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return None
+            return real(client, crumb)
+
+        ticker._yahoo_quote_request = flaky  # type: ignore[method-assign]
+        quotes = ticker.fetch()
+        assert calls["n"] == 2 and len(quotes) == 2
+        ticker.close()
+
+    def test_falls_back_to_v8_chart_when_v7_unavailable(self, router):
+        router.crumb_ok = False  # no crumb -> v7 skipped entirely
+        ticker = _ticker()
+        quotes = ticker.fetch()
+        assert {q.symbol for q in quotes} == {"^SPX", "AAPL"}
+        # v8 chart values (price 50 vs prev close 49), no marketState
+        assert all(q.price == 50.0 and q.market_state == "" for q in quotes)
+        ticker.close()
+
+    def test_all_providers_fail_returns_last_good_cache(self, router):
+        ticker = _ticker()
+        first = ticker.fetch()
+        assert len(first) == 2
+        router.crumb_ok = False
+        router.chart_ok = False  # both Yahoo paths dead
+        cached = ticker.fetch()
+        assert [q.symbol for q in cached] == [q.symbol for q in first]
+        assert [q.price for q in cached] == [q.price for q in first]
+        ticker.close()
+
+    def test_partial_fetch_keeps_missing_symbol_from_cache(self, router):
+        ticker = _ticker()
+        ticker.fetch()  # prime both symbols
+        # Now v7 returns only ^GSPC, and v8 chart is down, so AAPL is absent this round.
+        router.quote_symbols = {"^GSPC"}
+        router.chart_ok = False
+        quotes = ticker.fetch()
+        by_symbol = {q.symbol: q for q in quotes}
+        assert set(by_symbol) == {"^SPX", "AAPL"}  # AAPL retained from cache
+        assert by_symbol["AAPL"].price == 200.0
+        ticker.close()
+
+    def test_afterhours_price_when_post_market(self, router):
+        router.market_state = "POST"
+        router.post_price = 205.0
+        ticker = _ticker(afterhours=True)
+        by_symbol = {q.symbol: q for q in ticker.fetch()}
+        assert by_symbol["AAPL"].after_hours == 205.0
+        assert by_symbol["AAPL"].as_dict()["after_hours"] == 205.0
+        ticker.close()
+
+    def test_afterhours_suppressed_when_disabled(self, router):
+        router.market_state = "POST"
+        router.post_price = 205.0
+        ticker = _ticker(afterhours=False)
+        by_symbol = {q.symbol: q for q in ticker.fetch()}
+        assert by_symbol["AAPL"].after_hours is None
+        ticker.close()
+
+    def test_no_symbols_returns_empty(self, router):
+        ticker = _ticker(symbols=())
+        assert ticker.fetch() == []
+        ticker.close()
+
+
+class TestMarketHours:
+    def test_weekend_is_closed(self):
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        saturday = datetime(2026, 8, 8, 12, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert st.is_us_market_hours(saturday) is False
+
+    def test_weekday_midday_is_open(self):
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        wednesday = datetime(2026, 8, 5, 11, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert st.is_us_market_hours(wednesday) is True
+
+    def test_weekday_evening_is_closed(self):
+        from datetime import datetime
+        from zoneinfo import ZoneInfo
+
+        wednesday_evening = datetime(2026, 8, 5, 20, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert st.is_us_market_hours(wednesday_evening) is False

--- a/tests/test_stock_ticker.py
+++ b/tests/test_stock_ticker.py
@@ -20,11 +20,19 @@ class _Router:
         self.chart_ok = True
         self.market_state = "REGULAR"
         self.post_price: float | None = None
+        self.finnhub_status = 200
+        self.finnhub_prices: dict[str, dict] = {}  # symbol -> {"c","d","dp"}
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         # Route on the parsed host/path rather than substring-matching the whole URL.
         host = request.url.host
         path = request.url.path
+        if host == "finnhub.io":
+            if self.finnhub_status != 200:
+                return httpx.Response(self.finnhub_status, json={})
+            symbol = request.url.params.get("symbol", "")
+            data = self.finnhub_prices.get(symbol, {"c": 0, "d": None, "dp": None})
+            return httpx.Response(200, json=data)
         if path.endswith("/v1/test/getcrumb"):
             return httpx.Response(200 if self.crumb_ok else 500, text="CRUMB" if self.crumb_ok else "")
         if host == "fc.yahoo.com":
@@ -115,11 +123,11 @@ class TestFetch:
         calls = {"n": 0}
         real = ticker._yahoo_quote_request
 
-        def flaky(client, crumb):  # 401 on first attempt, real data on retry
+        def flaky(client, crumb, symbols):  # 401 on first attempt, real data on retry
             calls["n"] += 1
             if calls["n"] == 1:
                 return None
-            return real(client, crumb)
+            return real(client, crumb, symbols)
 
         ticker._yahoo_quote_request = flaky  # type: ignore[method-assign]
         quotes = ticker.fetch()
@@ -178,6 +186,32 @@ class TestFetch:
     def test_no_symbols_returns_empty(self, router):
         ticker = _ticker(symbols=())
         assert ticker.fetch() == []
+        ticker.close()
+
+
+class TestFinnhubProvider:
+    def test_finnhub_prices_equities_yahoo_fills_indices(self, router):
+        # Finnhub covers AAPL; it can't price the ^SPX index, which falls through to Yahoo.
+        router.finnhub_prices = {"AAPL": {"c": 210.0, "d": 5.0, "dp": 2.44}}
+        ticker = _ticker(symbols=("^SPX", "AAPL"), api_key="KEY")
+        by_symbol = {q.symbol: q for q in ticker.fetch()}
+        assert by_symbol["AAPL"].price == 210.0  # from Finnhub
+        assert by_symbol["^SPX"].price == 100.0  # index from Yahoo v7
+        ticker.close()
+
+    def test_finnhub_bad_key_falls_back_to_yahoo(self, router):
+        router.finnhub_status = 401
+        ticker = _ticker(symbols=("AAPL",), api_key="BADKEY")
+        by_symbol = {q.symbol: q for q in ticker.fetch()}
+        assert by_symbol["AAPL"].price == 200.0  # Yahoo v7
+        ticker.close()
+
+    def test_no_key_skips_finnhub_entirely(self, router):
+        # Even with a Finnhub price available, no key => provider not consulted.
+        router.finnhub_prices = {"AAPL": {"c": 999.0, "d": 1.0, "dp": 1.0}}
+        ticker = _ticker(symbols=("AAPL",))  # no api_key
+        by_symbol = {q.symbol: q for q in ticker.fetch()}
+        assert by_symbol["AAPL"].price == 200.0  # Yahoo, not the Finnhub 999
         ticker.close()
 
 

--- a/tests/test_stock_ticker.py
+++ b/tests/test_stock_ticker.py
@@ -22,12 +22,14 @@ class _Router:
         self.post_price: float | None = None
         self.finnhub_status = 200
         self.finnhub_prices: dict[str, dict] = {}  # symbol -> {"c","d","dp"}
+        self.finnhub_requests: list[httpx.Request] = []
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         # Route on the parsed host/path rather than substring-matching the whole URL.
         host = request.url.host
         path = request.url.path
         if host == "finnhub.io":
+            self.finnhub_requests.append(request)
             if self.finnhub_status != 200:
                 return httpx.Response(self.finnhub_status, json={})
             symbol = request.url.params.get("symbol", "")
@@ -212,6 +214,18 @@ class TestFinnhubProvider:
         ticker = _ticker(symbols=("AAPL",))  # no api_key
         by_symbol = {q.symbol: q for q in ticker.fetch()}
         assert by_symbol["AAPL"].price == 200.0  # Yahoo, not the Finnhub 999
+        assert router.finnhub_requests == []
+        ticker.close()
+
+    def test_api_key_sent_as_header_not_in_url(self, router):
+        # The key must never appear in the query string (it can leak via error/log URLs).
+        router.finnhub_prices = {"AAPL": {"c": 210.0, "d": 5.0, "dp": 2.44}}
+        ticker = _ticker(symbols=("AAPL",), api_key="SECRETKEY")
+        ticker.fetch()
+        assert router.finnhub_requests, "expected a Finnhub request"
+        req = router.finnhub_requests[0]
+        assert "SECRETKEY" not in str(req.url)
+        assert req.headers.get("X-Finnhub-Token") == "SECRETKEY"
         ticker.close()
 
 

--- a/tests/test_stock_ticker.py
+++ b/tests/test_stock_ticker.py
@@ -22,12 +22,14 @@ class _Router:
         self.post_price: float | None = None
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
-        url = str(request.url)
-        if "getcrumb" in url:
+        # Route on the parsed host/path rather than substring-matching the whole URL.
+        host = request.url.host
+        path = request.url.path
+        if path.endswith("/v1/test/getcrumb"):
             return httpx.Response(200 if self.crumb_ok else 500, text="CRUMB" if self.crumb_ok else "")
-        if "fc.yahoo.com" in url:
+        if host == "fc.yahoo.com":
             return httpx.Response(200, text="ok")
-        if "v7/finance/quote" in url:
+        if path.endswith("/v7/finance/quote"):
             if self.quote_status != 200:
                 return httpx.Response(self.quote_status, json={})
             catalog = {
@@ -52,10 +54,10 @@ class _Router:
                 catalog["AAPL"]["postMarketPrice"] = self.post_price
             result = [catalog[s] for s in self.quote_symbols if s in catalog]
             return httpx.Response(200, json={"quoteResponse": {"result": result}})
-        if "v8/finance/chart/" in url:
+        if path.startswith("/v8/finance/chart/"):
             if not self.chart_ok:
                 return httpx.Response(500, json={})
-            symbol = url.split("/chart/")[1].split("?")[0]
+            symbol = path.rsplit("/chart/", 1)[1]
             return httpx.Response(
                 200,
                 json={


### PR DESCRIPTION
## What

Adds an **opt-in** scrolling ticker bar across the bottom of the overlay, showing the major indices (and any symbols the user configures) over whatever is on screen. Off by default; enabled per device via `PULSE_TICKER_ENABLED`. It sits as a translucent marquee pinned to the bottom of the overlay, over the HA dashboard.

## How it works

- **`pulse/stock_ticker.py`** — on-device quote fetcher with a real reliability chain:
  **Yahoo v7** (cookie+crumb, obtained/refreshed transparently — one request, gives change %, `marketState`, after-hours) → **Yahoo v8 chart** (no-auth, resilient if the crumb flow breaks) → **Stooq** CSV → **last-good cache** (never blanks). Works for global symbols (Nikkei/FTSE/DAX/Hang Seng + foreign tickers); a US market-hours check paces the poll cadence.
- **`overlay.py`** — `set_ticker()` deliberately does **not** bump the overlay version (avoids forcing an extra iframe reload/repaint every fetch); `show_ticker`/speed/emoji theme flags; a `_build_ticker_bar()` with green ▲ / red ▼ moves, after-hours `AH` price, and accent emoji for outsized moves (🚀 ≥ +10%, 🔥 ≥ +5%, 📉 ≤ -5%, 🧊 ≤ -10%).
- **`overlay.css` / `overlay.js`** — a bottom fixed marquee matching the overlay's opaque card styling. Because the photo-card reloads the overlay iframe (`srcdoc`) periodically, the scroll uses a **wall-clock animation phase + constant px/sec speed** so it resumes seamlessly across reloads instead of stuttering.
- **`kiosk-mqtt-listener.py`** — `PULSE_TICKER_*` config, a telemetry-style background fetch thread with adaptive cadence (fast during US hours, slow otherwise), and lifecycle wiring.

## Config

New keys in `pulse.conf.sample` (auto-sync to devices) and documented in `docs/config-reference.md`:
`PULSE_TICKER_ENABLED` (default `false`), `PULSE_TICKER_SYMBOLS` (default `^SPX,^DJI,^NDX`), `PULSE_TICKER_INTERVAL` (60s), `PULSE_TICKER_INTERVAL_CLOSED` (900s), `PULSE_TICKER_AFTERHOURS`, `PULSE_TICKER_SPEED`, `PULSE_TICKER_EMOJI`.

`docs/troubleshooting.md` gains a **Stock ticker** section noting the DNS/Pi-hole allowlist (`query1.finance.yahoo.com`, `fc.yahoo.com`, `stooq.com`).

## Testing

- Fetcher verified live against Yahoo, including forced v8-chart and last-good-cache fallbacks, and non-US indices/equities.
- Overlay renders the bar (markup, emoji thresholds, after-hours, duplicated track) in both `/overlay` and frame modes; disabled path renders nothing.
- `ruff` / `black` / `mypy` clean; existing overlay test suite (69 tests) passes.

**Fallback note:** Quotes come from two independent Yahoo endpoints (v7 quote → no-auth v8 chart) plus a last-good cache. Stooq was evaluated as a non-Yahoo source but now gates its CSV endpoints behind a JavaScript anti-bot challenge (unusable headless), so it was dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds periodic outbound quote fetches and changes overlay boot refresh ordering; impact is limited because the feature is disabled by default and failures fall back to cached quotes.
> 
> **Overview**
> Adds an **opt-in** bottom-of-overlay stock ticker (default off via `PULSE_TICKER_ENABLED`), with configurable symbols, scroll speed, label mode, emoji accents, after-hours display, and adaptive poll intervals for US market hours vs closed.
> 
> **Backend:** New `pulse/stock_ticker.py` fetches quotes on-device through Finnhub (when `PULSE_TICKER_API_KEY` is set) then Yahoo v7/v8, with a last-good cache so the bar does not go blank on upstream failures. `kiosk-mqtt-listener.py` runs a daemon fetch loop, maps `PULSE_TICKER_*` env config, and stores quotes via `OverlayStateManager.set_ticker()` — overlay version bumps (and MQTT refresh) only when the **symbol set** first appears or changes, not on every price tick. Boot sequencing now starts the overlay HTTP server **before** the boot refresh emit so the photo-card does not hit a dead port.
> 
> **UI:** Overlay HTML/CSS/JS render a fixed translucent marquee (green/red moves, optional AH and move emojis) with wall-clock animation phase so scrolling survives periodic iframe reloads.
> 
> Docs (`config-reference`, `troubleshooting`, `pulse.conf.sample`, README) and tests cover rendering, version-bump behavior, and the fetch fallback chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3a9d44d299790834bef104bab829d61f046c51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->