### PR TITLE
fix: back off bt-autoconnect when speaker is unreachable to protect snapcast

### DIFF
--- a/bin/bt-autoconnect.sh
+++ b/bin/bt-autoconnect.sh
@@ -65,8 +65,50 @@ if [ -z "$MAC" ]; then
   exit 0
 fi
 
-# Try to connect (harmless if already connected)
-bluetoothctl connect "$MAC" >/dev/null 2>&1 || true
+# Try to connect, but back off when the target speaker is unreachable.
+#
+# bt-autoconnect runs every ~15s. A `bluetoothctl connect` to a powered-off
+# classic-BT speaker blocks ~60s before failing "Host is down", and each attempt
+# grabs the shared 2.4GHz radio long enough (2-4s) to stall WiFi and break
+# snapcast time-sync on the room display. So: if the device is already
+# connected, skip the call; otherwise only retry on an exponential backoff
+# (PULSE_BT_MIN_BACKOFF doubling up to PULSE_BT_MAX_BACKOFF) — a briefly-off
+# speaker reconnects quickly, a long-gone one is retried rarely, and the display
+# is no longer collateral damage when the speaker is off.
+BT_MIN_BACKOFF="${PULSE_BT_MIN_BACKOFF:-15}"
+BT_MAX_BACKOFF="${PULSE_BT_MAX_BACKOFF:-300}"
+BT_BACKOFF_STATE="/run/user/$(id -u)/pulse-bt-backoff"  # "<next_attempt_epoch> <backoff_secs>"
+
+bt_is_connected() {
+  bluetoothctl info "$MAC" 2>/dev/null | grep -q "Connected: yes"
+}
+
+if bt_is_connected; then
+  # Already connected — clear any backoff state and carry on.
+  rm -f "$BT_BACKOFF_STATE" 2>/dev/null || true
+else
+  now=$(date +%s)
+  next_attempt=0
+  backoff="$BT_MIN_BACKOFF"
+  if [ -f "$BT_BACKOFF_STATE" ]; then
+    read -r next_attempt backoff < "$BT_BACKOFF_STATE" 2>/dev/null || true
+  fi
+  # Guard against an empty/garbled state file.
+  case "$next_attempt" in ''|*[!0-9]*) next_attempt=0 ;; esac
+  case "$backoff" in ''|*[!0-9]*) backoff="$BT_MIN_BACKOFF" ;; esac
+
+  if [ "$now" -ge "$next_attempt" ]; then
+    if bluetoothctl connect "$MAC" >/dev/null 2>&1 && bt_is_connected; then
+      rm -f "$BT_BACKOFF_STATE" 2>/dev/null || true
+    else
+      next_backoff=$(( backoff * 2 ))
+      if [ "$next_backoff" -gt "$BT_MAX_BACKOFF" ]; then
+        next_backoff="$BT_MAX_BACKOFF"
+      fi
+      echo "$(( now + backoff )) $next_backoff" > "$BT_BACKOFF_STATE" 2>/dev/null || true
+    fi
+  fi
+fi
 
 # Ensure we know our XDG_RUNTIME_DIR (needed for pactl/pw-cli)
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
@@ -124,4 +166,3 @@ if [ -n "$SINK" ] && pactl list sinks short | grep -q "$SINK"; then
     fi
   fi
 fi
-

--- a/bin/bt-autoconnect.sh
+++ b/bin/bt-autoconnect.sh
@@ -105,7 +105,10 @@ else
       if [ "$next_backoff" -gt "$BT_MAX_BACKOFF" ]; then
         next_backoff="$BT_MAX_BACKOFF"
       fi
-      echo "$(( now + backoff )) $next_backoff" > "$BT_BACKOFF_STATE" 2>/dev/null || true
+      # Schedule the next attempt relative to a *fresh* timestamp: the connect
+      # above can block ~60s on a powered-off speaker, so reusing the pre-connect
+      # "now" would put next_attempt in the past and defeat short backoffs.
+      echo "$(( $(date +%s) + backoff )) $next_backoff" > "$BT_BACKOFF_STATE" 2>/dev/null || true
     fi
   fi
 fi


### PR DESCRIPTION
## Problem

`bt-autoconnect.timer` fires every ~15s and `bt-autoconnect.sh` unconditionally ran `bluetoothctl connect` on the configured speaker (`PULSE_BT_MAC`, or the first paired device). When that speaker is **powered off**, each connect blocks ~60s before failing `avdtp_connect_cb() ... Host is down (112)`, and each attempt grabs the shared 2.4 GHz radio long enough (2-4s) to stall WiFi — which blows snapcast's time-sync timeout and drops the room display into a continuous `Time sync request failed` reconnect loop.

Observed live: kitchen was looping ~1–2 fails/min for as long as its BT speaker stayed off (~30k errors/week class). This is a **separate** starvation path from the HFP retries fixed in #216 — this one is A2DP connect attempts driven by our own autoconnect timer.

## Fix

In `bt-autoconnect.sh`, gate the connect:
- If the device is already connected, skip the call entirely.
- Otherwise retry on an exponential backoff — `PULSE_BT_MIN_BACKOFF` (default 15s) doubling up to `PULSE_BT_MAX_BACKOFF` (default 300s), tracked in `/run/user/$UID/pulse-bt-backoff`.

A briefly-off speaker still reconnects within seconds; a long-gone one settles to one attempt every 5 min, so the display is no longer collateral damage. Both bounds are tunable via env/`pulse.conf`. State is cleared on successful connect.

## Test / rollout

- Deployed to `pulse-kitchen` and `pulse-great-room`; verified backoff state file advances and the per-minute `Host is down` / snapclient time-sync failure rate collapses once the speaker stays off.
- No change to behavior when the speaker is present/connected (A2DP music path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Operational change to reconnect timing only; connected-speaker path and audio sink handling are unchanged.
> 
> **Overview**
> **`bt-autoconnect.sh` no longer calls `bluetoothctl connect` on every ~15s timer tick.** When the target MAC is already connected, the connect step is skipped and any backoff state is cleared.
> 
> When disconnected, connect attempts are gated by **exponential backoff** (defaults **15s → 300s**, overridable via `PULSE_BT_MIN_BACKOFF` / `PULSE_BT_MAX_BACKOFF`), persisted in `/run/user/$UID/pulse-bt-backoff`. Failed connects double the interval (capped); success clears state. The next retry time is computed **after** a connect attempt so a ~60s block on a powered-off speaker does not schedule immediate retries.
> 
> This limits repeated A2DP connect storms that were stalling WiFi and breaking snapcast time-sync when the BT speaker stays off. Sink setup, boot sound, and keepalive logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57842bb7a63c07e830fefffa148e17fdcd3c1ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->