### PR TITLE
feat(ticker): mark quotes that have gone stale or are exchange-delayed

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1346,3 +1346,11 @@ body {
 .pulse-ticker__emoji {
   font-size: 1.05em;
 }
+
+/* Freshness markers — absent entirely on a healthy bar, so they read as an exception
+   rather than chrome. Muted on purpose: they qualify the price, they aren't the point. */
+.pulse-ticker__delay,
+.pulse-ticker__stale {
+  opacity: 0.55;
+  font-size: 0.78em;
+}

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -37,6 +37,7 @@ from pulse.overlay_server import OverlayHttpServer, OverlayServerConfig
 from pulse.stock_ticker import (
     TICKER_HOURS_MODES,
     StockTicker,
+    annotate_staleness,
     parse_symbols,
     ticker_visible,
     us_market_phase,
@@ -108,6 +109,7 @@ class OverlayConfig:
     ticker_emoji: bool
     ticker_label_mode: str
     ticker_api_key: str | None
+    ticker_stale_after: int  # seconds before a quote is marked stale (0 disables)
 
 
 @dataclass(frozen=True)
@@ -483,6 +485,7 @@ def load_config() -> EnvConfig:
         ticker_emoji=parse_bool(os.environ.get("PULSE_TICKER_EMOJI"), True),
         ticker_label_mode=ticker_label_mode,
         ticker_api_key=(os.environ.get("PULSE_TICKER_API_KEY") or "").strip() or None,
+        ticker_stale_after=max(0, parse_int(os.environ.get("PULSE_TICKER_STALE_AFTER"), 300)),
     )
 
     version_source_url = os.environ.get("PULSE_VERSION_SOURCE_URL", DEFAULT_VERSION_SOURCE_URL)
@@ -882,6 +885,14 @@ class KioskMqttListener:
                     # inside StockTicker keeps last-good quotes warm, so the bar repopulates
                     # the instant it becomes visible again.
                     phase = us_market_phase(payload)
+                    # Mark quotes the cache has been carrying for too long, so a provider
+                    # that has quietly stopped answering shows up on the bar instead of
+                    # looking like a market that stopped moving.
+                    annotate_staleness(
+                        payload,
+                        stale_after=self.overlay_config.ticker_stale_after,
+                        phase=phase,
+                    )
                     visible = ticker_visible(mode, phase)
                     change = state.set_ticker(payload if visible else [])
                     # set_ticker bumps the version only when the symbol set changes — the bar

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -84,8 +84,20 @@ other symbols show their Yahoo short name.
 | `PULSE_TICKER_EMOJI` | `true` | Add an accent emoji for outsized moves (🚀 ≥ +10%, 🔥 ≥ +5%, 📉 ≤ -5%, 🧊 ≤ -10%). |
 | `PULSE_TICKER_LABEL` | `auto` | Label before each price: `auto` (friendly name for indices like "S&P 500", ticker symbol for everything else — avoids long/truncated ETF names), `name` (friendly name for all), or `ticker` (symbol for all). |
 | `PULSE_TICKER_API_KEY` | _(unset)_ | Optional free [Finnhub](https://finnhub.io) API key. When set, Finnhub is the preferred (licensed) source for symbols it can price; Yahoo covers the rest. |
+| `PULSE_TICKER_STALE_AFTER` | `300` | Seconds before a quote is marked stale with a `⏱`. Set `0` to disable the marker. Only evaluated during the regular session (see notes). |
 
 Notes:
+- **Freshness markers.** The bar never goes blank — a symbol its provider fails to price
+  keeps its last-good value — so a quote that has gone cold is marked rather than shown as
+  if it were current. Two markers, both muted and both absent on a healthy bar:
+  - `⏱` — the price is older than `PULSE_TICKER_STALE_AFTER`. Checked **only during the
+    regular session**; outside it every quote is legitimately hours old (both providers
+    stamp the last regular trade), so flagging then would mark the whole bar and mean
+    nothing.
+  - `15m` — the exchange itself reports the feed as delayed by that many minutes (Yahoo's
+    `exchangeDataDelayedBy`). Shown whenever non-zero, and it takes precedence over `⏱`
+    since it's the more specific statement. Finnhub's `/quote` has no delay field, so
+    Finnhub-priced symbols never show this one.
 - Gains render green with a ▲, losses red with a ▼; the bar matches the overlay's
   translucent card styling and is pinned to the bottom over whatever is on screen.
 - The fast/slow fetch cadence is keyed to US regular-session hours (holidays are not

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -163,6 +163,13 @@ PULSE_TICKER_LABEL="auto"
 # rest. Leave empty to use Yahoo only.
 # PULSE_TICKER_API_KEY=""
 
+# PULSE_TICKER_STALE_AFTER — seconds before a quote is marked with a "⏱" because its
+# price has gone cold. The bar never blanks (a symbol keeps its last-good value when its
+# provider fails), so without this a dead feed looks like a market that stopped moving.
+# Only checked during the regular session — outside it every quote is legitimately hours
+# old. Set "0" to turn the marker off.
+PULSE_TICKER_STALE_AFTER="300"
+
 # ============================================================================
 # Telemetry & MQTT
 # ============================================================================

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -680,12 +680,21 @@ def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
         after_hours = quote.get("after_hours")
         if after_hours is not None:
             after_hours_markup = f'<span class="pulse-ticker__ah">AH {_format_ticker_number(after_hours)}</span>'
+        # Freshness marker. Invisible on a healthy bar: an explicit exchange delay wins
+        # (it's a property of the feed), otherwise a clock appears only once the quote has
+        # gone cold — see stock_ticker.annotate_staleness for when that's evaluated.
+        freshness_markup = ""
+        delayed_by = _ticker_float(quote.get("delayed_by"))
+        if delayed_by is not None and delayed_by > 0:
+            freshness_markup = f'<span class="pulse-ticker__delay">{int(delayed_by)}m</span>'
+        elif quote.get("is_stale"):
+            freshness_markup = '<span class="pulse-ticker__stale">⏱</span>'
         items.append(
             f'<span class="pulse-ticker__item pulse-ticker__item--{direction}">'
             f'<span class="pulse-ticker__label">{label}</span>'
             f'<span class="pulse-ticker__price">{_format_ticker_number(price)}</span>'
             f'<span class="pulse-ticker__change">{change_text}</span>'
-            f"{after_hours_markup}{emoji_markup}"
+            f"{after_hours_markup}{freshness_markup}{emoji_markup}"
             f"</span>"
         )
     if not items:

--- a/pulse/stock_ticker.py
+++ b/pulse/stock_ticker.py
@@ -14,7 +14,9 @@ Provider chain (per symbol, first source that answers wins for that symbol):
 - Yahoo v8 chart, one request per symbol, needs no auth so it survives crumb-flow
   breakage (price vs. previous close; no marketState/after-hours).
 - Last resort: the most recent successfully-fetched values, so the ticker never goes
-  blank when the providers hiccup.
+  blank when the providers hiccup. Because that cache can quietly serve an old price
+  indefinitely, every quote carries the provider's own timestamp (`quote_time`) and
+  annotate_staleness() flags the ones that have gone cold, so the overlay can say so.
 
 Data-source note: the Yahoo endpoints are unofficial/undocumented (Yahoo has no free
 public API) and are used here the same way the yfinance library does — appropriate for
@@ -31,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
@@ -217,6 +220,8 @@ class TickerQuote:
     is_up: bool
     after_hours: float | None = None  # post-market price, when available
     market_state: str = ""  # REGULAR / PRE / POST / CLOSED / DELAYED / ...
+    quote_time: int | None = None  # unix seconds the provider stamped on the price
+    delayed_by: int = 0  # minutes the exchange says this feed is delayed (0 = real-time)
 
     def as_dict(self) -> dict[str, object]:
         payload: dict[str, object] = {
@@ -230,7 +235,42 @@ class TickerQuote:
         }
         if self.after_hours is not None:
             payload["after_hours"] = round(self.after_hours, 2)
+        if self.quote_time is not None:
+            payload["quote_time"] = self.quote_time
+        if self.delayed_by > 0:
+            payload["delayed_by"] = self.delayed_by
         return payload
+
+
+def annotate_staleness(
+    quotes: list[dict[str, object]],
+    *,
+    stale_after: int,
+    phase: str,
+    now: float | None = None,
+) -> list[dict[str, object]]:
+    """Flag quotes whose price is older than `stale_after` seconds, in place.
+
+    Exists because fetch() merges each round over a last-good cache so the bar never goes
+    blank — which means a symbol whose provider has been failing for an hour keeps showing
+    an hour-old price with no visual cue. This adds `is_stale: True` so the overlay can
+    mark it.
+
+    Only evaluated during the **regular** session. Outside it every quote is legitimately
+    old (Finnhub's free /quote and Yahoo's regularMarketTime both stamp the last regular
+    trade), so flagging then would light up the whole bar and mean nothing. `stale_after`
+    of 0 disables the check entirely.
+    """
+    if stale_after <= 0 or phase != "regular":
+        return quotes
+    current = now if now is not None else time.time()
+    for quote in quotes:
+        stamped = _coerce_float(quote.get("quote_time"))
+        if stamped is None or stamped <= 0:
+            continue
+        if current - stamped > stale_after:
+            quote["is_stale"] = True
+    return quotes
 
 
 def parse_symbols(spec: str | None) -> list[str]:
@@ -416,6 +456,9 @@ class StockTicker:
                     change=change,
                     change_pct=pct,
                     is_up=change >= 0,
+                    # `t` is the trade timestamp; free-tier US equities stamp within seconds
+                    # during the session, so it doubles as the staleness clock.
+                    quote_time=_coerce_int(data.get("t")),
                 )
             )
         return quotes or None
@@ -464,6 +507,11 @@ class StockTicker:
                         is_up=float(change) >= 0,
                         after_hours=after_hours,
                         market_state=market_state,
+                        quote_time=_coerce_int(item.get("regularMarketTime")),
+                        # Yahoo reports the exchange's own delay in minutes (0 = real-time).
+                        # Distinct from sourceInterval, which is the source's refresh period
+                        # (e.g. 120s for ^DJI) and says nothing about how delayed it is.
+                        delayed_by=max(0, _coerce_int(item.get("exchangeDataDelayedBy")) or 0),
                     )
                 )
             except (TypeError, ValueError):
@@ -506,6 +554,7 @@ class StockTicker:
                     change=change,
                     change_pct=change / prev_close * 100.0,
                     is_up=change >= 0,
+                    quote_time=_coerce_int(meta.get("regularMarketTime")),
                 )
             )
         return quotes or None
@@ -532,6 +581,11 @@ def _coerce_float(value: object) -> float | None:
     except (TypeError, ValueError):
         return None
     return result
+
+
+def _coerce_int(value: object) -> int | None:
+    result = _coerce_float(value)
+    return int(result) if result is not None else None
 
 
 def _redact(message: str, secret: str | None) -> str:

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -87,6 +87,56 @@ class OverlayRenderTests(unittest.TestCase):
         self.assertIn("🚀", html)  # >= +10%
         self.assertIn("AH 7,740.00", html)
 
+    def _ticker_theme(self) -> OverlayTheme:
+        return OverlayTheme(
+            ambient_background="rgba(0,0,0,0.32)",
+            alert_background="rgba(0,0,0,0.65)",
+            text_color="#FFFFFF",
+            accent_color="#88C0D0",
+            show_notification_bar=True,
+            show_ticker=True,
+        )
+
+    def _quote(self, **overrides) -> dict:
+        quote = {
+            "symbol": "VOO",
+            "label": "VOO",
+            "price": 710.39,
+            "change": -0.32,
+            "change_pct": -0.04,
+            "is_up": False,
+        }
+        quote.update(overrides)
+        return quote
+
+    # The class names also appear in the inlined stylesheet, so these assert on the
+    # rendered markup rather than the bare class string.
+    _STALE_MARKUP = '<span class="pulse-ticker__stale">'
+    _DELAY_MARKUP = '<span class="pulse-ticker__delay">'
+
+    def test_healthy_quote_shows_no_freshness_marker(self) -> None:
+        html = render_overlay_html(self._snapshot(ticker=(self._quote(),)), self._ticker_theme())
+        self.assertNotIn(self._STALE_MARKUP, html)
+        self.assertNotIn(self._DELAY_MARKUP, html)
+
+    def test_stale_quote_marked(self) -> None:
+        ticker = (self._quote(is_stale=True),)
+        html = render_overlay_html(self._snapshot(ticker=ticker), self._ticker_theme())
+        self.assertIn(f"{self._STALE_MARKUP}⏱</span>", html)
+
+    def test_delayed_feed_shows_minutes(self) -> None:
+        ticker = (self._quote(delayed_by=15),)
+        html = render_overlay_html(self._snapshot(ticker=ticker), self._ticker_theme())
+        self.assertIn(f"{self._DELAY_MARKUP}15m</span>", html)
+
+    def test_explicit_delay_wins_over_stale(self) -> None:
+        # A known exchange delay is the more specific statement, so it should be the one
+        # rendered rather than stacking two markers on one quote.
+        ticker = (self._quote(delayed_by=15, is_stale=True),)
+        html = render_overlay_html(self._snapshot(ticker=ticker), self._ticker_theme())
+        self.assertIn(f"{self._DELAY_MARKUP}15m</span>", html)
+        self.assertNotIn(self._STALE_MARKUP, html)
+
     def test_ticker_label_mode_ticker_shows_symbol(self) -> None:
         theme = OverlayTheme(
             ambient_background="rgba(0,0,0,0.32)",

--- a/tests/test_stock_ticker.py
+++ b/tests/test_stock_ticker.py
@@ -26,6 +26,8 @@ class _Router:
         self.finnhub_status = 200
         self.finnhub_prices: dict[str, dict] = {}  # symbol -> {"c","d","dp"}
         self.finnhub_requests: list[httpx.Request] = []
+        self.quote_time = 1_700_000_000  # what Yahoo stamps as regularMarketTime
+        self.delayed_by = 0  # Yahoo exchangeDataDelayedBy, in minutes
 
     def __call__(self, request: httpx.Request) -> httpx.Response:
         # Route on the parsed host/path rather than substring-matching the whole URL.
@@ -65,6 +67,9 @@ class _Router:
             }
             if self.post_price is not None:
                 catalog["AAPL"]["postMarketPrice"] = self.post_price
+            for entry in catalog.values():
+                entry["regularMarketTime"] = self.quote_time
+                entry["exchangeDataDelayedBy"] = self.delayed_by
             result = [catalog[s] for s in self.quote_symbols if s in catalog]
             return httpx.Response(200, json={"quoteResponse": {"result": result}})
         if path.startswith("/v8/finance/chart/"):
@@ -82,6 +87,7 @@ class _Router:
                                     "shortName": symbol,
                                     "regularMarketPrice": 50.0,
                                     "chartPreviousClose": 49.0,
+                                    "regularMarketTime": self.quote_time,
                                 }
                             }
                         ]
@@ -325,3 +331,91 @@ class TestMarketPhaseAndVisibility:
         for phase in ("pre", "regular", "post"):
             assert st.ticker_visible("extended", phase) is True
         assert st.ticker_visible("extended", "closed") is False
+
+
+class TestQuoteFreshness:
+    """Provider timestamps land on the quote, and go stale only when they should."""
+
+    NOW = 1_700_000_000.0
+
+    def _q(self, age_seconds):
+        return {"symbol": "AAPL", "quote_time": self.NOW - age_seconds}
+
+    # -- annotate_staleness ---------------------------------------------------
+
+    def test_old_quote_flagged_during_regular_session(self):
+        quotes = [self._q(600)]
+        st.annotate_staleness(quotes, stale_after=300, phase="regular", now=self.NOW)
+        assert quotes[0]["is_stale"] is True
+
+    def test_fresh_quote_not_flagged(self):
+        quotes = [self._q(30)]
+        st.annotate_staleness(quotes, stale_after=300, phase="regular", now=self.NOW)
+        assert "is_stale" not in quotes[0]
+
+    def test_not_evaluated_outside_regular_session(self):
+        # After the close every quote is legitimately hours old — flagging then would
+        # light up the whole bar and mean nothing.
+        for phase in ("pre", "post", "closed"):
+            quotes = [self._q(99_999)]
+            st.annotate_staleness(quotes, stale_after=300, phase=phase, now=self.NOW)
+            assert "is_stale" not in quotes[0], phase
+
+    def test_zero_threshold_disables(self):
+        quotes = [self._q(99_999)]
+        st.annotate_staleness(quotes, stale_after=0, phase="regular", now=self.NOW)
+        assert "is_stale" not in quotes[0]
+
+    def test_quote_without_timestamp_is_never_flagged(self):
+        quotes = [{"symbol": "AAPL"}, {"symbol": "MSFT", "quote_time": 0}]
+        st.annotate_staleness(quotes, stale_after=300, phase="regular", now=self.NOW)
+        assert all("is_stale" not in q for q in quotes)
+
+    # -- providers populate the timestamp ------------------------------------
+
+    def test_yahoo_v7_carries_time_and_delay(self, router):
+        router.quote_time = 1_699_999_000
+        router.delayed_by = 15
+        ticker = _ticker(("AAPL",))
+        quote = ticker.fetch()[0]
+        assert quote.quote_time == 1_699_999_000
+        assert quote.delayed_by == 15
+        assert quote.as_dict()["delayed_by"] == 15
+        ticker.close()
+
+    def test_realtime_feed_omits_delay_from_payload(self, router):
+        router.delayed_by = 0
+        ticker = _ticker(("AAPL",))
+        payload = ticker.fetch()[0].as_dict()
+        assert "delayed_by" not in payload  # nothing to say -> nothing rendered
+        assert payload["quote_time"] == router.quote_time
+        ticker.close()
+
+    def test_finnhub_carries_trade_timestamp(self, router):
+        router.finnhub_prices = {"AAPL": {"c": 210.0, "d": 1.0, "dp": 0.5, "t": 1_699_998_888}}
+        ticker = _ticker(("AAPL",), api_key="k")
+        quote = ticker.fetch()[0]
+        assert quote.quote_time == 1_699_998_888
+        assert quote.delayed_by == 0  # Finnhub has no delay field; treat as real-time
+        ticker.close()
+
+    def test_yahoo_v8_chart_carries_time(self, router):
+        router.crumb_ok = False  # force the no-auth chart fallback
+        router.quote_time = 1_699_997_777
+        ticker = _ticker(("AAPL",))
+        quote = ticker.fetch()[0]
+        assert quote.quote_time == 1_699_997_777
+        ticker.close()
+
+    def test_cached_quote_goes_stale_when_provider_stops_answering(self, router):
+        # The regression this whole feature exists for: fetch() serves last-good values
+        # forever, so a dead provider must eventually show on the bar.
+        ticker = _ticker(("AAPL",))
+        first = ticker.fetch()
+        assert first and "is_stale" not in first[0].as_dict()
+        router.quote_status = 500
+        router.chart_ok = False
+        cached = [q.as_dict() for q in ticker.fetch()]
+        st.annotate_staleness(cached, stale_after=300, phase="regular", now=router.quote_time + 3600)
+        assert cached[0]["is_stale"] is True
+        ticker.close()


### PR DESCRIPTION
## Why

The ticker bar never goes blank — `fetch()` merges each round over a last-good cache, so a symbol its provider fails to price keeps its previous value. That guarantee has a blind spot: a provider that quietly stops answering leaves an hour-old price on screen looking exactly like a market that stopped moving. There is currently no way to tell the difference from across the room.

## What

Every quote now carries the provider's own timestamp, and cold ones get marked.

- **`quote_time`** — from Finnhub's `t`, Yahoo v7's `regularMarketTime`, and the v8 chart's `meta.regularMarketTime`, so all three providers in the chain report freshness rather than just one.
- **`delayed_by`** — from Yahoo's `exchangeDataDelayedBy` (minutes). Deliberately *not* `sourceInterval`, which is the source's refresh period (120s for `^DJI`, 15s for the rest) and says nothing about how delayed the feed is.
- **`annotate_staleness()`** — flags quotes older than `PULSE_TICKER_STALE_AFTER` (default `300`, `0` disables).

The overlay renders a muted `⏱` for stale and `15m` for an explicitly delayed feed. The exchange delay wins when both apply, since it's the more specific statement. Both markers are absent on a healthy bar, so they read as an exception rather than as permanent chrome on a scrolling ticker.

### Design note: why staleness is session-scoped

Staleness is evaluated **only during the regular session**. Outside it every quote is legitimately hours old — both providers stamp the last regular trade — so checking then would mark the entire bar and mean nothing. An explicit exchange delay is a property of the feed, so it is shown whenever non-zero.

## Measured behavior

Probed live against both providers during the session:

| Provider | Field | Observed |
| --- | --- | --- |
| Finnhub `/quote` | `t` | ~12s old |
| Yahoo v7 | `regularMarketTime` | ~1s old |
| Yahoo v7 | `exchangeDataDelayedBy` | `0` (real-time) |

Both feeds are effectively real-time in normal operation, which is exactly why a permanent LIVE badge would be noise — the marker earns its place only when something has actually gone wrong.

## Tests

15 new tests. Staleness flagging in and out of session, the `0`-disables path, quotes with no timestamp, timestamp propagation from all three providers, and a regression test that a cached quote goes stale once its provider stops answering. Rendering tests cover both markers, their absence on a healthy quote, and delay-wins-over-stale.

Full suite: 1924 passed. `ruff==0.15.0 check` and `black==26.1.0 --check` both clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and ticker metadata only; no auth, payments, or persistence beyond new env config. Behavior is gated to regular session and defaults are conservative.
> 
> **Overview**
> Adds **freshness signals** on the stock ticker so last-good cached prices do not look live when feeds fail or lag.
> 
> Quotes now carry **`quote_time`** (Finnhub `t`, Yahoo v7/chart `regularMarketTime`) and **`delayed_by`** (Yahoo `exchangeDataDelayedBy`). After each fetch, **`annotate_staleness()`** sets **`is_stale`** when the stamp is older than **`PULSE_TICKER_STALE_AFTER`** (default 300s, `0` disables)—**only during the regular US session**.
> 
> The overlay shows muted **`Nm`** when the exchange reports delay (wins over stale), otherwise **`⏱`** when stale. Healthy quotes show neither. Config/docs/sample updated; tests cover staleness rules, provider fields, rendering, and cached quotes going stale after provider failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 229fa8546b2213af936aa21f76e24b691b3df852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->