### PR TITLE
fix(deps): bump click to 8.4.2 in mcp-server (PYSEC-2026-2132)

### DIFF
--- a/mcp-server/uv.lock
+++ b/mcp-server/uv.lock
@@ -107,14 +107,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `click` 8.3.1 → 8.4.2 in `mcp-server/uv.lock`.

## Why

`click` 8.3.1 is vulnerable to **PYSEC-2026-2132** (first patched: 8.3.3).

It is pulled in transitively:

```
click v8.3.1
├── typer v0.21.1
│   └── mcp v1.28.1 (extra: cli)
│       └── pulse-os-mcp[cli]
└── uvicorn v0.40.0
    └── mcp v1.28.1
        └── pulse-os-mcp[cli]
```

Since nothing declares `click` directly, a targeted `uv lock --upgrade-package click` is sufficient — no `pyproject.toml` change.

## Coverage gap worth noting

CI's pip-audit step (`build.yaml`) runs `uv run pip-audit` from the **repo root only**, so the `mcp-server` workspace's locked deps are never audited there. This was found by auditing `mcp-server` locally. Root workspace audits clean.

## Verification

```
$ uv export --frozen --no-emit-project | uvx pip-audit -r -
No known vulnerabilities found
```

Diff is 3 lines in `mcp-server/uv.lock`; root `uv.lock` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch bump for a known CVE; no source or API changes in this repo.
> 
> **Overview**
> Updates **`mcp-server/uv.lock`** so transitive **`click`** moves from **8.3.1** to **8.4.2**, addressing **PYSEC-2026-2132** (patched from 8.3.3). **`click`** is not declared in `pyproject.toml`; it comes in via **`mcp[cli]`** (`typer`) and **`uvicorn`**, so only the lockfile changes—the repo root **`uv.lock`** is untouched.
> 
> This is a security-only dependency refresh with no application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a5f418aab683db53566622f94615a7c830b9c57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->