### PR TITLE
feat(ticker): summarize the market in a notification-bar pill

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -50,7 +50,10 @@ body {
   align-items: center;
   padding: 0.35rem 0.65rem;
   border-radius: 999px;
-  background: var(--overlay-ambient-bg);
+  /* The opaque-biased background the ticker bar uses, not the lighter ambient one the
+     cards use: badges sit over whatever photo or camera feed is on screen, and a bright
+     sky washes their text out — colored text (the market pill) worst of all. */
+  background: var(--overlay-alert-bg, rgba(0, 0, 0, 0.65));
   backdrop-filter: blur(12px);
   cursor: default;
   user-select: none;
@@ -86,9 +89,6 @@ body {
 .overlay-badge--market {
   gap: 0.5rem;
   font-variant-numeric: tabular-nums;
-  /* The bar's opaque-biased background rather than the lighter ambient badge one: green
-     and red on a translucent pill wash out badly over a bright photo or camera feed. */
-  background: var(--overlay-alert-bg, rgba(0, 0, 0, 0.65));
 }
 
 .overlay-market__move {

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -80,6 +80,30 @@ body {
   box-shadow: 0 0 12px rgba(220, 50, 47, 0.8);
 }
 
+/* Market summary pill — rides alongside the ticker bar, so it borrows the bar's
+   up/down colors. Numbers only (the names are in the aria-label/title) to keep it
+   narrow next to the alarm/timer/calendar badges. */
+.overlay-badge--market {
+  gap: 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.overlay-market__move {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.1rem;
+  font-size: 0.92em;
+  font-weight: 600;
+}
+
+.overlay-market__move--up {
+  color: #4caf50;
+}
+
+.overlay-market__move--down {
+  color: #ff5c5c;
+}
+
 .overlay-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -86,6 +86,9 @@ body {
 .overlay-badge--market {
   gap: 0.5rem;
   font-variant-numeric: tabular-nums;
+  /* The bar's opaque-biased background rather than the lighter ambient badge one: green
+     and red on a translucent pill wash out badly over a bright photo or camera feed. */
+  background: var(--overlay-alert-bg, rgba(0, 0, 0, 0.65));
 }
 
 .overlay-market__move {

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -100,6 +100,13 @@ Notes:
     Finnhub-priced symbols never show this one.
 - Gains render green with a ▲, losses red with a ▼; the bar matches the overlay's
   translucent card styling and is pinned to the bottom over whatever is on screen.
+- **Market pill.** Whenever the bar is up, a matching 📈 pill joins the notification
+  badges at the top of the overlay with an at-a-glance read on the market: the day's
+  percent move for up to three symbols (indices first — e.g. `📈 ▲0.42 ▲0.31 ▼0.12` for
+  the default `^SPX,^DJI,^NDX`), green/red with the same ▲/▼ as the bar. Names are left
+  off to keep the pill narrow; they're in its tooltip (following `PULSE_TICKER_LABEL`) and
+  spelled out in full on the bar below. The pill hides with the bar, so
+  `PULSE_TICKER_HOURS` governs both.
 - The fast/slow fetch cadence is keyed to US regular-session hours (holidays are not
   tracked — an extra harmless fast poll may occur). Data itself is global.
 - **DNS/ad-blocker allowlist:** the device fetches quotes from these hosts — if you run

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -605,6 +605,7 @@ ICON_MAP = {
     "earmuffs": "&#127911;",  # 🎧
     "update": "&#128260;",  # 🔄
     "sound": "&#127925;",  # 🎵
+    "market": "&#128200;",  # 📈
 }
 
 
@@ -642,6 +643,20 @@ def _ticker_float(value: Any) -> float | None:
         return None
 
 
+def _ticker_display_label(quote: dict[str, Any], mode: str) -> str:
+    """Raw (unescaped) display name for a quote under the configured label mode.
+
+    "auto": friendly name for indices (symbols with a caret prefix, e.g. ^SPX), ticker
+    symbol for everything else (avoids long/truncated ETF/stock names).
+    """
+    symbol = str(quote.get("symbol") or "")
+    name = str(quote.get("label") or "")
+    use_symbol = mode == "ticker" or (mode == "auto" and not symbol.startswith("^"))
+    if use_symbol:
+        return (symbol.lstrip("^") or name).strip()  # e.g. "^SPX" -> "SPX", "VTI" -> "VTI"
+    return (name or symbol).strip()
+
+
 def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     quotes = snapshot.ticker or ()
     mode = theme.ticker_label_mode  # "name" | "ticker" | "auto"
@@ -649,16 +664,7 @@ def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     for quote in quotes:
         if not isinstance(quote, dict):
             continue
-        symbol = str(quote.get("symbol") or "")
-        name = str(quote.get("label") or "")
-        # "auto": friendly name for indices (symbols with a caret prefix, e.g. ^SPX),
-        # ticker symbol for everything else (avoids long/truncated ETF/stock names).
-        use_symbol = mode == "ticker" or (mode == "auto" and not symbol.startswith("^"))
-        if use_symbol:
-            raw_label = symbol.lstrip("^") or name  # e.g. "^SPX" -> "SPX", "VTI" -> "VTI"
-        else:
-            raw_label = name or symbol
-        label = html_escape(raw_label).strip()
+        label = html_escape(_ticker_display_label(quote, mode))
         if not label:
             continue
         price = _ticker_float(quote.get("price"))
@@ -712,6 +718,68 @@ def _build_ticker_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     )
 
 
+# How many symbols the notification-bar pill summarizes. Three covers the default
+# ^SPX/^DJI/^NDX set without crowding the other badges — the scrolling bar below carries
+# the full list, prices included.
+_MARKET_PILL_MAX = 3
+
+
+def _market_pill_quotes(quotes: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    """The (at most three) quotes the pill summarizes.
+
+    Indices win whenever any are configured — the pill is meant to read as "the market",
+    so a caret symbol beats whatever equities happen to come first. With no indices at all
+    (an all-equities symbol list), the first few configured symbols are the stand-in.
+    """
+    usable = [
+        quote for quote in quotes if isinstance(quote, dict) and _ticker_float(quote.get("change_pct")) is not None
+    ]
+    indices = [quote for quote in usable if str(quote.get("symbol") or "").startswith("^")]
+    return (indices or usable)[:_MARKET_PILL_MAX]
+
+
+def _build_market_pill(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
+    """Compact market summary badge for the notification bar.
+
+    Appears and disappears with the ticker bar itself: the caller gates on
+    theme.show_ticker, and the ticker thread pushes an empty quote list whenever the
+    configured hours mode says the bar shouldn't show, so an off-hours pill is impossible.
+
+    Deliberately numbers-only (arrow + percent, no labels) because badge space is scarce;
+    the index names are spelled out in the aria-label/tooltip, and in full on the bar.
+    """
+    picks = _market_pill_quotes(snapshot.ticker or ())
+    if not picks:
+        return ""
+    moves: list[str] = []
+    described: list[str] = []
+    for quote in picks:
+        pct = _ticker_float(quote.get("change_pct"))
+        if pct is None:
+            continue
+        raw_is_up = quote.get("is_up")
+        is_up = bool(raw_is_up) if raw_is_up is not None else pct >= 0
+        direction = "up" if is_up else "down"
+        arrow = "▲" if is_up else "▼"
+        moves.append(
+            f'<span class="overlay-market__move overlay-market__move--{direction}">' f"{arrow}{abs(pct):.2f}</span>"
+        )
+        # Tooltip names follow the same label mode as the bar, so a display configured for
+        # bare symbols doesn't get long fund names smuggled back in via the pill.
+        name = _ticker_display_label(quote, theme.ticker_label_mode)
+        described.append(f"{name} {direction} {abs(pct):.2f}%")
+    if not moves:
+        return ""
+    icon = ICON_MAP.get("market", "&#9679;")
+    detail = html_escape(f"Markets: {', '.join(described)}", quote=True)
+    return (
+        f'<span class="overlay-badge overlay-badge--market" aria-label="{detail}" title="{detail}">'
+        f'<span class="overlay-badge__icon" aria-hidden="true">{icon}</span>'
+        f"{''.join(moves)}"
+        "</span>"
+    )
+
+
 def render_overlay_html(
     snapshot: OverlaySnapshot,
     theme: OverlayTheme,
@@ -758,7 +826,7 @@ def render_overlay_html(
     if info_card_markup:
         grid_markup += info_card_markup
 
-    notification_html = _build_notification_bar(snapshot) if theme.show_notification_bar else ""
+    notification_html = _build_notification_bar(snapshot, theme) if theme.show_notification_bar else ""
 
     ticker_html = _build_ticker_bar(snapshot, theme) if theme.show_ticker else ""
     root_class = "overlay-root overlay-root--ticker" if ticker_html else "overlay-root"
@@ -1134,7 +1202,7 @@ def _build_now_playing_card(snapshot: OverlaySnapshot) -> tuple[str, str] | None
     return "bottom-right", card
 
 
-def _build_notification_bar(snapshot: OverlaySnapshot) -> str:
+def _build_notification_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     badges: list[str] = []
     badges.append(_render_badge("help", "Help"))
     badges.append(_render_badge("config", "Config"))
@@ -1166,6 +1234,12 @@ def _build_notification_bar(snapshot: OverlaySnapshot) -> str:
         badges.append(_render_badge("music", "Now playing"))
     if snapshot.update_available:
         badges.append(_render_badge("update", "Update available"))
+    if theme.show_ticker:
+        # Least urgent of the informational badges, so it sits after the time-critical
+        # ones and just before the earmuffs toggle.
+        market_pill = _build_market_pill(snapshot, theme)
+        if market_pill:
+            badges.append(market_pill)
     badges.append(_render_earmuffs_badge(snapshot.earmuffs_enabled))
     classes = ["overlay-notification-bar"]
     if not badges:

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -195,6 +195,66 @@ class OverlayRenderTests(unittest.TestCase):
         html = render_overlay_html(self._snapshot(ticker=ticker), self.theme)  # theme.show_ticker defaults False
         self.assertNotIn('class="pulse-ticker"', html)
 
+    # --- Market summary pill (notification bar) ---------------------------------
+    _MARKET_PILL_MARKUP = '<span class="overlay-badge overlay-badge--market"'
+
+    def _index(self, symbol: str, label: str, pct: float) -> dict:
+        return {
+            "symbol": symbol,
+            "label": label,
+            "price": 100.0,
+            "change": pct,
+            "change_pct": pct,
+            "is_up": pct >= 0,
+        }
+
+    def test_market_pill_shows_percents_with_direction(self) -> None:
+        ticker = (
+            self._index("^SPX", "S&P 500", 0.42),
+            self._index("^DJI", "Dow", 0.31),
+            self._index("^IXIC", "Nasdaq", -0.12),
+        )
+        html = render_overlay_html(self._snapshot(ticker=ticker), self._ticker_theme())
+        self.assertIn(self._MARKET_PILL_MARKUP, html)
+        self.assertIn(">▲0.42</span>", html)
+        self.assertIn(">▲0.31</span>", html)
+        self.assertIn(">▼0.12</span>", html)  # sign lives in the arrow, not the number
+        self.assertIn("overlay-market__move--up", html)
+        self.assertIn("overlay-market__move--down", html)
+        # Names are dropped from the visible pill but kept for hover/screen readers.
+        self.assertIn("Markets: S&amp;P 500 up 0.42%, Dow up 0.31%, Nasdaq down 0.12%", html)
+
+    def test_market_pill_prefers_indices_and_caps_at_three(self) -> None:
+        ticker = (
+            self._index("VTI", "VTI", 1.0),
+            self._index("^SPX", "S&P 500", 0.42),
+            self._index("^DJI", "Dow", 0.31),
+            self._index("^IXIC", "Nasdaq", -0.12),
+            self._index("^RUT", "Russell 2000", 0.55),
+        )
+        html = render_overlay_html(self._snapshot(ticker=ticker), self._ticker_theme())
+        self.assertIn(">▲0.42</span>", html)
+        self.assertIn("Markets: S&amp;P 500 up 0.42%, Dow up 0.31%, Nasdaq down 0.12%", html)
+        self.assertNotIn(">▲1.00</span>", html)  # equity skipped in favor of indices
+        self.assertNotIn(">▲0.55</span>", html)  # fourth index trimmed
+
+    def test_market_pill_falls_back_to_equities_when_no_indices(self) -> None:
+        ticker = (self._index("VTI", "VTI", 1.0), self._index("VOO", "VOO", -0.25))
+        html = render_overlay_html(self._snapshot(ticker=ticker), self._ticker_theme())
+        self.assertIn(">▲1.00</span>", html)
+        self.assertIn(">▼0.25</span>", html)
+
+    def test_market_pill_absent_when_ticker_disabled(self) -> None:
+        ticker = (self._index("^SPX", "S&P 500", 0.42),)
+        html = render_overlay_html(self._snapshot(ticker=ticker), self.theme)  # show_ticker False
+        self.assertNotIn(self._MARKET_PILL_MARKUP, html)
+
+    def test_market_pill_absent_when_no_quotes(self) -> None:
+        # The ticker thread pushes an empty list when the hours mode hides the bar, so the
+        # pill must vanish with it rather than freezing the last quotes on screen.
+        html = render_overlay_html(self._snapshot(ticker=()), self._ticker_theme())
+        self.assertNotIn(self._MARKET_PILL_MARKUP, html)
+
     def test_only_first_clock_used_if_multiple_provided(self) -> None:
         # Even if multiple clocks are provided, only the first one is rendered
         clocks = (


### PR DESCRIPTION
## What

While the ticker bar is up, a compact 📈 pill joins the notification badges at the top of the overlay with an at-a-glance read on the market: the day's percent move for up to three symbols, green/red with the same ▲/▼ as the bar.

With the default `^SPX,^DJI,^NDX` it reads: `📈 ▲0.42 ▲0.31 ▼0.12`

## Why this shape

Badge space is at a premium, so the pill is numbers-only — no labels. The index names live in its tooltip/`aria-label` ("Markets: S&P 500 up 0.42%, Dow up 0.31%, Nasdaq down 0.12%", following `PULSE_TICKER_LABEL`) and in full on the scrolling bar below.

Symbol selection prefers indices (caret symbols) so the pill reads as "the market" even when the configured list is mostly equities; with no indices configured at all it falls back to the first few symbols.

## Visibility

Gated on `theme.show_ticker` **and** on the quote list — which the ticker thread empties whenever `PULSE_TICKER_HOURS` says the bar shouldn't show — so the pill and the bar appear and disappear together, holidays and half-days included. Its numbers refresh on the same cadence as the bar's prices.

## Also

Factors the per-quote label logic out of `_build_ticker_bar` into `_ticker_display_label()` so the bar and the pill's tooltip name things identically.

## Tests

5 new tests: percent/direction markup, indices-preferred + capped at three, equity fallback, absent when the ticker is disabled, absent when the hours mode empties the quotes. Full suite passes (1929).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Overlay HTML/CSS presentation only; no changes to quote fetching, auth, or persistence.
> 
> **Overview**
> Adds a compact **📈 market pill** to the overlay notification bar whenever the stock ticker is enabled, giving an at-a-glance view of up to three symbols’ daily percent moves (e.g. `▲0.42 ▲0.31 ▼0.12`) with the same green/red styling as the bottom ticker bar.
> 
> The pill is **numbers-only** on screen; names follow `PULSE_TICKER_LABEL` in the tooltip/`aria-label`. Symbol selection **prefers index quotes** (`^…`) and caps at three; with no indices it uses the first configured symbols. It only renders when `show_ticker` is on and quotes are present, so it tracks **`PULSE_TICKER_HOURS`** with the bar.
> 
> **Also:** extracts `_ticker_display_label()` for shared bar/pill naming; switches default badge background to the darker `--overlay-alert-bg` so colored pill text stays readable over bright photos; documents the pill in `config-reference.md`; adds five overlay tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd228752e8a417b8f8a3f936a34203f58572d8bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->