### PR TITLE
feat(overlay): badge the notification bar when the speaker is unreachable

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -107,6 +107,35 @@ body {
   color: #ff5c5c;
 }
 
+/* Speaker-offline badge — the one badge on this bar that reports a fault, so it gets
+   amber rather than the neutral translucent background. Amber, not the earmuffs red:
+   red on this bar already means "earmuffs are on", a deliberate user choice, and a
+   broken speaker shouldn't read as the same kind of thing at a glance. */
+.overlay-badge.overlay-badge--speaker-offline {
+  background: #cb4b16 !important;
+  border: 1px solid rgba(255, 255, 255, 0.5) !important;
+  color: #ffffff !important;
+  animation: overlaySpeakerOfflinePulse 2.4s ease-in-out infinite alternate;
+}
+
+/* Slower and dimmer than overlayPulse (the ringing-alarm glow). This condition can
+   persist for hours until somebody walks over to the speaker, so it needs to catch a
+   passing glance without strobing at whoever is sitting in the room. */
+@keyframes overlaySpeakerOfflinePulse {
+  from {
+    box-shadow: 0 0 0 rgba(203, 75, 22, 0.35);
+  }
+  to {
+    box-shadow: 0 0 14px rgba(203, 75, 22, 0.75);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay-badge.overlay-badge--speaker-offline {
+    animation: none;
+  }
+}
+
 .overlay-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -34,6 +34,7 @@ from pulse.overlay import (
     parse_clock_config,
 )
 from pulse.overlay_server import OverlayHttpServer, OverlayServerConfig
+from pulse.speaker import SpeakerConfig, check_speaker
 from pulse.stock_ticker import (
     TICKER_HOURS_MODES,
     StockTicker,
@@ -110,6 +111,13 @@ class OverlayConfig:
     ticker_label_mode: str
     ticker_api_key: str | None
     ticker_stale_after: int  # seconds before a quote is marked stale (0 disables)
+    speaker_alert: bool  # show a badge when the configured speaker is unreachable
+    speaker_interval: int  # seconds between reachability checks
+    # Reused from the Bluetooth autoconnect settings — the badge and bin/bt-autoconnect.sh
+    # must agree on which speaker this room owns, so they read the same two variables.
+    bt_autoconnect: bool
+    bt_mac: str
+    speaker_sink: str  # substring of the expected wired sink; empty disables that check
 
 
 @dataclass(frozen=True)
@@ -484,6 +492,13 @@ def load_config() -> EnvConfig:
         ticker_label_mode=ticker_label_mode,
         ticker_api_key=(os.environ.get("PULSE_TICKER_API_KEY") or "").strip() or None,
         ticker_stale_after=max(0, parse_int(os.environ.get("PULSE_TICKER_STALE_AFTER"), 300)),
+        speaker_alert=parse_bool(os.environ.get("PULSE_SPEAKER_ALERT"), True),
+        # Floor of 15s matches the bt-autoconnect timer cadence; polling faster than the
+        # thing doing the reconnecting only burns CPU on a Pi.
+        speaker_interval=max(15, parse_int(os.environ.get("PULSE_SPEAKER_INTERVAL"), 60)),
+        bt_autoconnect=parse_bool(os.environ.get("PULSE_BLUETOOTH_AUTOCONNECT"), True),
+        bt_mac=(os.environ.get("PULSE_BT_MAC") or "").strip(),
+        speaker_sink=(os.environ.get("PULSE_SPEAKER_SINK") or "").strip(),
     )
 
     version_source_url = os.environ.get("PULSE_VERSION_SOURCE_URL", DEFAULT_VERSION_SOURCE_URL)
@@ -701,6 +716,10 @@ class KioskMqttListener:
         self._ticker_thread: threading.Thread | None = None
         self._ticker_stop_event = threading.Event()
         self._stock_ticker: StockTicker | None = None
+        self._speaker_lock = threading.Lock()
+        self._speaker_thread: threading.Thread | None = None
+        self._speaker_stop_event = threading.Event()
+        self._speaker_offline_streak = 0
         self._watchdog_thread: threading.Thread | None = None
         self._watchdog_stop_event = threading.Event()
         self._last_mqtt_ok: float = time.monotonic()
@@ -860,6 +879,67 @@ class KioskMqttListener:
             self._ticker_stop_event.set()
             self._ticker_thread.join(timeout=self.overlay_config.ticker_interval)
             self._ticker_thread = None
+
+    def start_speaker_monitor(self) -> None:
+        if not self.overlay_state or not self.overlay_config.speaker_alert:
+            return
+        with self._speaker_lock:
+            if self._speaker_thread and self._speaker_thread.is_alive():
+                return
+            self._speaker_stop_event.clear()
+            thread = threading.Thread(target=self._speaker_loop, name="pulse-speaker", daemon=True)
+            self._speaker_thread = thread
+            thread.start()
+
+    def stop_speaker_monitor(self) -> None:
+        with self._speaker_lock:
+            if not self._speaker_thread:
+                return
+            self._speaker_stop_event.set()
+            self._speaker_thread.join(timeout=self.overlay_config.speaker_interval)
+            self._speaker_thread = None
+
+    # A single bad read must not raise the badge. BlueZ briefly reports a speaker as
+    # disconnected while it renegotiates A2DP (and during the ~15s bt-autoconnect
+    # window after a reboot), so requiring two consecutive offline reads costs one
+    # extra poll of latency and buys immunity to that flapping. Recovery is not
+    # debounced — the moment the speaker answers, the badge goes away.
+    _SPEAKER_OFFLINE_STREAK_TO_ALERT = 2
+
+    def _speaker_loop(self) -> None:
+        state = self.overlay_state
+        if not state:
+            return
+        config = SpeakerConfig(
+            bt_autoconnect=self.overlay_config.bt_autoconnect,
+            bt_mac=self.overlay_config.bt_mac,
+            wired_sink=self.overlay_config.speaker_sink,
+        )
+        try:
+            while not self._speaker_stop_event.is_set():
+                try:
+                    status = check_speaker(config)
+                    if status is None or not status.offline:
+                        # Reachable, unconfigured, or the check couldn't run — in all
+                        # three cases we have nothing to tell anyone.
+                        self._speaker_offline_streak = 0
+                        change = state.update_speaker_offline(None)
+                    else:
+                        self._speaker_offline_streak += 1
+                        if self._speaker_offline_streak < self._SPEAKER_OFFLINE_STREAK_TO_ALERT:
+                            change = None
+                        else:
+                            if self._speaker_offline_streak == self._SPEAKER_OFFLINE_STREAK_TO_ALERT:
+                                self.log(f"speaker: {status.kind} speaker '{status.name}' is not connected")
+                            change = state.update_speaker_offline({"name": status.name, "kind": status.kind})
+                    if change and change.changed:
+                        self._emit_overlay_refresh(change.version, change.reason)
+                except Exception as exc:  # nosec B110 - never let a probe error kill the loop
+                    self.log(f"speaker: check failed: {exc}")
+                if self._speaker_stop_event.wait(self.overlay_config.speaker_interval):
+                    break
+        finally:
+            self._speaker_offline_streak = 0
 
     def _ticker_loop(self) -> None:
         ticker = self._stock_ticker
@@ -2056,6 +2136,7 @@ class KioskMqttListener:
         self.start_update_checker(client)
         self.start_telemetry()
         self.start_ticker()
+        self.start_speaker_monitor()
         if self.overlay_state:
             # Start the HTTP server BEFORE announcing the boot refresh, otherwise the
             # photo-card re-fetches /overlay against a not-yet-listening port, fails, and
@@ -2355,6 +2436,7 @@ def main():
     atexit.register(listener.stop_update_checker)
     atexit.register(listener.stop_telemetry)
     atexit.register(listener.stop_ticker)
+    atexit.register(listener.stop_speaker_monitor)
     atexit.register(listener.stop_overlay_server)
     atexit.register(listener._stop_watchdog)
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -146,6 +146,29 @@ Notes:
 | `PULSE_VOLUME_TEST_SOUND` | `true` | Plays a short “thump” after MQTT volume changes. |
 | `PULSE_BLUETOOTH_AUTOCONNECT` | `true` | Reconnects to the last paired Bluetooth speaker and sends keepalives. |
 | `PULSE_BT_MAC` | *(empty)* | Optional explicit Bluetooth MAC to target. |
+| `PULSE_SPEAKER_ALERT` | `true` | Shows a notification-bar badge while the configured speaker is unreachable. |
+| `PULSE_SPEAKER_SINK` | *(empty)* | Substring of the expected wired sink name (`pactl list sinks short`) to watch on non-Bluetooth displays. |
+| `PULSE_SPEAKER_INTERVAL` | `60` | Seconds between speaker reachability checks (minimum 15). |
+
+### Speaker-offline badge
+
+A speaker that has been switched off or unplugged fails silently — playback "succeeds",
+snapclient stays connected, and the only evidence is bluetoothd retrying in the journal
+(`avdtp_connect_cb() connect to …: Host is down (112)`). `PULSE_SPEAKER_ALERT` surfaces that
+as an amber badge at the front of the notification bar, ahead of the alarm badges, because a
+silent speaker also means a silent alarm.
+
+Which speaker is watched follows the same rules `bin/bt-autoconnect.sh` uses, so the badge and
+the reconnect loop can't disagree:
+
+- `PULSE_BLUETOOTH_AUTOCONNECT="true"` (the default) → `PULSE_BT_MAC` if set, otherwise the
+  connected device, otherwise the first paired one.
+- `PULSE_BLUETOOTH_AUTOCONNECT="false"` → the wired check, and only if `PULSE_SPEAKER_SINK` is set.
+
+Displays with neither configured are never checked, so stale pairings left over from a
+re-purposed display can't produce a badge that never clears. The badge needs two consecutive
+failed checks to appear (riding out the A2DP renegotiation blips and the post-reboot
+autoconnect window) and clears on the first successful one.
 
 ## Display Selection (DSI vs HDMI)
 

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -276,6 +276,19 @@ PULSE_BLUETOOTH_AUTOCONNECT="true"
 # PULSE_BT_MAC — optional Bluetooth MAC (XX:XX:XX:XX:XX:XX) to force which device we connect to.
 PULSE_BT_MAC=""
 
+# PULSE_SPEAKER_ALERT — show a notification-bar badge when the configured speaker can't be
+# reached. A powered-off Bluetooth speaker is otherwise invisible: the room just goes quiet.
+PULSE_SPEAKER_ALERT="true"
+
+# PULSE_SPEAKER_SINK — for displays driving a WIRED speaker (PULSE_BLUETOOTH_AUTOCONNECT="false"),
+# a substring of the expected sink name from `pactl list sinks short`, e.g. "C-Media". When the
+# matching sink disappears the same badge appears. Leave empty to skip the wired check — without
+# a name to expect there's no way to tell "unplugged" from "never had one".
+PULSE_SPEAKER_SINK=""
+
+# PULSE_SPEAKER_INTERVAL — seconds between speaker reachability checks (minimum 15).
+PULSE_SPEAKER_INTERVAL="60"
+
 # ============================================================================
 # Logging & Reliability
 # ============================================================================

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -84,6 +84,9 @@ class OverlaySnapshot:
     earmuffs_enabled: bool
     update_available: bool
     ticker: tuple[dict[str, Any], ...] = ()
+    # {"name": str, "kind": "bluetooth"|"wired"} while the configured speaker is
+    # unreachable; None whenever it is reachable, unconfigured, or unknown.
+    speaker_offline: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -172,6 +175,7 @@ class OverlayStateManager:
         self._earmuffs_enabled = False
         self._update_available = False
         self._ticker: tuple[dict[str, Any], ...] = ()
+        self._speaker_offline: dict[str, Any] | None = None
         self._version = 0
         self._last_reason = "init"
         self._last_updated = time.time()
@@ -190,6 +194,7 @@ class OverlayStateManager:
             "earmuffs_enabled": "",
             "update_available": "",
             "ticker": "",
+            "speaker_offline": "",
         }
 
     @property
@@ -466,6 +471,21 @@ class OverlayStateManager:
             self._signatures["update_available"] = signature
             return self._bump("update_available")
 
+    def update_speaker_offline(self, speaker: dict[str, Any] | None) -> OverlayChange:
+        """Record that the configured speaker is (un)reachable.
+
+        Pass None for reachable/unconfigured/unknown. Bumps only on a real transition,
+        so the poll loop can call this every cycle without churning the overlay version.
+        """
+        normalized = dict(speaker) if speaker else None
+        signature = "" if normalized is None else f"{normalized.get('kind', '')}:{normalized.get('name', '')}"
+        with self._lock:
+            if signature == self._signatures["speaker_offline"]:
+                return OverlayChange(False, self._version, "speaker_offline")
+            self._speaker_offline = normalized
+            self._signatures["speaker_offline"] = signature
+            return self._bump("speaker_offline")
+
     def snapshot(self) -> OverlaySnapshot:
         with self._lock:
             return OverlaySnapshot(
@@ -490,6 +510,7 @@ class OverlayStateManager:
                 earmuffs_enabled=self._earmuffs_enabled,
                 update_available=self._update_available,
                 ticker=tuple(dict(item) for item in self._ticker),
+                speaker_offline=copy.deepcopy(self._speaker_offline),
             )
 
     def _bump(self, reason: str) -> OverlayChange:
@@ -606,6 +627,7 @@ ICON_MAP = {
     "update": "&#128260;",  # 🔄
     "sound": "&#127925;",  # 🎵
     "market": "&#128200;",  # 📈
+    "speaker_off": "&#128263;",  # 🔇
 }
 
 
@@ -776,6 +798,37 @@ def _build_market_pill(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
         f'<span class="overlay-badge overlay-badge--market" aria-label="{detail}" title="{detail}">'
         f'<span class="overlay-badge__icon" aria-hidden="true">{icon}</span>'
         f"{''.join(moves)}"
+        "</span>"
+    )
+
+
+def _build_speaker_pill(snapshot: OverlaySnapshot) -> str:
+    """Badge shown only while the configured speaker is unreachable.
+
+    Deliberately one-sided: there is no "speaker OK" badge, because the healthy state
+    is the overwhelmingly common one and a permanent green pill would train everyone
+    to stop reading the bar. This appears only when the room has gone silent for a
+    reason a person can fix, and says which fix — power-cycle vs. reseat the cable.
+    """
+    speaker = snapshot.speaker_offline
+    if not speaker:
+        return ""
+    name = str(speaker.get("name") or "Speaker").strip() or "Speaker"
+    kind = str(speaker.get("kind") or "bluetooth")
+    if kind == "wired":
+        label = "Speaker unplugged"
+        detail = f"{name} is not connected — check the speaker's USB and power cables."
+    else:
+        label = f"{name} offline"
+        detail = f'Bluetooth speaker "{name}" is not connected — power-cycle the speaker to restore audio.'
+    icon = ICON_MAP.get("speaker_off", "&#9679;")
+    safe_label = html_escape(label)
+    safe_detail = html_escape(detail, quote=True)
+    return (
+        f'<span class="overlay-badge overlay-badge--speaker-offline" '
+        f'aria-label="{safe_detail}" title="{safe_detail}">'
+        f'<span class="overlay-badge__icon" aria-hidden="true">{icon}</span>'
+        f"<span>{safe_label}</span>"
         "</span>"
     )
 
@@ -1206,6 +1259,12 @@ def _build_notification_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> s
     badges: list[str] = []
     badges.append(_render_badge("help", "Help"))
     badges.append(_render_badge("config", "Config"))
+    # Ahead of the alarm/timer badges on purpose: a speaker that is off doesn't just
+    # mean no music, it means the alarm sitting next to it won't be heard either. If
+    # anything on this bar deserves to be read first, it's this.
+    speaker_pill = _build_speaker_pill(snapshot)
+    if speaker_pill:
+        badges.append(speaker_pill)
     upcoming = _filter_upcoming_alarms(snapshot.alarms)
     if snapshot.active_alarm:
         badges.append(_render_badge("alarm_ringing", "Alarm ringing"))

--- a/pulse/speaker.py
+++ b/pulse/speaker.py
@@ -1,0 +1,180 @@
+"""Detect whether the room's configured speaker is actually reachable.
+
+A speaker that has been powered off (Bluetooth) or unplugged (USB/analog) fails
+*silently* on Pulse. Playback still "succeeds", snapclient stays connected to the
+server, the overlay looks perfectly healthy — the room just stops making sound. The
+only trace is bluetoothd retrying in the journal, roughly every 15s forever:
+
+    profiles/audio/avdtp.c:avdtp_connect_cb() connect to AA:BB:CC:DD:EE:FF: Host is down (112)
+
+Nobody reads the journal, so this module turns that into something the notification
+bar can show as a badge (see ``_build_speaker_pill`` in ``pulse.overlay``).
+
+Only the *configured* speaker counts. BlueZ pairings are not a usable signal on their
+own: a display that has been re-purposed keeps stale pairings to speakers that now
+live in another room, and alerting on those would mean a badge that never clears. So
+the source of truth is what ``pulse.conf`` says this display is supposed to drive --
+``PULSE_BT_MAC``/``PULSE_BLUETOOTH_AUTOCONNECT`` for Bluetooth, ``PULSE_SPEAKER_SINK``
+for a wired one. A display with neither configured is never checked.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess  # nosec B404 - fixed command arrays, no shell
+from dataclasses import dataclass
+
+_LOGGER = logging.getLogger(__name__)
+
+# BlueZ prints "Device 11:22:33:44:55:66 Name" from `bluetoothctl devices`.
+_MAC_RE = re.compile(r"^Device\s+((?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2})\s*(.*)$")
+_MAC_ONLY_RE = re.compile(r"^(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+
+_SUBPROCESS_TIMEOUT = 10
+
+
+@dataclass(frozen=True)
+class SpeakerConfig:
+    """What this display is configured to play through."""
+
+    bt_autoconnect: bool = True
+    bt_mac: str = ""
+    # Substring matched against `pactl list sinks short` names. Empty disables the
+    # wired check entirely — there is no way to tell "unplugged" from "never had one"
+    # without being told which sink to expect.
+    wired_sink: str = ""
+
+
+@dataclass(frozen=True)
+class SpeakerStatus:
+    """Result of one reachability check."""
+
+    offline: bool
+    name: str
+    kind: str  # "bluetooth" | "wired"
+
+
+def _runtime_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+    return env
+
+
+def _run(args: list[str]) -> str | None:
+    """Run a command and return stdout, or None if it failed.
+
+    Never raises: every caller is on a background poll loop where a missing binary or
+    a wedged daemon must degrade to "unknown" rather than take the loop down.
+    """
+    try:
+        result = subprocess.run(  # nosec B603 B607 - fixed command array, no shell
+            args,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+            env=_runtime_env(),
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
+        _LOGGER.debug("[speaker] %s failed: %s", " ".join(args), exc)
+        return None
+    return result.stdout
+
+
+def _bluetooth_devices(kind: str) -> list[tuple[str, str]]:
+    """(mac, name) pairs from `bluetoothctl devices <Paired|Connected>`."""
+    out = _run(["bluetoothctl", "devices", kind])
+    if out is None:
+        return []
+    devices: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        match = _MAC_RE.match(line.strip())
+        if match:
+            devices.append((match.group(1), match.group(2).strip()))
+    return devices
+
+
+def resolve_bt_mac(configured: str) -> tuple[str, str]:
+    """The MAC to watch, plus its friendly name. ("", "") when there is nothing to watch.
+
+    Mirrors the discovery order in ``bin/bt-autoconnect.sh`` so the badge and the
+    reconnect loop can never disagree about *which* speaker this room owns: an
+    explicit ``PULSE_BT_MAC`` wins, otherwise the connected device, otherwise the
+    first paired one.
+    """
+    candidate = (configured or "").strip()
+    if candidate:
+        if not _MAC_ONLY_RE.match(candidate):
+            _LOGGER.warning("[speaker] PULSE_BT_MAC is not a MAC address, ignoring: %r", candidate)
+            return "", ""
+        name = ""
+        for mac, device_name in _bluetooth_devices("Paired"):
+            if mac.upper() == candidate.upper():
+                name = device_name
+                break
+        return candidate.upper(), name
+    for kind in ("Connected", "Paired"):
+        for mac, device_name in _bluetooth_devices(kind):
+            return mac.upper(), device_name
+    return "", ""
+
+
+def bt_connected(mac: str) -> bool | None:
+    """Is this MAC currently connected? None when BlueZ could not be asked.
+
+    Reads cached device state, so this stays a few-millisecond call even when the
+    speaker is powered off — unlike `bluetoothctl connect`, which blocks ~60s against
+    an absent device.
+    """
+    out = _run(["bluetoothctl", "info", mac])
+    if out is None:
+        return None
+    for line in out.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Connected:"):
+            return stripped.split(":", 1)[1].strip().lower() == "yes"
+    # `bluetoothctl info` on an unknown MAC prints "Device <mac> not available".
+    return None
+
+
+def wired_sink_present(token: str) -> bool | None:
+    """Is a non-monitor sink whose name contains ``token`` present? None if pactl failed."""
+    out = _run(["pactl", "list", "sinks", "short"])
+    if out is None:
+        return None
+    needle = token.strip().lower()
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        sink = parts[1]
+        if sink.endswith(".monitor"):
+            continue
+        if needle in sink.lower():
+            return True
+    return False
+
+
+def check_speaker(config: SpeakerConfig) -> SpeakerStatus | None:
+    """Reachability of the configured speaker.
+
+    Returns None — meaning "no opinion, show nothing" — when this display has no
+    speaker configured, or when the check itself could not run. An unanswerable check
+    must not render as "offline": a momentarily busy BlueZ would otherwise flash a
+    badge telling someone to go power-cycle a speaker that is playing fine.
+    """
+    if config.bt_autoconnect:
+        mac, name = resolve_bt_mac(config.bt_mac)
+        if mac:
+            connected = bt_connected(mac)
+            if connected is None:
+                return None
+            return SpeakerStatus(offline=not connected, name=name or "Speaker", kind="bluetooth")
+    if config.wired_sink:
+        present = wired_sink_present(config.wired_sink)
+        if present is None:
+            return None
+        return SpeakerStatus(offline=not present, name="Speaker", kind="wired")
+    return None

--- a/pulse/speaker.py
+++ b/pulse/speaker.py
@@ -140,11 +140,19 @@ def bt_connected(mac: str) -> bool | None:
 
 
 def wired_sink_present(token: str) -> bool | None:
-    """Is a non-monitor sink whose name contains ``token`` present? None if pactl failed."""
+    """Is a non-monitor sink whose name contains ``token`` present?
+
+    None when pactl failed, and also when ``token`` is blank: an empty needle is a
+    substring of every sink name, so answering True there would report "speaker fine"
+    for a display nobody has actually told us what to look for. Silently healthy is
+    the one answer this module must never invent.
+    """
+    needle = token.strip().lower()
+    if not needle:
+        return None
     out = _run(["pactl", "list", "sinks", "short"])
     if out is None:
         return None
-    needle = token.strip().lower()
     for line in out.splitlines():
         parts = line.split()
         if len(parts) < 2:
@@ -172,7 +180,10 @@ def check_speaker(config: SpeakerConfig) -> SpeakerStatus | None:
             if connected is None:
                 return None
             return SpeakerStatus(offline=not connected, name=name or "Speaker", kind="bluetooth")
-    if config.wired_sink:
+    # Strip here too, not just inside wired_sink_present: a whitespace-only setting is
+    # an unconfigured display, and must fall through to "no opinion" rather than count
+    # as a wired speaker to watch.
+    if config.wired_sink.strip():
         present = wired_sink_present(config.wired_sink)
         if present is None:
             return None

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -255,6 +255,54 @@ class OverlayRenderTests(unittest.TestCase):
         html = render_overlay_html(self._snapshot(ticker=()), self._ticker_theme())
         self.assertNotIn(self._MARKET_PILL_MARKUP, html)
 
+    # --- Speaker-offline badge (notification bar) -------------------------------
+    _SPEAKER_PILL_MARKUP = '<span class="overlay-badge overlay-badge--speaker-offline"'
+
+    def test_speaker_pill_absent_when_speaker_reachable(self) -> None:
+        # The healthy case is the common one and gets no badge at all — a permanent
+        # "speaker OK" pill would train everyone to stop reading the bar.
+        html = render_overlay_html(self._snapshot(speaker_offline=None), self.theme)
+        self.assertNotIn(self._SPEAKER_PILL_MARKUP, html)
+
+    def test_speaker_pill_names_the_bluetooth_speaker(self) -> None:
+        snapshot = self._snapshot(speaker_offline={"name": "Living Room", "kind": "bluetooth"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertIn(self._SPEAKER_PILL_MARKUP, html)
+        self.assertIn("<span>Living Room offline</span>", html)
+        self.assertIn("power-cycle the speaker", html)
+
+    def test_speaker_pill_wired_says_check_the_cables(self) -> None:
+        # A USB speaker can't be power-cycled from the couch, so the wired variant has
+        # to point at the actual fix rather than reusing the Bluetooth wording.
+        snapshot = self._snapshot(speaker_offline={"name": "Speaker", "kind": "wired"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertIn("<span>Speaker unplugged</span>", html)
+        self.assertIn("USB and power cables", html)
+        self.assertNotIn("power-cycle the speaker", html)
+
+    def test_speaker_pill_escapes_speaker_name(self) -> None:
+        # Speaker names come from BlueZ, i.e. from whatever the device advertises.
+        snapshot = self._snapshot(speaker_offline={"name": '<b>"Bad"</b>', "kind": "bluetooth"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertNotIn("<b>", html)
+        self.assertIn("&lt;b&gt;", html)
+
+    def test_speaker_pill_falls_back_to_generic_name(self) -> None:
+        # BlueZ returns an empty name for a device that has never been resolved.
+        snapshot = self._snapshot(speaker_offline={"name": "", "kind": "bluetooth"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertIn("<span>Speaker offline</span>", html)
+
+    def test_speaker_pill_precedes_alarm_badge(self) -> None:
+        # Ordering is load-bearing: a speaker that's off means the alarm won't be heard,
+        # so the badge has to land ahead of the alarm badge, not after it.
+        snapshot = self._snapshot(
+            speaker_offline={"name": "Living Room", "kind": "bluetooth"},
+            active_alarm={"label": "Wake up"},
+        )
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertLess(html.index(self._SPEAKER_PILL_MARKUP), html.index("Alarm ringing"))
+
     def test_only_first_clock_used_if_multiple_provided(self) -> None:
         # Even if multiple clocks are provided, only the first one is rendered
         clocks = (

--- a/tests/test_speaker.py
+++ b/tests/test_speaker.py
@@ -1,0 +1,168 @@
+"""Tests for speaker reachability detection."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from pulse.speaker import (
+    SpeakerConfig,
+    bt_connected,
+    check_speaker,
+    resolve_bt_mac,
+    wired_sink_present,
+)
+
+# Trimmed to the lines the parser cares about.
+_INFO_CONNECTED = """Device AA:BB:CC:DD:EE:FF (public)
+\tName: Living Room
+\tAlias: Living Room
+\tPaired: yes
+\tConnected: yes
+"""
+
+_INFO_DISCONNECTED = _INFO_CONNECTED.replace("Connected: yes", "Connected: no")
+
+_DEVICES_PAIRED = "Device AA:BB:CC:DD:EE:FF Living Room\nDevice 11:22:33:44:55:66 Other Speaker\n"
+
+_SINKS_SHORT = (
+    "72\talsa_output.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.analog-stereo\tPipeWire\ts24le 2ch\tSUSPENDED\n"
+    "74\talsa_output.usb-C-Media_Electronics_Inc._USB_Audio_Device-00.analog-stereo\tPipeWire\ts16le 2ch\tSUSPENDED\n"
+)
+
+
+def _patch_run(side_effect):
+    return mock.patch("pulse.speaker._run", side_effect=side_effect)
+
+
+class BtConnectedTests(unittest.TestCase):
+    def test_reports_connected(self) -> None:
+        with _patch_run(lambda args: _INFO_CONNECTED):
+            self.assertIs(bt_connected("AA:BB:CC:DD:EE:FF"), True)
+
+    def test_reports_disconnected(self) -> None:
+        with _patch_run(lambda args: _INFO_DISCONNECTED):
+            self.assertIs(bt_connected("AA:BB:CC:DD:EE:FF"), False)
+
+    def test_unknown_when_bluetoothctl_fails(self) -> None:
+        # Distinct from False: a wedged or missing BlueZ must not be reported as a
+        # speaker someone needs to go power-cycle.
+        with _patch_run(lambda args: None):
+            self.assertIsNone(bt_connected("AA:BB:CC:DD:EE:FF"))
+
+    def test_unknown_when_device_not_in_bluez(self) -> None:
+        with _patch_run(lambda args: "Device AA:BB:CC:DD:EE:FF not available\n"):
+            self.assertIsNone(bt_connected("AA:BB:CC:DD:EE:FF"))
+
+
+class ResolveBtMacTests(unittest.TestCase):
+    def test_configured_mac_wins_and_picks_up_its_name(self) -> None:
+        with _patch_run(lambda args: _DEVICES_PAIRED):
+            self.assertEqual(resolve_bt_mac("aa:bb:cc:dd:ee:ff"), ("AA:BB:CC:DD:EE:FF", "Living Room"))
+
+    def test_configured_mac_kept_even_when_not_paired(self) -> None:
+        # The speaker being absent from BlueZ is exactly the condition we're detecting,
+        # so an unmatched MAC must still be watched — just without a friendly name.
+        with _patch_run(lambda args: ""):
+            self.assertEqual(resolve_bt_mac("AA:BB:CC:DD:EE:FF"), ("AA:BB:CC:DD:EE:FF", ""))
+
+    def test_malformed_mac_is_ignored(self) -> None:
+        with _patch_run(lambda args: _DEVICES_PAIRED):
+            self.assertEqual(resolve_bt_mac("not-a-mac"), ("", ""))
+
+    def test_falls_back_to_first_paired_device(self) -> None:
+        with _patch_run(lambda args: "" if args[2] == "Connected" else _DEVICES_PAIRED):
+            self.assertEqual(resolve_bt_mac(""), ("AA:BB:CC:DD:EE:FF", "Living Room"))
+
+    def test_nothing_to_watch_when_no_devices(self) -> None:
+        with _patch_run(lambda args: ""):
+            self.assertEqual(resolve_bt_mac(""), ("", ""))
+
+
+class WiredSinkTests(unittest.TestCase):
+    def test_finds_sink_by_substring(self) -> None:
+        with _patch_run(lambda args: _SINKS_SHORT):
+            self.assertIs(wired_sink_present("C-Media"), True)
+
+    def test_missing_sink(self) -> None:
+        with _patch_run(lambda args: _SINKS_SHORT):
+            self.assertIs(wired_sink_present("Unitek"), False)
+
+    def test_ignores_monitor_sinks(self) -> None:
+        sinks = "1\talsa_output.usb-C-Media_Foo.analog-stereo.monitor\tPipeWire\ts16le\tIDLE\n"
+        with _patch_run(lambda args: sinks):
+            self.assertIs(wired_sink_present("C-Media"), False)
+
+    def test_unknown_when_pactl_fails(self) -> None:
+        with _patch_run(lambda args: None):
+            self.assertIsNone(wired_sink_present("C-Media"))
+
+
+class CheckSpeakerTests(unittest.TestCase):
+    def test_bluetooth_offline(self) -> None:
+        def run(args: list[str]) -> str:
+            return _DEVICES_PAIRED if args[1] == "devices" else _INFO_DISCONNECTED
+
+        with _patch_run(run):
+            status = check_speaker(SpeakerConfig(bt_autoconnect=True, bt_mac="AA:BB:CC:DD:EE:FF"))
+        assert status is not None
+        self.assertTrue(status.offline)
+        self.assertEqual(status.name, "Living Room")
+        self.assertEqual(status.kind, "bluetooth")
+
+    def test_bluetooth_online(self) -> None:
+        def run(args: list[str]) -> str:
+            return _DEVICES_PAIRED if args[1] == "devices" else _INFO_CONNECTED
+
+        with _patch_run(run):
+            status = check_speaker(SpeakerConfig(bt_autoconnect=True, bt_mac="AA:BB:CC:DD:EE:FF"))
+        assert status is not None
+        self.assertFalse(status.offline)
+
+    def test_no_opinion_when_nothing_configured(self) -> None:
+        # A display with autoconnect off and no wired sink named has no expectation to
+        # violate, so it must never show the badge.
+        with _patch_run(lambda args: _SINKS_SHORT):
+            self.assertIsNone(check_speaker(SpeakerConfig(bt_autoconnect=False)))
+
+    def test_stale_pairing_alone_does_not_trigger(self) -> None:
+        # pulse-office keeps a pairing to a speaker that now lives in the kitchen. With
+        # autoconnect off that pairing must be invisible here, or the badge would never
+        # clear on a re-purposed display.
+        with _patch_run(lambda args: _DEVICES_PAIRED):
+            self.assertIsNone(check_speaker(SpeakerConfig(bt_autoconnect=False, bt_mac="AA:BB:CC:DD:EE:FF")))
+
+    def test_wired_speaker_unplugged(self) -> None:
+        config = SpeakerConfig(bt_autoconnect=False, wired_sink="Unitek")
+        with _patch_run(lambda args: _SINKS_SHORT):
+            status = check_speaker(config)
+        assert status is not None
+        self.assertTrue(status.offline)
+        self.assertEqual(status.kind, "wired")
+
+    def test_wired_speaker_present(self) -> None:
+        config = SpeakerConfig(bt_autoconnect=False, wired_sink="C-Media")
+        with _patch_run(lambda args: _SINKS_SHORT):
+            status = check_speaker(config)
+        assert status is not None
+        self.assertFalse(status.offline)
+
+    def test_falls_through_to_wired_when_no_bluetooth_device_exists(self) -> None:
+        # Autoconnect defaults to true, so a wired-speaker display that never turned it
+        # off would otherwise get stuck on the Bluetooth branch and skip its own check.
+        def run(args: list[str]) -> str:
+            return "" if args[0] == "bluetoothctl" else _SINKS_SHORT
+
+        with _patch_run(run):
+            status = check_speaker(SpeakerConfig(bt_autoconnect=True, wired_sink="Unitek"))
+        assert status is not None
+        self.assertTrue(status.offline)
+        self.assertEqual(status.kind, "wired")
+
+    def test_probe_failure_is_not_an_outage(self) -> None:
+        with _patch_run(lambda args: None):
+            self.assertIsNone(check_speaker(SpeakerConfig(bt_autoconnect=True, bt_mac="AA:BB:CC:DD:EE:FF")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speaker.py
+++ b/tests/test_speaker.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import unittest
-from unittest import mock
+from unittest.mock import patch
 
 from pulse.speaker import (
     SpeakerConfig,
@@ -32,7 +32,7 @@ _SINKS_SHORT = (
 
 
 def _patch_run(side_effect):
-    return mock.patch("pulse.speaker._run", side_effect=side_effect)
+    return patch("pulse.speaker._run", side_effect=side_effect)
 
 
 class BtConnectedTests(unittest.TestCase):
@@ -97,6 +97,14 @@ class WiredSinkTests(unittest.TestCase):
         with _patch_run(lambda args: None):
             self.assertIsNone(wired_sink_present("C-Media"))
 
+    def test_blank_token_is_unknown_not_present(self) -> None:
+        # An empty needle is a substring of every sink name, so the naive answer here is
+        # True — i.e. "speaker fine" for a display nobody named a sink for. Reporting a
+        # silent room as healthy is the one mistake this module can't afford.
+        with _patch_run(lambda args: _SINKS_SHORT):
+            self.assertIsNone(wired_sink_present(""))
+            self.assertIsNone(wired_sink_present("   "))
+
 
 class CheckSpeakerTests(unittest.TestCase):
     def test_bluetooth_offline(self) -> None:
@@ -124,6 +132,12 @@ class CheckSpeakerTests(unittest.TestCase):
         # violate, so it must never show the badge.
         with _patch_run(lambda args: _SINKS_SHORT):
             self.assertIsNone(check_speaker(SpeakerConfig(bt_autoconnect=False)))
+
+    def test_whitespace_only_sink_counts_as_unconfigured(self) -> None:
+        # Same trap as the blank needle, one level up: a truthy-but-blank setting must
+        # not make a display look like it has a wired speaker being watched.
+        with _patch_run(lambda args: _SINKS_SHORT):
+            self.assertIsNone(check_speaker(SpeakerConfig(bt_autoconnect=False, wired_sink="   ")))
 
     def test_stale_pairing_alone_does_not_trigger(self) -> None:
         # pulse-office keeps a pairing to a speaker that now lives in the kitchen. With


### PR DESCRIPTION
## Why

A speaker that has been switched off or unplugged fails **silently** on Pulse. Playback still "succeeds", snapclient stays connected to the server, the overlay looks perfectly healthy — the room just stops making sound. The only evidence is bluetoothd retrying in the journal, roughly every 15s forever:

```
profiles/audio/avdtp.c:avdtp_connect_cb() connect to AA:BB:CC:DD:EE:FF: Host is down (112)
```

Nobody reads the journal, so a room can stay silent for days. On the fleet this was written against, two of four displays were in exactly this state, each having logged ~240 retries in the previous 24h.

## What

`pulse/speaker.py` answers "is the configured speaker reachable", and an amber badge appears in the notification bar only while it isn't.

There is deliberately **no healthy-state badge** — a permanent green pill would train everyone to stop reading the bar. This shows up only when the room has gone quiet for a reason a person can fix, and says which fix: `Living Room offline` (power-cycle it) for Bluetooth, `Speaker unplugged` (check the cables) for wired.

### Design notes

- **Which speaker gets watched** follows the same rules `bin/bt-autoconnect.sh` uses (explicit `PULSE_BT_MAC` → connected → first paired), so the badge and the reconnect loop can never disagree about which speaker a room owns.
- **BlueZ pairings don't count on their own.** A re-purposed display keeps stale pairings to speakers that now live in other rooms; alerting on pairings would give it a badge that never clears. The source of truth is what `pulse.conf` says the display should be driving.
- **Placement is ahead of the alarm badges** — a speaker that's off means the alarm sitting next to it won't be heard either.
- **Debounced on the way up, instant on the way down.** Two consecutive failed checks are required before the badge appears (riding out A2DP renegotiation blips and the ~15s post-reboot autoconnect window); it clears on the first successful check.
- **A check that can't run is "unknown", never "offline".** A momentarily busy BlueZ must not tell someone to go power-cycle a speaker that is playing fine.
- **Amber, not the earmuffs red.** Red on this bar already means "earmuffs are on", a deliberate user choice; a broken speaker shouldn't read as the same kind of thing at a glance.

### Wired speakers

Covered too, via the new `PULSE_SPEAKER_SINK`: name the sink the display expects (a substring matched against `pactl list sinks short`) and the same badge appears when it disappears. Off by default — without a name to expect there is no way to distinguish "unplugged" from "never had one".

## New config

| Key | Default | Description |
|---|---|---|
| `PULSE_SPEAKER_ALERT` | `true` | Show the badge while the configured speaker is unreachable. |
| `PULSE_SPEAKER_SINK` | *(empty)* | Expected wired sink substring, for non-Bluetooth displays. |
| `PULSE_SPEAKER_INTERVAL` | `60` | Seconds between checks (min 15). |

Both existing Bluetooth variables (`PULSE_BLUETOOTH_AUTOCONNECT`, `PULSE_BT_MAC`) are reused as-is, so Bluetooth rooms need no config change to get the badge.

## Testing

- Full suite passes (1956 tests); adds `tests/test_speaker.py` (17 cases) and 6 overlay-rendering cases.
- ruff lint + format clean, bandit clean.
- Detection verified against real hardware in all four states: Bluetooth speaker powered off → `offline=True`; Bluetooth speaker connected → `offline=False`; wired display with nothing configured → no opinion; wired display with a matching sink → `offline=False`, and with a non-matching one → `offline=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Background polling and overlay UI only; probe failures are treated as unknown, and behavior is covered by unit tests with no auth or data-path changes.
> 
> **Overview**
> Adds **speaker reachability monitoring** so a powered-off Bluetooth speaker or missing wired sink is visible on the overlay instead of failing silently.
> 
> New **`pulse/speaker.py`** probes the room’s configured output via `bluetoothctl` / `pactl`, using the same MAC resolution order as **`bin/bt-autoconnect.sh`**. Unconfigured displays and failed probes return “no opinion” so stale pairings or wedged BlueZ do not flash a false alarm. **`kiosk-mqtt-listener.py`** runs a background poll (`PULSE_SPEAKER_ALERT`, `PULSE_SPEAKER_INTERVAL`, reuses `PULSE_BT_MAC` / `PULSE_BLUETOOTH_AUTOCONNECT`; optional **`PULSE_SPEAKER_SINK`** for wired), debounces **two** consecutive offline reads before updating state, and clears on the first good read.
> 
> **`OverlayStateManager`** gains `speaker_offline` and **`_build_speaker_pill`** renders an amber **`overlay-badge--speaker-offline`** ahead of alarm badges, with Bluetooth vs wired copy. Config docs and **`pulse.conf.sample`** document the new keys. Tests cover **`check_speaker`** and overlay HTML ordering/escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ac74d75ea766ba03eef8b26231121458bc89a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->