### PR TITLE
fix(mqtt): publish select options that match the states we publish

### DIFF
--- a/pulse/assistant/mqtt_publisher.py
+++ b/pulse/assistant/mqtt_publisher.py
@@ -216,6 +216,37 @@ class AssistantMqttPublisher:
         """
         return [label for _, label in self._sound_options.get(kind, [])]
 
+    def _get_all_sound_labels(self) -> list[str]:
+        """Get every sound label across all kinds, de-duplicated.
+
+        ``ha_tone_sound`` holds an arbitrary sound_id — PULSE_ASSISTANT_HA_TONE_SOUND
+        accepts any sound in the library, not just notification-kind ones — so its
+        select must offer every sound. Scoping it to "notification" meant a device
+        configured with, say, ``alarm-sonar`` published a state that was not in its
+        own options list, and Home Assistant rejected it with
+        "Invalid option for select.<device>_ha_tone_sound".
+
+        Returns:
+            Sorted list of unique sound labels
+        """
+        labels = {label for options in self._sound_options.values() for _, label in options}
+        return sorted(labels, key=str.lower)
+
+    def _get_sound_label_by_id_any(self, sound_id: str) -> str | None:
+        """Look up a sound label by ID across all kinds.
+
+        Args:
+            sound_id: Sound ID to look up
+
+        Returns:
+            Sound label, or None if no kind knows this ID
+        """
+        for options in self._sound_options.values():
+            for sid, label in options:
+                if sid == sound_id:
+                    return label
+        return None
+
     def _get_sound_id_by_label(self, kind: str, label: str) -> str | None:
         """Look up sound_id from its label.
 
@@ -470,7 +501,7 @@ class AssistantMqttPublisher:
         self._publish_preference_state("wake_sensitivity", preferences.wake_sensitivity)
         self._publish_preference_state("ha_response_mode", preferences.ha_response_mode)
 
-        tone_label = self._get_sound_label_by_id("notification", preferences.ha_tone_sound) or preferences.ha_tone_sound
+        tone_label = self._get_sound_label_by_id_any(preferences.ha_tone_sound) or preferences.ha_tone_sound
         self._publish_preference_state("ha_tone_sound", tone_label)
         self._publish_preference_state("ha_pipeline", active_pipeline or "")
         self._publish_preference_state("llm_provider", active_provider)
@@ -492,6 +523,10 @@ class AssistantMqttPublisher:
             hostname: Device hostname
             device_name: Human-readable device name
         """
+        # Imported here to avoid a circular dependency, matching the pattern in
+        # preference_manager._handle_llm_provider_command.
+        from pulse.assistant.llm import get_supported_providers
+
         device = {
             "identifiers": [f"pulse:{hostname}"],
             "manufacturer": "Pulse",
@@ -667,7 +702,7 @@ class AssistantMqttPublisher:
                     "unique_id": f"{hostname}-llm-provider",
                     "state_topic": f"{self._preferences_topic}/llm_provider/state",
                     "command_topic": f"{self._preferences_topic}/llm_provider/set",
-                    "options": ["openai", "gemini"],
+                    "options": list(get_supported_providers().keys()),
                     "device": device,
                     "entity_category": "config",
                 }
@@ -692,7 +727,7 @@ class AssistantMqttPublisher:
             retain=True,
         )
 
-        tone_options = self._get_sound_options_for_kind("notification")
+        tone_options = self._get_all_sound_labels()
         if tone_options:
             self._publish_message(
                 f"{prefix}/select/{hostname_safe}_ha_tone_sound/config",

--- a/pulse/assistant/preference_manager.py
+++ b/pulse/assistant/preference_manager.py
@@ -170,6 +170,39 @@ class PreferenceManager:
                 return sound_id
         return None
 
+    def get_sound_id_by_label_any(self, label: str) -> str | None:
+        """Look up sound_id from its label across all kinds.
+
+        Used by ha_tone_sound, whose select offers every sound rather than only
+        notification-kind ones, so a label may come from any kind.
+
+        Args:
+            label: Display label to look up
+
+        Returns:
+            Sound ID or None if no kind knows this label
+        """
+        for options in self._sound_options.values():
+            for sound_id, sound_label in options:
+                if sound_label == label:
+                    return sound_id
+        return None
+
+    def get_sound_label_by_id_any(self, sound_id: str) -> str | None:
+        """Look up label from sound_id across all kinds.
+
+        Args:
+            sound_id: Sound ID to look up
+
+        Returns:
+            Sound label or None if no kind knows this ID
+        """
+        for options in self._sound_options.values():
+            for sid, label in options:
+                if sid == sound_id:
+                    return label
+        return None
+
     def get_sound_label_by_id(self, kind: str, sound_id: str) -> str | None:
         """Look up label from sound_id.
 
@@ -352,11 +385,11 @@ class PreferenceManager:
         label = payload.strip()
         if not label:
             return
-        sound_id = self.get_sound_id_by_label("notification", label) or label
+        sound_id = self.get_sound_id_by_label_any(label) or label
         if sound_id == self.preferences.ha_tone_sound:
             return
         self.preferences = replace(self.preferences, ha_tone_sound=sound_id)
-        label_or_id = self.get_sound_label_by_id("notification", sound_id) or label
+        label_or_id = self.get_sound_label_by_id_any(sound_id) or label
         self.publisher._publish_preference_state("ha_tone_sound", label_or_id)
         persist_preference("ha_tone_sound", sound_id, logger=self.logger)
 

--- a/tests/test_mqtt_publisher.py
+++ b/tests/test_mqtt_publisher.py
@@ -452,6 +452,76 @@ def test_publish_assistant_discovery(publisher, mock_mqtt):
         assert call[1]["retain"] is True
 
 
+def _discovery_payload(mock_mqtt, suffix):
+    """Pull a published discovery payload by topic suffix."""
+    for call in mock_mqtt.publish.call_args_list:
+        topic = call[0][0] if call[0] else call[1].get("topic", "")
+        if topic.endswith(suffix):
+            payload = call[0][1] if len(call[0]) > 1 else call[1].get("payload")
+            return json.loads(payload)
+    raise AssertionError(f"no discovery config published for {suffix}")
+
+
+def test_llm_provider_discovery_lists_every_supported_provider(publisher, mock_mqtt):
+    """The select must offer every provider the command handler accepts.
+
+    It was hardcoded to ["openai", "gemini"], so a device running any other
+    provider published a state outside its own options and Home Assistant logged
+    "Invalid option for select.<device>_llm_provider: 'anthropic'".
+    """
+    from pulse.assistant.llm import get_supported_providers
+
+    publisher._publish_assistant_discovery(hostname="test-device", device_name="Test Device")
+    config = _discovery_payload(mock_mqtt, "_llm_provider/config")
+
+    assert config["options"] == list(get_supported_providers().keys())
+    assert "anthropic" in config["options"]
+
+
+def test_ha_tone_sound_discovery_offers_all_sound_kinds(publisher, mock_mqtt):
+    """ha_tone_sound holds an arbitrary sound_id, so its options span every kind.
+
+    Scoped to "notification" it excluded e.g. alarm-kind sounds, so a device
+    configured with one published an out-of-options state.
+    """
+    publisher._publish_assistant_discovery(hostname="test-device", device_name="Test Device")
+    config = _discovery_payload(mock_mqtt, "_ha_tone_sound/config")
+
+    # "Digital Rise" is alarm-kind in the fixture, "Soft Chime" is notification-kind
+    assert "Digital Rise" in config["options"]
+    assert "Soft Chime" in config["options"]
+
+
+def test_ha_tone_sound_state_resolves_non_notification_sound(publisher, mock_mqtt):
+    """A non-notification sound must publish its label, not the raw sound_id."""
+    preferences = Mock()
+    preferences.wake_sound = True
+    preferences.speaking_style = "normal"
+    preferences.wake_sensitivity = "high"
+    preferences.ha_response_mode = "full"
+    preferences.ha_tone_sound = "alarm-digital-rise"  # alarm-kind, not notification
+
+    publisher._publish_preferences(
+        preferences=preferences,
+        log_llm=True,
+        active_pipeline="test_pipeline",
+        active_provider="openai",
+        config_sounds=SoundSettings(
+            default_alarm="alarm-digital-rise",
+            default_timer="timer-woodblock",
+            default_reminder="reminder-marimba",
+            default_notification="notify-soft-chime",
+        ),
+    )
+
+    published = [
+        call[0][1] if len(call[0]) > 1 else call[1].get("payload")
+        for call in mock_mqtt.publish.call_args_list
+        if (call[0][0] if call[0] else "").endswith("/ha_tone_sound/state")
+    ]
+    assert published == ["Digital Rise"]
+
+
 def test_clone_schedule_snapshot(publisher):
     """Test cloning schedule snapshot."""
     snapshot = {


### PR DESCRIPTION
Two Home Assistant discovery payloads advertised option lists narrower than the states the device actually reports, so HA rejected valid states with `Invalid option for select.<device>_<entity>`. Seen on all four kiosks after a Home Assistant restart.

### `llm_provider`

Hardcoded `["openai", "gemini"]`, while `preference_manager._handle_llm_provider_command` accepts anything in `llm.SUPPORTED_PROVIDERS` (six providers) and `pulse.conf.sample` documents all six. A device running `anthropic` published a state outside its own options:

```
Invalid option for select.pulse_great_room_pulse_great_room_llm_provider:
  'anthropic' (valid options: ['openai', 'gemini'])
```

Now derived from `get_supported_providers()` so the two lists cannot drift again.

### `ha_tone_sound`

Options were scoped to notification-kind sounds, but the preference holds an arbitrary `sound_id` — `PULSE_ASSISTANT_HA_TONE_SOUND` accepts any sound in the library. A device configured with an alarm-kind sound failed the notification-scoped label lookup, fell back to publishing the raw id, and HA rejected it:

```
Invalid option for select.pulse_bedroom_pulse_bedroom_ha_tone_sound:
  'alarm-sonar' (valid options: ['Airy Pluck', ...])
```

The select now offers every sound, and label/id resolution spans all kinds (`_get_all_sound_labels`, `_get_sound_label_by_id_any`, `get_sound_id_by_label_any`) so the configured sound round-trips through HA.

### Testing

- 1932 tests pass; `ruff format --check`, `ruff check` and `mypy` clean.
- Three regression tests added, each verified to fail without the corresponding fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> MQTT/Home Assistant discovery and preference publishing only; no auth, data, or core assistant pipeline changes.
> 
> **Overview**
> Home Assistant was rejecting valid MQTT select states because discovery **options** were narrower than the values the device actually publishes. This PR aligns those lists so retained states stay valid after HA restarts.
> 
> For **`llm_provider`**, discovery no longer hardcodes `openai` and `gemini`; options come from **`get_supported_providers()`**, matching what `preference_manager` accepts and what gets published as state.
> 
> For **`ha_tone_sound`**, the preference can be any library sound ID, not only notification-kind sounds. Discovery now advertises **all** sound labels (`_get_all_sound_labels`), and label/id resolution spans every kind in both the publisher and preference handler (`*_by_id_any` / `get_sound_id_by_label_any`), so alarm-kind tones publish human labels instead of raw IDs like `alarm-sonar`.
> 
> Regression tests cover LLM provider options, cross-kind tone discovery, and non-notification tone state publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad78ce544e3af5381c62b4dff768017e370fe67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->