### PR TITLE
fix: send a real tone as the Bluetooth keepalive, not digital silence

### DIFF
--- a/bin/bt-autoconnect.sh
+++ b/bin/bt-autoconnect.sh
@@ -6,30 +6,52 @@ set -euo pipefail
 MAC="${PULSE_BT_MAC:-}"
 BOOT_SOUND="/opt/pulse-os/sounds/pulse-revived.wav"
 FLAG="/run/user/$(id -u)/pulse-boot-sound-played"
-KEEPALIVE_SOUND="/tmp/pulse-bt-keepalive.wav"
+KEEPALIVE_SOUND="/tmp/pulse-bt-keepalive-v2.wav"
 KEEPALIVE_INTERVAL=120  # Send keepalive every 2 minutes
 LAST_KEEPALIVE="/run/user/$(id -u)/pulse-bt-last-keepalive"
 
-# Generate keepalive sound file if it doesn't exist (very short, very quiet silence)
+# Generate the keepalive tone if it doesn't exist.
+#
+# This must NOT be digital silence. Speakers with auto-power-off decide they are idle
+# from the *signal*, not from whether an A2DP socket is open, so a buffer of zero
+# samples resets nothing and the speaker sleeps anyway -- and pw-play still exits 0,
+# so the failure is completely invisible. It also has to run long enough that PipeWire
+# does not suspend the bluez sink again milliseconds later.
+#
+# So: a 30 Hz tone at ~1.2% full scale for 2s. A small Bluetooth driver cannot
+# reproduce 30 Hz audibly, but the DSP sees a real signal and restarts its idle timer.
+# Amplitude stays well above the codec noise floor on purpose -- a few LSBs would risk
+# SBC quantising it back to silence, which is exactly the bug this replaces.
 generate_keepalive_sound() {
   if [ ! -f "$KEEPALIVE_SOUND" ]; then
-    # Generate a 0.1 second silent WAV file using Python
     python3 -c "
-import wave
+import math
 import struct
 import sys
+import wave
 
 sample_rate = 44100
-duration = 0.1  # 100ms
+duration = 2.0
+freq = 30.0        # below what a small BT speaker can reproduce
+amplitude = 400    # of 32767 -- inaudible, but not zero
+fade = int(sample_rate * 0.05)  # 50ms raised-cosine fade, avoids a click
+
 num_samples = int(sample_rate * duration)
-# Generate silence (all zeros)
-samples = b''.join([struct.pack('<h', 0) for _ in range(num_samples)])
+out = bytearray()
+for i in range(num_samples):
+    v = amplitude * math.sin(2.0 * math.pi * freq * i / sample_rate)
+    if i < fade:
+        v *= 0.5 * (1.0 - math.cos(math.pi * i / fade))
+    elif i > num_samples - fade:
+        j = num_samples - i
+        v *= 0.5 * (1.0 - math.cos(math.pi * j / fade))
+    out += struct.pack('<h', int(v))
 
 with wave.open(sys.argv[1], 'wb') as wav_file:
     wav_file.setnchannels(1)  # Mono
     wav_file.setsampwidth(2)  # 16-bit
     wav_file.setframerate(sample_rate)
-    wav_file.writeframes(samples)
+    wav_file.writeframes(bytes(out))
 " "$KEEPALIVE_SOUND" 2>/dev/null || true
   fi
 }

--- a/bin/bt-autoconnect.sh
+++ b/bin/bt-autoconnect.sh
@@ -184,8 +184,9 @@ if [ -n "$SINK" ] && pactl list sinks short | grep -q "$SINK"; then
 
     # Send keepalive if enough time has passed
     if [ "$time_diff" -ge "$KEEPALIVE_INTERVAL" ]; then
-      # Play silent keepalive to prevent speaker from auto-powering off
-      # The silent sound keeps the audio connection active
+      # Play the keepalive tone to prevent the speaker auto-powering off.
+      # It has to be an actual signal, not silence: the speaker judges idleness
+      # on what it receives, so zero samples would leave its timer running.
       pw-play --target "$SINK" "$KEEPALIVE_SOUND" >/dev/null 2>&1 || true
       echo "$current_time" > "$LAST_KEEPALIVE" 2>/dev/null || true
     fi


### PR DESCRIPTION
## Problem

`generate_keepalive_sound()` in `bin/bt-autoconnect.sh` built its WAV as `struct.pack('<h', 0)` repeated for 100 ms — **every sample is zero**. Verified on a running kiosk:

```
frames: 4410   rate: 44100   dur: 0.100s
nonzero bytes: 0
peak amplitude: 0
```

Bluetooth speakers with auto-power-off decide they are idle from the *signal*, not from whether an A2DP socket is nominally open. A buffer of zeros resets nothing, so the speaker powers itself off on schedule regardless — and `pw-play` still exits 0, so the failure is completely invisible. The keepalive appears to run every 2 minutes forever while doing nothing.

100 ms is also far too short to hold the link up: PipeWire suspends the bluez sink again within a second, so even a non-silent buffer that brief would be marginal.

The symptom is a speaker that "keeps silently turning off", followed by `bt-autoconnect` retrying an unreachable device indefinitely (`avdtp_connect_cb() ... Host is down (112)` at the backoff cap). On one kiosk this ran at a flat ~240 error lines/day continuously for over 5 days. That retry traffic is the same 2.4 GHz radio pressure #216 and #222 were about, so a dead keepalive quietly re-creates the condition those fixed.

## Fix

Generate a 30 Hz sine at ~1.2% full scale for 2 s instead:

- **30 Hz** — a small Bluetooth driver cannot reproduce it audibly, but the DSP sees a real signal and restarts its idle timer.
- **~1.2% FS (peak 399/32767)** — deliberately well above the codec noise floor. A few LSBs would risk SBC quantising it back to silence, which is exactly the bug being replaced.
- **2 s** — long enough that the sink is not suspended immediately.
- **50 ms raised-cosine fade** at each end to avoid a click.

The output file is renamed to `pulse-bt-keepalive-v2.wav`. The generator only writes the file `if [ ! -f ... ]`, so **without a new name every kiosk would keep reusing its existing zero-filled WAV** and the fix would look deployed while changing nothing.

## Verification

Generated from this branch:

```
dur 2.00s  peak 399 (1.22% FS)  nonzero=True
```

Played to a real speaker via `pw-play --target <bluez sink>`: exits 0, speaker stays connected, and the timer-driven keepalive stamp refreshes on its 120 s cadence.

Not yet confirmed over a full idle period — worth watching whether the `Host is down` retries stop on a kiosk whose speaker was previously sleeping. Anyone reviewing should also sanity-check that 30 Hz is inaudible on their own speaker; if any unit reproduces it, dropping the frequency or amplitude is the knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to optional keepalive audio generation in `bt-autoconnect.sh`; no auth, data, or core service logic touched.
> 
> **Overview**
> Fixes Bluetooth speakers auto-powering off despite periodic keepalives by changing what `bin/bt-autoconnect.sh` generates and plays every 120s.
> 
> **Keepalive WAV** is renamed to `pulse-bt-keepalive-v2.wav` so kiosks that already cached the old file regenerate instead of reusing all-zero samples. Generation switches from 100ms digital silence to a **2s, 30 Hz sine** at ~1.2% full scale with **50ms raised-cosine fades**, so the speaker DSP sees real audio (above SBC noise floor) and PipeWire is less likely to suspend the sink immediately.
> 
> Comments at generation and playback now document why silence fails invisibly (`pw-play` still exits 0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b8e62cd4e505370e87ed32b1385ceaa23035d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->