### PR TITLE
fix: recover when a speaker is connected but has no audio sink

### DIFF
--- a/bin/bt-autoconnect.sh
+++ b/bin/bt-autoconnect.sh
@@ -105,9 +105,49 @@ bt_is_connected() {
   bluetoothctl info "$MAC" 2>/dev/null | grep -q "Connected: yes"
 }
 
+# Is there actually an audio path, not just an ACL link?
+bt_sink_present() {
+  pactl list sinks short 2>/dev/null | grep -qi "bluez_output.${MAC//:/_}"
+}
+
+# WirePlumber only builds a bluez card when it observes the device *connect*. If
+# it restarts while the speaker is already connected — an update, a crash, a
+# manual restart — no card is ever created. bluetoothctl still says
+# "Connected: yes" and the ACL link genuinely is up, so nothing here noticed and
+# nothing logged an error, while the room had no audio path at all. That state
+# persisted for days on two displays before anyone spotted it.
+#
+# Re-issuing connect on the already-connected device makes BlueZ re-establish the
+# audio profile, which WirePlumber then picks up. Deliberately WITHOUT a
+# disconnect first: dropping the ACL link can convince a speaker it is idle so it
+# powers itself off, turning a self-healing state into one that needs somebody to
+# walk over and press a button.
+BT_NOSINK_COOLDOWN="${PULSE_BT_NOSINK_COOLDOWN:-60}"
+BT_NOSINK_STATE="/run/user/$(id -u)/pulse-bt-nosink"  # "<last_recovery_epoch>"
+
 if bt_is_connected; then
   # Already connected — clear any backoff state and carry on.
   rm -f "$BT_BACKOFF_STATE" 2>/dev/null || true
+
+  if bt_sink_present; then
+    rm -f "$BT_NOSINK_STATE" 2>/dev/null || true
+  else
+    # Connected but no sink. Rate-limit the retry so a device WirePlumber
+    # genuinely refuses cannot become a connect loop, and so we do not race the
+    # couple of seconds it normally takes to publish the card after a connect.
+    now=$(date +%s)
+    last_recover=0
+    if [ -f "$BT_NOSINK_STATE" ]; then
+      read -r last_recover < "$BT_NOSINK_STATE" 2>/dev/null || true
+      case "$last_recover" in ''|*[!0-9]*) last_recover=0 ;; esac
+    fi
+    if [ "$(( now - last_recover ))" -ge "$BT_NOSINK_COOLDOWN" ]; then
+      echo "$now" > "$BT_NOSINK_STATE" 2>/dev/null || true
+      # Fast on a reachable device: the ~60s block that motivated the backoff
+      # below only happens when the speaker is powered off, and we know it is not.
+      bluetoothctl connect "$MAC" >/dev/null 2>&1 || true
+    fi
+  fi
 else
   now=$(date +%s)
   next_attempt=0


### PR DESCRIPTION
## Problem

`bt_is_connected()` tests the **ACL link**, not whether audio can actually reach the speaker. Those are not the same thing.

WirePlumber only builds a bluez card when it *observes* a device connect. If WirePlumber restarts while the speaker is already connected — an update, a crash, a manual restart — it never creates a card for the existing connection. The result:

```
card=0  sink=0  conn=1        # bluetoothctl: "Connected: yes"
```

`bt_is_connected()` sees a healthy device, clears the backoff, and skips the reconnect. The room has **no audio path at all**, and because the link genuinely is up, nothing logs an error and nothing alarms. It just stays that way.

This had been true on two displays for long enough that it was invisible — they read as connected and healthy the entire time.

## Reproduction

Fully deterministic:

```
baseline:      card=1 sink=1
# systemctl --user restart wireplumber
fault induced: card=0 sink=0 conn=1
```

## Fix

Gate on whether a `bluez_output` sink exists, not just on the ACL link, and re-issue `connect` when it does not. BlueZ re-establishes the audio profile and WirePlumber picks it up.

**No disconnect first — deliberately.** Dropping the ACL link can convince a speaker it is idle so it powers itself off, turning a state the display can fix by itself into one that needs a person to walk over and press a button. That is not hypothetical; it happened while diagnosing this. A plain `connect` on the already-connected device is sufficient, which was confirmed before writing the fix:

```
after restart:       card=0 sink=0 conn=1
after plain connect: card=1 sink=1
```

Retries are rate-limited via `PULSE_BT_NOSINK_COOLDOWN` (default 60s) so that a device WirePlumber genuinely refuses cannot turn into a connect loop, and so we do not race the couple of seconds it normally takes to publish the card after a connect. The ~60s block that motivated the existing backoff only happens against a powered-off speaker, and this path only runs when the link is already up — so it is cheap here.

## Verification

Patched script run against the reproduced fault on a real display:

```
fault induced:   card=0 sink=0 conn=1
--- running PATCHED script ---
exit=0
after patched:   card=1 sink=1
cooldown state:  1787152199
```

Second run, now healthy — state file cleared, no redundant connect:

```
second run exit=0
cooldown state after healthy run: (cleared)
final: card=1 sink=1
```

## Relation to #238

Independent bug, same file. #238 fixed the keepalive that let speakers fall asleep in the first place; this fixes the case where the speaker is awake and linked but the audio path was never built. Rebased on top of #238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live Bluetooth reconnect behavior on room displays; mis-detection or cooldown bugs could cause extra connect attempts, though the path only runs when ACL is already up and retries are capped.
> 
> **Overview**
> **Fixes silent “connected but no audio” after WirePlumber restarts** by treating an ACL link as insufficient: `bt-autoconnect.sh` now checks for a `bluez_output` sink for the configured MAC, not only `bluetoothctl` “Connected: yes”.
> 
> When the link is up but no sink exists, it **re-issues `bluetoothctl connect`** (no disconnect) so BlueZ rebuilds the audio profile and WirePlumber can create the card. Retries are **rate-limited** via `PULSE_BT_NOSINK_COOLDOWN` (default 60s) and a per-user state file; the nosink state is cleared once a sink appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07edc887b61dd874e96fbbe3794bcfd07bf8c27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->