### PR TITLE
chore(deps): switch dependabot to the uv ecosystem and enforce lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
-  # Enable version updates for Python dependencies
-  # Note: pip does not auto-follow subdirectories, so the mcp-server
-  # project must be listed explicitly or its deps/advisories never get PRs.
-  - package-ecosystem: "pip"
+  # Enable version updates for Python dependencies.
+  # The uv ecosystem updates uv.lock alongside pyproject.toml, so lockfiles
+  # stay in step with the floors dependabot bumps.
+  # Note: subdirectories are not auto-followed, so the mcp-server project
+  # must be listed explicitly or its deps/advisories never get PRs.
+  - package-ecosystem: "uv"
     directories:
       - "/"
       - "/mcp-server"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,8 @@ jobs:
           filters: |
             python:
               - '**/*.py'
-              - 'pyproject.toml'
+              - '**/pyproject.toml'
+              - '**/uv.lock'
               - 'requirements*.txt'
 
   lint:
@@ -116,6 +117,15 @@ jobs:
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
           version: "latest"
+
+      # `uv sync --frozen` installs straight from the lockfile without
+      # validating it against pyproject.toml, so drift would silently test the
+      # old pinned versions. Check both projects explicitly.
+      - name: Lockfiles up to date
+        if: needs.changes.outputs.python == 'true' && matrix.python-version == '3.13'
+        run: |
+          uv lock --check
+          uv lock --check --directory mcp-server
 
       - name: Install dependencies
         if: needs.changes.outputs.python == 'true'


### PR DESCRIPTION
## Problem

`package-ecosystem: "pip"` only bumps version floors in `pyproject.toml` — it never touches `uv.lock`. Three sibling repos (`amcrest2mqtt`, `blink2mqtt`, `govee2mqtt`) had silently accumulated real drift this way.

Both lockfiles here happen to be in sync today, but the failure mode is worse in this repo than in the siblings: the test job runs `uv sync --frozen --dev`, which installs straight from the lockfile **without** validating it against `pyproject.toml`. Drift would therefore not fail — it would quietly test the *old* pinned versions while `pyproject.toml` claimed newer floors.

While adding the check I found a second, pre-existing gap. The `changes` path filter was:

```yaml
python:
  - '**/*.py'
  - 'pyproject.toml'        # root only
  - 'requirements*.txt'
```

`uv.lock` is absent and `pyproject.toml` is unanchored to root, which means:

- a dependabot PR touching **only** `uv.lock` skipped the Python job entirely, and
- `mcp-server/pyproject.toml` never matched, so **mcp-server dependency PRs never ran tests or `pip-audit` at all**.

## Fix

- **`dependabot.yml`: `pip` → `uv`.** Dependabot has supported the [`uv` ecosystem since March 2025](https://docs.astral.sh/uv/guides/integration/dependabot/) and updates `uv.lock` in its own PR commit. `directories:` is kept — subdirectories still are not auto-followed.
- **Check both lockfiles** (`uv lock --check` and `uv lock --check --directory mcp-server`), gated to 3.13 to keep one clear signal.
- **Widen the path filter** to `'**/pyproject.toml'` and `'**/uv.lock'` so dependency PRs — including mcp-server's — actually exercise the Python job.

## Verification

- Both lock checks pass on this branch.
- Negative-tested: bumping an `mcp-server` floor without re-locking makes `uv lock --check --directory mcp-server` fail as intended; restoring it passes. So the new check is not a no-op.
- `mcp-server` deps audited by hand for this change — no known vulnerabilities.
- Workflow YAML parses; step order confirmed.

## Context

Mirrors weirdtangent/amcrest2mqtt#88, already merged. There the switch is confirmed working end to end: dependabot re-ran as `uv in /. - Update` and completed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Dependabot and GitHub Actions workflow configuration; no runtime application code is modified.
> 
> **Overview**
> **Dependabot** now uses the **`uv`** ecosystem (root and **`mcp-server`**) so dependency PRs update **`uv.lock`** together with **`pyproject.toml`**, instead of only bumping floors under **`pip`**.
> 
> **CI** widens the Python change filter to **`**/pyproject.toml`** and **`**/uv.lock`**, so lock-only and **`mcp-server`** dependency updates run lint/tests/audit. On Python **3.13**, the test job runs **`uv lock --check`** for both projects before **`uv sync --frozen`**, catching lockfile drift that frozen sync would not surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d272f9968426b39f6d9b3da281289141260dffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->