### PR TITLE
chore(deps-dev): bump pip to 26.2.1 for PYSEC-2026-3721

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -691,11 +691,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.2"
+version = "26.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/15/4500e320e6b101ec3b719ae85b697d9940b6cda672bc555bd6016fc60c6f/pip-26.2.1.tar.gz", hash = "sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f", size = 1848877, upload-time = "2026-08-04T22:51:14.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6e/1736e5b4ae2b778ef2f81c47d797de9f891d4d8acb047a24ca37a60294dd/pip-26.2.1-py3-none-any.whl", hash = "sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e", size = 1816632, upload-time = "2026-08-04T22:51:12.472Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps the locked `pip` from 26.1.2 to 26.2.1.

## Why

`pip-audit` flags pip 26.1.2 under **PYSEC-2026-3721** (CVE-2026-13346, CVSS 3.1 `AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N`), fixed in pip 26.2.

The advisory range data was updated upstream on 2026-08-21, which is why CI was green yesterday and is not anymore. A red `pip-audit` turns `main` red, and that cascades to block every open dependabot PR in the repo — so this is worth landing ahead of the dependency queue.

## Risk

Minimal. `pip` is a **dev-only transitive dependency** (`pip-audit` → `pip-api` → `pip`); it is not a runtime dep and does not ship in the container image. The change is a 3-line lockfile edit with no `pyproject.toml` change.

Fixed by a lock bump rather than another `--ignore-vuln` entry, since a real fixed version exists.

## Verification

`pip-audit` run locally with this repo's exact CI ignore-list: **No known vulnerabilities found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only bump of a dev-only transitive dependency; not used at runtime or in the container image.
> 
> **Overview**
> Bumps locked `pip` from **26.1.2** to **26.2.1** to clear **PYSEC-2026-3721** (CVE-2026-13346) flagged by `pip-audit`.
> 
> `pip` is a **dev-only transitive** dep (`pip-audit` → `pip-api` → `pip`); no `pyproject.toml` or runtime/image change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01daaa3fe3eb3819da5fe1776ab9d6b0b20c4c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->