### PR TITLE
feat(overlay): expand device controls; tidy the config card

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Jeffrey Culverhouse
+Copyright (c) 2025-2026 Jeffrey Culverhouse
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1442,9 +1442,49 @@ body {
 }
 
 /* Config About Section */
+/* Typographic wordmark rather than a logo image. The old inline SVG was a 200x90 box
+   holding a heartbeat line and 11px of text, so most of its height was empty and it
+   pushed the actual settings down the card. Type carries the brand in a third of the
+   space, and the gradient keeps the identity. */
 .overlay-config-logo {
   text-align: center;
-  padding: 1rem 0 0.5rem;
+  padding: 0.25rem 0 0.75rem;
+}
+
+.overlay-config-logo__mark {
+  display: inline-block;
+  font-size: 1.55rem;
+  line-height: 1.1;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  /* The gradient the old SVG stroke used, so the wordmark reads as the same brand. */
+  background: linear-gradient(100deg, #ff6b35 0%, #ffd700 45%, #00d4ff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  /* Indent by the tracking, so the letter-spacing on the final glyph doesn't shift the
+     wordmark visually left of center. */
+  padding-left: 0.16em;
+}
+
+/* Weight, not color, separates the two words — they share one gradient sweep, so
+   coloring them apart would break it. */
+.overlay-config-logo__gray {
+  font-weight: 300;
+}
+
+.overlay-config-logo__pulse {
+  font-weight: 800;
+  margin-left: 0.18em;
+}
+
+/* Chromium on the Pi supports background-clip:text; this keeps the wordmark legible
+   anywhere that doesn't rather than rendering it invisible. */
+@supports not ((-webkit-background-clip: text) or (background-clip: text)) {
+  .overlay-config-logo__mark {
+    background: none;
+    color: #ffd700;
+  }
 }
 
 .overlay-config-about {

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -463,15 +463,35 @@ body {
   opacity: 0.75;
 }
 
+/* Rendered as an inline listbox (size=6), not a dropdown. A native popup holding every
+   installed font is taller than a 720px kiosk screen, so it opens against the top edge
+   and covers the display; this keeps the list inside the card and scrolls it instead. */
 .overlay-control__select {
   width: 100%;
-  padding: 0.55rem 0.75rem;
+  padding: 0.35rem;
   border-radius: 0.7rem;
   border: 1px solid rgba(255, 255, 255, 0.25);
   background: rgba(0, 0, 0, 0.35);
   color: inherit;
   font: inherit;
   font-size: 0.95rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--overlay-accent-color) transparent;
+}
+
+.overlay-control__select option {
+  padding: 0.4rem 0.55rem;
+  border-radius: 0.45rem;
+  /* Touch targets: this is a finger on a wall display, not a mouse. */
+  min-height: 2rem;
+  background: transparent;
+  color: inherit;
+}
+
+.overlay-control__select option:checked {
+  background: var(--overlay-accent-color);
+  color: #10233a;
+  font-weight: 600;
 }
 
 .overlay-device-actions {

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -444,6 +444,59 @@ body {
   position: relative;
 }
 
+/* Grouped targets (day/night) sit under the live brightness slider they belong to. */
+.overlay-control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.overlay-control-group__title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.overlay-control__select {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  font: inherit;
+  font-size: 0.95rem;
+}
+
+.overlay-device-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.overlay-device-actions .overlay-button {
+  flex: 1 1 auto;
+}
+
+/* Reboot is destructive enough to look it, but only shouts once armed — an always-red
+   button on a wall display becomes wallpaper. */
+.overlay-button--danger {
+  border-color: rgba(220, 50, 47, 0.6);
+}
+
+.overlay-button--danger.overlay-button--armed {
+  background: #dc322f;
+  border-color: rgba(255, 255, 255, 0.6);
+  color: #ffffff;
+  font-weight: 600;
+}
+
 .overlay-device-controls {
   display: flex;
   flex-direction: column;

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -561,7 +561,11 @@ body {
   gap: 0.6rem;
 }
 
+/* Sliders are horizontal, and this is a touchscreen: pan-y hands vertical drags to the
+   scroller so a finger swiping down a long card scrolls it instead of dragging whichever
+   slider it happened to cross. Without this, scrolling changed the brightness. */
 .overlay-control__slider {
+  touch-action: pan-y;
   flex: 1;
   accent-color: var(--overlay-accent-color);
 }

--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1018,6 +1018,14 @@ body {
   color: var(--overlay-accent-color);
 }
 
+/* The clock gets its own family. It is the one thing on screen rendered at 100px+, where a
+   face picked for legibility in a 14px badge often reads badly, so the two are chosen
+   separately. Falls back to the overlay font when no clock font is set. */
+.overlay-clock__time,
+.overlay-clock__date {
+  font-family: var(--overlay-clock-font-family, var(--overlay-font-family));
+}
+
 .overlay-clock__time {
   font-size: clamp(3.5rem, 8vw, 6.5rem);
   font-weight: 300;

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -45,11 +45,14 @@ window.PulseOverlay.initialize = function() {
   }
 
   if (window.PulseOverlay.eventHandlers) {
-    const { clickHandler, inputHandler, resizeHandler } = window.PulseOverlay.eventHandlers;
+    const { clickHandler, inputHandler, changeHandler, resizeHandler } = window.PulseOverlay.eventHandlers;
     const oldRoot = window.PulseOverlay.eventHandlers.root;
     if (oldRoot) {
       oldRoot.removeEventListener('click', clickHandler);
       oldRoot.removeEventListener('input', inputHandler);
+      if (changeHandler) {
+        oldRoot.removeEventListener('change', changeHandler);
+      }
     }
     if (resizeHandler) {
       window.removeEventListener('resize', resizeHandler);
@@ -500,7 +503,6 @@ window.PulseOverlay.initialize = function() {
       return;
     }
   };
-  document.addEventListener('change', changeHandler);
 
   // Handle stop timer button clicks
   const clickHandler = (e) => {
@@ -582,7 +584,14 @@ window.PulseOverlay.initialize = function() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'reboot_device' })
       }).catch(() => {
+        // Disarm fully on failure. Leaving it armed meant the next single tap would
+        // reboot with no confirmation at all, which is the opposite of the point.
         rebootButton.disabled = false;
+        rebootButton.dataset.armed = 'false';
+        rebootButton.classList.remove('overlay-button--armed');
+        if (rebootButton.dataset.idleLabel) {
+          rebootButton.innerHTML = rebootButton.dataset.idleLabel;
+        }
       });
       return;
     }
@@ -946,12 +955,14 @@ window.PulseOverlay.initialize = function() {
   // Attach event listeners
   root.addEventListener('click', clickHandler);
   root.addEventListener('input', inputHandler);
+  root.addEventListener('change', changeHandler);
 
   // Store handler references for cleanup on next initialization
   window.PulseOverlay.eventHandlers = {
     root,
     clickHandler,
     inputHandler,
+    changeHandler,
     resizeHandler
   };
 })();

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -380,7 +380,11 @@ window.PulseOverlay.initialize = function() {
                            !wrapper.classList.contains('overlay-info-card__text-wrapper');
 
       if (needsWrapper) {
-        // Create wrapper if needed
+        // Moving an element to a new parent resets its scrollTop, and the refresh loop
+        // re-renders the card (losing the wrapper) on every state change, so this ran
+        // again each time and snapped anyone reading a long card back to the top ~100ms
+        // after they scrolled. Capture the offset across the re-parent and put it back.
+        const preservedScroll = scrollableElement.scrollTop;
         wrapper = document.createElement('div');
         if (scrollableElement.classList.contains('overlay-info-card__body')) {
           wrapper.className = 'overlay-info-card__body-wrapper';
@@ -389,6 +393,9 @@ window.PulseOverlay.initialize = function() {
         }
         scrollableElement.parentElement.insertBefore(wrapper, scrollableElement);
         wrapper.appendChild(scrollableElement);
+        if (preservedScroll > 0) {
+          scrollableElement.scrollTop = preservedScroll;
+        }
       }
 
       // Create arrows if they don't exist

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -477,19 +477,28 @@ window.PulseOverlay.initialize = function() {
     }, 100);
   }
 
+  // The overlay font and the clock font are separate pickers posting separate actions.
+  const FONT_SELECT_ACTIONS = [
+    { attribute: '[data-font-select]', action: 'set_font' },
+    { attribute: '[data-clock-font-select]', action: 'set_clock_font' }
+  ];
+
   const changeHandler = (e) => {
-    const fontSelect = e.target.closest('[data-font-select]');
-    if (!fontSelect) {
+    for (const { attribute, action } of FONT_SELECT_ACTIONS) {
+      const select = e.target.closest(attribute);
+      if (!select) {
+        continue;
+      }
+      select.disabled = true;
+      fetch(infoEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action, font: select.value })
+      }).finally(() => {
+        select.disabled = false;
+      });
       return;
     }
-    fontSelect.disabled = true;
-    fetch(infoEndpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ action: 'set_font', font: fontSelect.value })
-    }).finally(() => {
-      fontSelect.disabled = false;
-    });
   };
   document.addEventListener('change', changeHandler);
 

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -110,8 +110,21 @@ window.PulseOverlay.initialize = function() {
     }
   };
 
+  // Explicit map rather than a ternary. This was `kind === 'brightness' ? ... : 'set_volume'`,
+  // which silently routes every unknown slider to the volume endpoint — so adding the
+  // day/night brightness targets would have made those sliders change the volume instead.
+  const DEVICE_CONTROL_ACTIONS = {
+    brightness: 'set_brightness',
+    volume: 'set_volume',
+    day_brightness: 'set_day_brightness',
+    night_brightness: 'set_night_brightness'
+  };
+
   const sendDeviceControl = (kind, value) => {
-    const action = kind === 'brightness' ? 'set_brightness' : 'set_volume';
+    const action = DEVICE_CONTROL_ACTIONS[kind];
+    if (!action) {
+      return Promise.resolve();
+    }
     return fetch(infoEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -457,6 +470,22 @@ window.PulseOverlay.initialize = function() {
     }, 100);
   }
 
+  const changeHandler = (e) => {
+    const fontSelect = e.target.closest('[data-font-select]');
+    if (!fontSelect) {
+      return;
+    }
+    fontSelect.disabled = true;
+    fetch(infoEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'set_font', font: fontSelect.value })
+    }).finally(() => {
+      fontSelect.disabled = false;
+    });
+  };
+  document.addEventListener('change', changeHandler);
+
   // Handle stop timer button clicks
   const clickHandler = (e) => {
     const closeCardButton = e.target.closest('[data-info-card-close]');
@@ -504,6 +533,41 @@ window.PulseOverlay.initialize = function() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       }).finally(resetOpacity);
+      return;
+    }
+
+    // Reboot is armed by the first tap and fires on the second. This card is a
+    // touchscreen on a wall; one stray press must not be able to restart the room.
+    const rebootButton = e.target.closest('[data-reboot-button]');
+    if (rebootButton) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (rebootButton.dataset.armed !== 'true') {
+        rebootButton.dataset.armed = 'true';
+        rebootButton.dataset.idleLabel = rebootButton.innerHTML;
+        rebootButton.textContent = rebootButton.getAttribute('data-confirm-label') || 'Tap again to confirm';
+        rebootButton.classList.add('overlay-button--armed');
+        // Disarm on its own, so a card left open doesn't sit armed indefinitely.
+        window.clearTimeout(rebootButton._disarm);
+        rebootButton._disarm = window.setTimeout(() => {
+          rebootButton.dataset.armed = 'false';
+          rebootButton.classList.remove('overlay-button--armed');
+          if (rebootButton.dataset.idleLabel) {
+            rebootButton.innerHTML = rebootButton.dataset.idleLabel;
+          }
+        }, 5000);
+        return;
+      }
+      window.clearTimeout(rebootButton._disarm);
+      rebootButton.disabled = true;
+      rebootButton.textContent = 'Rebooting…';
+      fetch(infoEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reboot_device' })
+      }).catch(() => {
+        rebootButton.disabled = false;
+      });
       return;
     }
 

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -847,20 +847,7 @@ class KioskMqttListener:
                 self.log("weather-alerts: enabled but PULSE_LOCATION did not resolve — alerts disabled")
             if self._weather_alert_client and self.overlay_config.weather_alerts_sound:
                 self._weather_alert_sound_path = self._resolve_weather_alert_sound()
-            self._overlay_theme = OverlayTheme(
-                ambient_background=self.overlay_config.ambient_background,
-                alert_background=self.overlay_config.alert_background,
-                text_color=self.overlay_config.text_color,
-                accent_color=self.overlay_config.accent_color,
-                show_notification_bar=self.overlay_config.show_notification_bar,
-                font_family=self._current_font_stack,
-                show_ticker=self.overlay_config.ticker_enabled,
-                ticker_scroll_speed=self.overlay_config.ticker_speed,
-                ticker_emoji=self.overlay_config.ticker_emoji,
-                ticker_label_mode=self.overlay_config.ticker_label_mode,
-                weather_alert_banner_minutes=self.overlay_config.weather_alerts_banner_minutes,
-                weather_alert_rotate_seconds=self.overlay_config.weather_alerts_rotate_seconds,
-            )
+            self._overlay_theme = self._build_overlay_theme(self._current_font_stack)
             self._overlay_topic_handlers = {
                 self.assistant_topics.schedules_state: self._handle_overlay_schedule_state,
                 self.assistant_topics.alarms_active: lambda payload: self._handle_overlay_active_event(
@@ -1452,6 +1439,29 @@ class KioskMqttListener:
                 return f"{quoted}, {base_stack}" if base_stack else quoted
         return base_stack or DEFAULT_FONT_STACK
 
+    def _build_overlay_theme(self, font_stack: str) -> OverlayTheme:
+        """Single construction site for OverlayTheme.
+
+        It used to be built in two places — once at startup and again whenever the font
+        changed — which meant every new theme field had to be added twice or a font change
+        would silently reset it to the dataclass default. That is exactly what happened to
+        the weather-alert fields.
+        """
+        return OverlayTheme(
+            ambient_background=self.overlay_config.ambient_background,
+            alert_background=self.overlay_config.alert_background,
+            text_color=self.overlay_config.text_color,
+            accent_color=self.overlay_config.accent_color,
+            show_notification_bar=self.overlay_config.show_notification_bar,
+            font_family=font_stack,
+            show_ticker=self.overlay_config.ticker_enabled,
+            ticker_scroll_speed=self.overlay_config.ticker_speed,
+            ticker_emoji=self.overlay_config.ticker_emoji,
+            ticker_label_mode=self.overlay_config.ticker_label_mode,
+            weather_alert_banner_minutes=self.overlay_config.weather_alerts_banner_minutes,
+            weather_alert_rotate_seconds=self.overlay_config.weather_alerts_rotate_seconds,
+        )
+
     def _apply_overlay_font_choice(self, reason: str) -> None:
         new_stack = self._resolve_font_stack()
         if new_stack == self._current_font_stack:
@@ -1459,18 +1469,7 @@ class KioskMqttListener:
         self._current_font_stack = new_stack
         if not self.overlay_config.enabled:
             return
-        self._overlay_theme = OverlayTheme(
-            ambient_background=self.overlay_config.ambient_background,
-            alert_background=self.overlay_config.alert_background,
-            text_color=self.overlay_config.text_color,
-            accent_color=self.overlay_config.accent_color,
-            show_notification_bar=self.overlay_config.show_notification_bar,
-            font_family=new_stack,
-            show_ticker=self.overlay_config.ticker_enabled,
-            ticker_scroll_speed=self.overlay_config.ticker_speed,
-            ticker_emoji=self.overlay_config.ticker_emoji,
-            ticker_label_mode=self.overlay_config.ticker_label_mode,
-        )
+        self._overlay_theme = self._build_overlay_theme(new_stack)
         if self._overlay_http:
             self._overlay_http.theme = self._overlay_theme
         if self.overlay_state:

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -326,8 +326,11 @@ _CSS_GENERIC_FAMILIES = ("sans-serif", "serif", "monospace", "cursive", "fantasy
 
 def _with_generic_fallback(font_stack: str) -> str:
     stack = (font_stack or "").strip() or DEFAULT_FONT_STACK
-    lowered = stack.lower()
-    if any(generic in lowered for generic in _CSS_GENERIC_FAMILIES):
+    # Compare whole entries, not substrings: "DejaVu Serif" contains "serif", so a
+    # substring test reads a real family as a generic and skips the fallback that family
+    # needs. Split on commas and strip quotes so only an actual generic entry counts.
+    entries = {entry.strip().strip("\"'").lower() for entry in stack.split(",")}
+    if entries & set(_CSS_GENERIC_FAMILIES):
         return stack
     return f'{stack}, sans-serif, "Noto Color Emoji"'
 

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -318,6 +318,25 @@ def _extract_primary_font(font_stack: str) -> str | None:
     return None
 
 
+# Families fontconfig reports that are not usable as a UI typeface: symbol, dingbat, math,
+# and emoji sets. Picking one renders the overlay as gibberish, and on a 720px kiosk every
+# extra entry pushes the font list further up the screen. Text faces are all kept, including
+# the URW/Nimbus clones — those are perfectly good choices, just unfashionable ones.
+_NON_TEXT_FONT_FAMILIES = {
+    "d050000l",  # URW Dingbats
+    "standard symbols ps",
+    "dejavu math tex gyre",
+    "noto color emoji",
+    "noto emoji",
+    "droid sans fallback",  # CJK fallback, not a display face
+    "z003",  # URW Chancery, a script face that is unreadable at overlay sizes
+}
+
+
+def _is_non_text_font(name: str) -> bool:
+    return name.strip().casefold() in _NON_TEXT_FONT_FAMILIES
+
+
 def _detect_installed_fonts() -> list[str]:
     try:
         result = subprocess.run(  # nosec B603 B607 - hardcoded command array
@@ -1469,7 +1488,7 @@ class KioskMqttListener:
         )
 
     def _refresh_font_options(self) -> None:
-        fonts = _detect_installed_fonts()
+        fonts = [name for name in _detect_installed_fonts() if not _is_non_text_font(name)]
         primary = _extract_primary_font(self._default_font_stack)
         if primary:
             fonts.append(primary)

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -888,6 +888,10 @@ class KioskMqttListener:
                 on_set_volume=self._handle_overlay_volume_request,
                 on_set_brightness=self._handle_overlay_brightness_request,
                 get_device_levels=self._collect_device_control_snapshot,
+                on_set_font=self._handle_overlay_set_font,
+                on_set_brightness_target=self._handle_overlay_set_brightness_target,
+                on_go_home=self._handle_overlay_go_home,
+                on_reboot=self._handle_overlay_reboot,
                 on_media_control=self._handle_overlay_media_control,
             )
 
@@ -1301,7 +1305,40 @@ class KioskMqttListener:
             "volume_supported": True,
             "brightness": brightness,
             "brightness_supported": self._brightness_supported,
+            # Everything below already exists as a Home Assistant entity; the card just had
+            # no on-screen equivalent, which is backwards for a touchscreen on a wall.
+            "day_brightness": self._day_brightness,
+            "night_brightness": self._night_brightness,
+            "fonts": list(self._font_options),
+            "font": self._overlay_font_override or OVERLAY_FONT_DEFAULT_OPTION,
+            "home_supported": bool(self.config.pulse_url),
+            "reboot_supported": True,
         }
+
+    def _handle_overlay_set_font(self, choice: str) -> bool:
+        """Reuse the MQTT font handler so the display and Home Assistant can't diverge."""
+        if choice != OVERLAY_FONT_DEFAULT_OPTION and choice not in self._font_option_set:
+            self.log(f"overlay-font: '{choice}' is not an available font")
+            return False
+        self.handle_overlay_font(choice.encode())
+        return True
+
+    def _handle_overlay_set_brightness_target(self, kind: str, value: int) -> bool:
+        payload = str(value).encode()
+        if kind == "day":
+            self.handle_day_brightness(payload)
+        else:
+            self.handle_night_brightness(payload)
+        return True
+
+    def _handle_overlay_go_home(self) -> bool:
+        self.handle_home()
+        return True
+
+    def _handle_overlay_reboot(self) -> bool:
+        self.log("reboot: requested from the device controls card")
+        self.handle_reboot()
+        return True
 
     def _collect_now_playing_text(self) -> tuple[str, str, str]:
         """Return (display_text, ha_state, image_data_uri) for the media player."""

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -106,7 +106,9 @@ class OverlayConfig:
     accent_color: str
     show_notification_bar: bool
     clock_24h: bool
-    font_family: str
+    font_family: str  # configured default stack; never rewritten by a pick
+    font_choice: str  # overlay font picked on-screen or from HA ("" = use the default)
+    clock_font_choice: str  # clock font picked separately ("" = follow the overlay font)
     auth_token: str | None
     ticker_enabled: bool
     ticker_symbols: tuple[str, ...]
@@ -295,6 +297,10 @@ TELEMETRY_SENSORS: list[TelemetryDescriptor] = [
 ]
 
 OVERLAY_FONT_DEFAULT_OPTION = "System default"
+# The clock's "inherit" choice, distinct from the overlay's "System default".
+OVERLAY_CLOCK_FONT_DEFAULT_OPTION = "Same as overlay"
+# Sentinel so _resolve_font_stack can tell "no argument" from an explicit None.
+_UNSET = object()
 FONT_DETECT_TIMEOUT_SECONDS = 6
 
 
@@ -499,6 +505,12 @@ def load_config() -> EnvConfig:
     if resolved and resolved.timezone:
         overlay_clock_spec = f"{resolved.timezone}={friendly_name}"
     overlay_font_stack = (os.environ.get("PULSE_OVERLAY_FONT_FAMILY") or "").strip() or DEFAULT_FONT_STACK
+    # Separate from the stack above on purpose: PULSE_OVERLAY_FONT_FAMILY is the configured
+    # default and is never rewritten, so "System default" always means the same thing and a
+    # font picked on-screen can always be undone. The two used to share one variable, which
+    # meant the first pick destroyed the default permanently.
+    overlay_font_choice = (os.environ.get("PULSE_OVERLAY_FONT") or "").strip()
+    overlay_clock_font_choice = (os.environ.get("PULSE_OVERLAY_CLOCK_FONT") or "").strip()
     overlay_clocks = parse_clock_config(
         overlay_clock_spec,
         default_label=friendly_name,
@@ -521,6 +533,8 @@ def load_config() -> EnvConfig:
         show_notification_bar=parse_bool(os.environ.get("PULSE_OVERLAY_NOTIFICATION_BAR"), True),
         clock_24h=parse_bool(os.environ.get("PULSE_OVERLAY_CLOCK_24H"), False),
         font_family=overlay_font_stack,
+        font_choice=overlay_font_choice,
+        clock_font_choice=overlay_clock_font_choice,
         auth_token=(os.environ.get("PULSE_OVERLAY_AUTH_TOKEN") or "").strip() or None,
         ticker_enabled=parse_bool(os.environ.get("PULSE_TICKER_ENABLED"), False),
         ticker_symbols=tuple(parse_symbols(os.environ.get("PULSE_TICKER_SYMBOLS")) or ["^SPX", "^DJI", "^NDX"]),
@@ -798,7 +812,8 @@ class KioskMqttListener:
         self._overlay_http: OverlayHttpServer | None = None
         self._overlay_topic_handlers: dict[str, Any] = {}
         self._default_font_stack = (self.overlay_config.font_family or DEFAULT_FONT_STACK).strip() or DEFAULT_FONT_STACK
-        self._overlay_font_override: str | None = None
+        self._overlay_font_override: str | None = self.overlay_config.font_choice or None
+        self._overlay_clock_font_override: str | None = self.overlay_config.clock_font_choice or None
         self._current_font_stack = self._default_font_stack
         self._font_options: list[str] = []
         self._font_option_set: set[str] = set()
@@ -895,6 +910,7 @@ class KioskMqttListener:
                 on_set_brightness=self._handle_overlay_brightness_request,
                 get_device_levels=self._collect_device_control_snapshot,
                 on_set_font=self._handle_overlay_set_font,
+                on_set_clock_font=self._handle_overlay_set_clock_font,
                 on_set_brightness_target=self._handle_overlay_set_brightness_target,
                 on_go_home=self._handle_overlay_go_home,
                 on_reboot=self._handle_overlay_reboot,
@@ -1317,9 +1333,18 @@ class KioskMqttListener:
             "night_brightness": self._night_brightness,
             "fonts": list(self._font_options),
             "font": self._overlay_font_override or OVERLAY_FONT_DEFAULT_OPTION,
+            "clock_fonts": [OVERLAY_CLOCK_FONT_DEFAULT_OPTION, *self._font_options[1:]],
+            "clock_font": self._overlay_clock_font_override or OVERLAY_CLOCK_FONT_DEFAULT_OPTION,
             "home_supported": bool(self.config.pulse_url),
             "reboot_supported": True,
         }
+
+    def _handle_overlay_set_clock_font(self, choice: str) -> bool:
+        if choice != OVERLAY_CLOCK_FONT_DEFAULT_OPTION and choice not in self._font_option_set:
+            self.log(f"overlay-clock-font: '{choice}' is not an available font")
+            return False
+        self.handle_overlay_clock_font(choice.encode())
+        return True
 
     def _handle_overlay_set_font(self, choice: str) -> bool:
         """Reuse the MQTT font handler so the display and Home Assistant can't diverge."""
@@ -1431,13 +1456,25 @@ class KioskMqttListener:
         )
         self._safe_publish(client, self.config.topics.overlay_refresh, payload, qos=0, retain=False)
 
-    def _resolve_font_stack(self) -> str:
+    def _resolve_font_stack(self, override: str | None = _UNSET) -> str:  # type: ignore[assignment]
+        """Build a CSS stack: the chosen face first, then the configured default behind it.
+
+        The default always stays on the tail so a face missing its glyphs (or missing
+        entirely) still lands somewhere sensible rather than on the browser's generic.
+        """
+        chosen = self._overlay_font_override if override is _UNSET else override
         base_stack = self._default_font_stack or DEFAULT_FONT_STACK
-        if self._overlay_font_override:
-            quoted = _quote_font_name(self._overlay_font_override)
+        if chosen:
+            quoted = _quote_font_name(chosen)
             if quoted:
                 return f"{quoted}, {base_stack}" if base_stack else quoted
         return base_stack or DEFAULT_FONT_STACK
+
+    def _resolve_clock_font_stack(self) -> str:
+        """The clock's stack, or "" when it should just inherit the overlay font."""
+        if not self._overlay_clock_font_override:
+            return ""
+        return self._resolve_font_stack(self._overlay_clock_font_override)
 
     def _build_overlay_theme(self, font_stack: str) -> OverlayTheme:
         """Single construction site for OverlayTheme.
@@ -1454,6 +1491,7 @@ class KioskMqttListener:
             accent_color=self.overlay_config.accent_color,
             show_notification_bar=self.overlay_config.show_notification_bar,
             font_family=font_stack,
+            clock_font_family=self._resolve_clock_font_stack(),
             show_ticker=self.overlay_config.ticker_enabled,
             ticker_scroll_speed=self.overlay_config.ticker_speed,
             ticker_emoji=self.overlay_config.ticker_emoji,
@@ -1488,8 +1526,11 @@ class KioskMqttListener:
 
     def _refresh_font_options(self) -> None:
         fonts = [name for name in _detect_installed_fonts() if not _is_non_text_font(name)]
+        # Only add the configured default's primary if it is actually installed. The shipped
+        # default names "Inter", which is not on the Pi, so it appeared in the picker as a
+        # selectable font that silently rendered as something else entirely.
         primary = _extract_primary_font(self._default_font_stack)
-        if primary:
+        if primary and any(primary.casefold() == name.casefold() for name in fonts):
             fonts.append(primary)
         dedup: dict[str, str] = {}
         for name in fonts:
@@ -2536,10 +2577,38 @@ class KioskMqttListener:
         self.log(f"overlay-font: set to '{label}'")
         self._publish_overlay_font_state(None)
         self._apply_overlay_font_choice(reason="font")
-        # Persist the font choice to config
-        # If "System default", persist the default stack; otherwise persist the selected font
-        config_value = normalized_choice if normalized_choice else self._default_font_stack
-        persist_preference("overlay_font", config_value)
+        # Persisted to PULSE_OVERLAY_FONT, not PULSE_OVERLAY_FONT_FAMILY. Writing the pick
+        # over the configured default used to destroy it: "System default" drifted to mean
+        # whatever was picked last, and a default naming a font that isn't installed (the
+        # shipped "Inter") vanished from the list the moment anything else was chosen.
+        # Empty clears the override and restores the configured default.
+        persist_preference("overlay_font", normalized_choice or "")
+
+    def handle_overlay_clock_font(self, payload: bytes) -> None:
+        """Handle clock font selection. Empty/"Same as overlay" makes the clock inherit."""
+        choice = payload.decode("utf-8", errors="ignore").strip()
+        normalized_choice: str | None
+        if not choice or choice == OVERLAY_CLOCK_FONT_DEFAULT_OPTION:
+            normalized_choice = None
+        elif choice not in self._font_option_set:
+            self.log(f"overlay-clock-font: '{choice}' is not an available font")
+            return
+        else:
+            normalized_choice = choice
+        if normalized_choice == self._overlay_clock_font_override:
+            return
+        self._overlay_clock_font_override = normalized_choice
+        self.log(f"overlay-clock-font: set to '{choice or OVERLAY_CLOCK_FONT_DEFAULT_OPTION}'")
+        # The clock stack lives outside _current_font_stack, so nudge the theme directly
+        # rather than going through the overlay-font path, which short-circuits when the
+        # overlay stack itself hasn't changed.
+        if self.overlay_config.enabled:
+            self._overlay_theme = self._build_overlay_theme(self._current_font_stack)
+            if self._overlay_http:
+                self._overlay_http.theme = self._overlay_theme
+            if self.overlay_state:
+                self._emit_overlay_refresh(self.overlay_state.snapshot().version, "clock_font")
+        persist_preference("overlay_clock_font", normalized_choice or "")
 
     def _run_step(self, description: str, command: list[str], cwd: str | None) -> bool:
         display_cmd = " ".join(command)

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -316,6 +316,22 @@ def _quote_font_name(name: str) -> str:
     return f'"{escaped}"' if escaped else ""
 
 
+# A CSS stack that ends in a real family and no generic has nowhere to go if that family
+# is missing: the browser drops to its own default, which is not the same thing on every
+# platform. PULSE_OVERLAY_FONT_FAMILY is normally a bare name ("Inter"), and the shipped
+# default names a font that is not installed on a Pi, so the display quietly rendered in
+# Chromium's fallback rather than anything anyone chose.
+_CSS_GENERIC_FAMILIES = ("sans-serif", "serif", "monospace", "cursive", "fantasy", "system-ui")
+
+
+def _with_generic_fallback(font_stack: str) -> str:
+    stack = (font_stack or "").strip() or DEFAULT_FONT_STACK
+    lowered = stack.lower()
+    if any(generic in lowered for generic in _CSS_GENERIC_FAMILIES):
+        return stack
+    return f'{stack}, sans-serif, "Noto Color Emoji"'
+
+
 def _extract_primary_font(font_stack: str) -> str | None:
     for token in font_stack.split(","):
         candidate = _normalize_font_name(token)
@@ -504,7 +520,7 @@ def load_config() -> EnvConfig:
     )
     if resolved and resolved.timezone:
         overlay_clock_spec = f"{resolved.timezone}={friendly_name}"
-    overlay_font_stack = (os.environ.get("PULSE_OVERLAY_FONT_FAMILY") or "").strip() or DEFAULT_FONT_STACK
+    overlay_font_stack = _with_generic_fallback((os.environ.get("PULSE_OVERLAY_FONT_FAMILY") or "").strip())
     # Separate from the stack above on purpose: PULSE_OVERLAY_FONT_FAMILY is the configured
     # default and is never rewritten, so "System default" always means the same thing and a
     # font picked on-screen can always be undone. The two used to share one variable, which
@@ -814,7 +830,10 @@ class KioskMqttListener:
         self._default_font_stack = (self.overlay_config.font_family or DEFAULT_FONT_STACK).strip() or DEFAULT_FONT_STACK
         self._overlay_font_override: str | None = self.overlay_config.font_choice or None
         self._overlay_clock_font_override: str | None = self.overlay_config.clock_font_choice or None
-        self._current_font_stack = self._default_font_stack
+        # Fold the saved pick in at startup. These used to be the same config variable, so
+        # the stack already contained the choice; now that they are separate, the override
+        # has to be resolved here or a picked font is forgotten on every restart.
+        self._current_font_stack = self._resolve_font_stack()
         self._font_options: list[str] = []
         self._font_option_set: set[str] = set()
         self._refresh_font_options()

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -37,7 +37,7 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_OVERLAY_PORT` | `8800` | TCP port serving `/overlay`. |
 | `PULSE_OVERLAY_BIND` | `127.0.0.1` | Bind address for the overlay server (use `0.0.0.0` to allow remote access). |
 | `PULSE_OVERLAY_ALLOWED_ORIGINS` | `*` | Comma-separated CORS allow list for overlay requests. |
-| `PULSE_OVERLAY_FONT_FAMILY` | `Inter` | Primary overlay font (fallback stack added automatically). |
+| `PULSE_OVERLAY_FONT_FAMILY` | `Inter` | Primary overlay font (fallback stack added automatically). Also settable from [Device controls](#on-screen-device-controls) on the display, which writes the choice back here. |
 | `PULSE_OVERLAY_AMBIENT_BG` | `rgba(0, 0, 0, 0.32)` | Background color for ambient cards. |
 | `PULSE_OVERLAY_ALERT_BG` | `rgba(0, 0, 0, 0.65)` | Background color for alert cards. |
 | `PULSE_OVERLAY_TEXT_COLOR` | `#FFFFFF` | Overlay text color. |
@@ -227,8 +227,8 @@ listening off and is not a mute.
 | `PULSE_LOCATION` | *(empty)* | Preferred location string for weather, [weather alerts](#weather-alerts), and sunrise/sunset (`lat,lon`, ZIP, `City, ST`, plus code, or what3words). |
 | `PULSE_LANGUAGE` | `en` | Default language for assistant, news, and weather. |
 | `PULSE_DAY_NIGHT_AUTO` | `true` | Sunrise/sunset-driven backlight changes. |
-| `PULSE_DAY_BRIGHTNESS` | `85` | Daytime brightness target (%) used by sunrise/sunset automation. |
-| `PULSE_NIGHT_BRIGHTNESS` | `25` | Nighttime brightness target (%) used by sunrise/sunset automation. |
+| `PULSE_DAY_BRIGHTNESS` | `85` | Daytime brightness target (%) used by sunrise/sunset automation. Also settable from [Device controls](#on-screen-device-controls) on the display. |
+| `PULSE_NIGHT_BRIGHTNESS` | `25` | Nighttime brightness target (%) used by sunrise/sunset automation. Also settable from [Device controls](#on-screen-device-controls) on the display. |
 | `PULSE_TWILIGHT_MODE` | `OFFICIAL` | Twilight definition (`OFFICIAL`, `CIVIL`, `NAUTICAL`, `ASTRONOMICAL`). |
 | `PULSE_BACKLIGHT_DEVICE` | `/sys/class/backlight/11-0045` | Backlight device path (auto-detect if unset). |
 | `PULSE_VOLUME_TEST_SOUND` | `true` | Plays a short “thump” after MQTT volume changes. |
@@ -237,6 +237,35 @@ listening off and is not a mute.
 | `PULSE_SPEAKER_ALERT` | `true` | Shows a notification-bar badge while the configured speaker is unreachable. |
 | `PULSE_SPEAKER_SINK` | *(empty)* | Substring of the expected wired sink name (`pactl list sinks short`) to watch on non-Bluetooth displays. |
 | `PULSE_SPEAKER_INTERVAL` | `60` | Seconds between speaker reachability checks (minimum 15). |
+
+### On-screen device controls
+
+Tapping **Config → Device controls** on the display opens the settings below without
+needing Home Assistant, which matters for a touchscreen hanging on a wall. Everything here
+reuses the same handlers as the MQTT entities, so the screen and Home Assistant cannot
+drift apart.
+
+| Control | What it changes | Persisted? |
+| --- | --- | --- |
+| Brightness | The backlight, right now | No — the sunrise/sunset schedule overwrites it. Set the targets below to make it stick |
+| Day / night targets | `PULSE_DAY_BRIGHTNESS` / `PULSE_NIGHT_BRIGHTNESS` | Yes, to `pulse.conf` and the generated backlight conf |
+| Volume | The audio sink, right now | No — left to the audio stack |
+| Overlay font | `PULSE_OVERLAY_FONT_FAMILY` | Yes, to `pulse.conf` |
+| Go home | Navigates back to `PULSE_URL` | n/a |
+| Reboot | Safe reboot | n/a — armed by the first tap, fired by the second, and disarms itself after five seconds so a stray touch can't restart the room |
+
+Persisted values survive both a reboot and an update: `setup.sh` merges new template
+variables into `pulse.conf` on every update while preserving what is already set.
+
+The font list shows the families actually installed on that Pi, each previewed in its own
+face, with symbol, dingbat, math, and emoji families filtered out — they render the overlay
+as gibberish if chosen. It is an inline scrolling list rather than a dropdown on purpose: a
+popup holding every installed font is taller than a 720px kiosk screen, so it opens against
+the top edge and covers the display. Changing the font re-renders the overlay immediately;
+there is no save step.
+
+The day/night targets are hidden entirely on a display with no backlight, since it cannot
+act on a schedule.
 
 ### Speaker-offline badge
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -37,7 +37,9 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_OVERLAY_PORT` | `8800` | TCP port serving `/overlay`. |
 | `PULSE_OVERLAY_BIND` | `127.0.0.1` | Bind address for the overlay server (use `0.0.0.0` to allow remote access). |
 | `PULSE_OVERLAY_ALLOWED_ORIGINS` | `*` | Comma-separated CORS allow list for overlay requests. |
-| `PULSE_OVERLAY_FONT_FAMILY` | `Inter` | Primary overlay font (fallback stack added automatically). Also settable from [Device controls](#on-screen-device-controls) on the display, which writes the choice back here. |
+| `PULSE_OVERLAY_FONT_FAMILY` | `Inter` | Configured default font stack, used when nothing is picked. Never rewritten by a pick, so "System default" keeps its meaning. |
+| `PULSE_OVERLAY_FONT` | *(empty)* | Font picked from [Device controls](#on-screen-device-controls) or Home Assistant. Empty = use the default above. |
+| `PULSE_OVERLAY_CLOCK_FONT` | *(empty)* | Font for the big clock only. Empty = follow the overlay font. |
 | `PULSE_OVERLAY_AMBIENT_BG` | `rgba(0, 0, 0, 0.32)` | Background color for ambient cards. |
 | `PULSE_OVERLAY_ALERT_BG` | `rgba(0, 0, 0, 0.65)` | Background color for alert cards. |
 | `PULSE_OVERLAY_TEXT_COLOR` | `#FFFFFF` | Overlay text color. |
@@ -250,14 +252,22 @@ drift apart.
 | Brightness | The backlight, right now | No — the sunrise/sunset schedule overwrites it. Set the targets below to make it stick |
 | Day / night targets | `PULSE_DAY_BRIGHTNESS` / `PULSE_NIGHT_BRIGHTNESS` | Yes, to `pulse.conf` and the generated backlight conf |
 | Volume | The audio sink, right now | No — left to the audio stack |
-| Overlay font | `PULSE_OVERLAY_FONT_FAMILY` | Yes, to `pulse.conf` |
+| Overlay font | `PULSE_OVERLAY_FONT` | Yes, to `pulse.conf` |
+| Clock font | `PULSE_OVERLAY_CLOCK_FONT` | Yes, to `pulse.conf` |
 | Go home | Navigates back to `PULSE_URL` | n/a |
 | Reboot | Safe reboot | n/a — armed by the first tap, fired by the second, and disarms itself after five seconds so a stray touch can't restart the room |
 
 Persisted values survive both a reboot and an update: `setup.sh` merges new template
 variables into `pulse.conf` on every update while preserving what is already set.
 
-The font list shows the families actually installed on that Pi, each previewed in its own
+There are two font pickers: one for the clock and one for everything else. The clock is
+the only element rendered at 100px+, where a face chosen to stay legible in a 14px badge
+often looks wrong, so the two are chosen separately; leaving the clock on "Same as overlay"
+makes it follow the other. Picking a font writes `PULSE_OVERLAY_FONT` (or
+`PULSE_OVERLAY_CLOCK_FONT`) and never touches `PULSE_OVERLAY_FONT_FAMILY`, so "System
+default" always means the configured default and any pick can be undone.
+
+Both lists show the families actually installed on that Pi, each previewed in its own
 face, with symbol, dingbat, math, and emoji families filtered out — they render the overlay
 as gibberish if chosen. It is an inline scrolling list rather than a dropdown on purpose: a
 popup holding every installed font is taller than a 720px kiosk screen, so it opens against

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -74,6 +74,17 @@ PULSE_OVERLAY_ALLOWED_ORIGINS="*"
 # Fallback fonts are appended automatically if not provided.
 PULSE_OVERLAY_FONT_FAMILY="Inter"
 
+# PULSE_OVERLAY_FONT — the font picked on the display (Config → Device controls) or from
+# Home Assistant. Separate from the default above, which is never rewritten: that way
+# "System default" always means the same thing and any pick can be undone. Leave empty to
+# use the default. Only fonts actually installed on the device are offered.
+PULSE_OVERLAY_FONT=""
+
+# PULSE_OVERLAY_CLOCK_FONT — font for the big clock only. The clock is the one element
+# rendered at 100px+, where a face chosen to stay legible in a 14px badge often looks
+# wrong, so it is picked separately. Leave empty for the clock to follow PULSE_OVERLAY_FONT.
+PULSE_OVERLAY_CLOCK_FONT=""
+
 # PULSE_OVERLAY_AMBIENT_BG — CSS color for persistent cards (clocks, now playing).
 PULSE_OVERLAY_AMBIENT_BG="rgba(0, 0, 0, 0.32)"
 

--- a/pulse/config_persist.py
+++ b/pulse/config_persist.py
@@ -288,7 +288,13 @@ def update_config(var_name: str, value: str, *, logger: logging.Logger | None = 
 #   ha_pipeline       -> HOME_ASSISTANT_ASSIST_PIPELINE  (ha_ is shorthand for HOME_ASSISTANT_)
 #   llm_provider      -> PULSE_ASSISTANT_PROVIDER        (llm_ prefix clarifies context)
 #   log_llm           -> PULSE_ASSISTANT_LOG_LLM       -> on/off -> true/false
-#   overlay_font      -> PULSE_OVERLAY_FONT_FAMILY       (font -> FONT_FAMILY for CSS context)
+#   overlay_font      -> PULSE_OVERLAY_FONT              (the on-screen/HA pick; the
+#                                                        configured default lives in
+#                                                        PULSE_OVERLAY_FONT_FAMILY and is
+#                                                        never rewritten, so "System
+#                                                        default" keeps its meaning)
+#   overlay_clock_font-> PULSE_OVERLAY_CLOCK_FONT        (the clock is rendered at 100px+,
+#                                                        so it is chosen separately)
 #   sound_alarm       -> PULSE_SOUND_ALARM
 #   sound_timer       -> PULSE_SOUND_TIMER
 #   sound_reminder    -> PULSE_SOUND_REMINDER
@@ -316,7 +322,8 @@ PREFERENCE_TO_CONFIG: dict[str, tuple[str, Callable[[str], str]]] = {
     "mistral_model": ("MISTRAL_MODEL", str),
     "openrouter_model": ("OPENROUTER_MODEL", str),
     # Overlay settings (font -> FONT_FAMILY matches CSS terminology)
-    "overlay_font": ("PULSE_OVERLAY_FONT_FAMILY", str),
+    "overlay_font": ("PULSE_OVERLAY_FONT", str),
+    "overlay_clock_font": ("PULSE_OVERLAY_CLOCK_FONT", str),
     # Sound preferences (sound_<kind> -> PULSE_SOUND_<KIND>)
     "sound_alarm": ("PULSE_SOUND_ALARM", str),
     "sound_timer": ("PULSE_SOUND_TIMER", str),

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -49,6 +49,8 @@ from pulse.weather_alerts import BANNER_ALWAYS, TIER_RANK, banner_active
 
 DEFAULT_FONT_STACK = '"Inter", "Segoe UI", "Helvetica Neue", sans-serif, "Noto Color Emoji"'
 DEFAULT_CALENDAR_LOOKAHEAD_HOURS = 72
+# Mirrors the sentinel the listener publishes for the Home Assistant font select.
+OVERLAY_FONT_DEFAULT_OPTION = "System default"
 WEATHER_ICON_DIR = Path(__file__).resolve().parent.parent / "assets" / "weather" / "icons"
 
 
@@ -437,6 +439,18 @@ class OverlayStateManager:
                 volume_value = _coerce_percent(card.get("volume"))
                 if volume_supported and volume_value is not None:
                     normalized["volume"] = volume_value
+                for key in ("day_brightness", "night_brightness"):
+                    target = _coerce_percent(card.get(key))
+                    if brightness_supported and target is not None:
+                        normalized[key] = target
+                fonts_payload = card.get("fonts")
+                if isinstance(fonts_payload, list):
+                    fonts = [str(name) for name in fonts_payload if str(name).strip()]
+                    if fonts:
+                        normalized["fonts"] = fonts
+                        normalized["font"] = str(card.get("font") or fonts[0])
+                normalized["home_supported"] = bool(card.get("home_supported"))
+                normalized["reboot_supported"] = bool(card.get("reboot_supported"))
             if not normalized:
                 normalized = None
         signature = _signature(normalized)
@@ -2119,6 +2133,21 @@ def _build_config_info_overlay() -> str:
 """.strip()
 
 
+# Font names come from fontconfig on the device, so they are not trusted input for a style
+# attribute. Anything carrying CSS punctuation is rendered without a preview rather than
+# escaped and hoped for — the preview is a nicety, breaking out of the attribute is not.
+_UNSAFE_FONT_CHARS = set("\"';{}\\<>()")
+
+
+def _css_font_style(name: str) -> str:
+    """A style attribute previewing this font, or "" when the name can't be shown safely."""
+    cleaned = name.strip()
+    # "System default" is a sentinel, not a font, so it has nothing to preview.
+    if not cleaned or cleaned == OVERLAY_FONT_DEFAULT_OPTION or _UNSAFE_FONT_CHARS & set(cleaned):
+        return ""
+    return f" style=\"font-family: '{html_escape(cleaned, quote=True)}', sans-serif\""
+
+
 def _build_device_controls_info_overlay(card: dict[str, Any]) -> str:
     brightness_supported = bool(card.get("brightness_supported"))
     volume_supported = bool(card.get("volume_supported", True))
@@ -2196,18 +2225,87 @@ def _build_device_controls_info_overlay(card: dict[str, Any]) -> str:
         step=5,
     )
 
+    # The day/night targets are what the sunrise/sunset automation drives toward, as
+    # opposed to the live backlight above them, so they sit together under brightness.
+    targets_markup = ""
+    day_value = _coerce_percent(card.get("day_brightness"))
+    night_value = _coerce_percent(card.get("night_brightness"))
+    if brightness_supported and (day_value is not None or night_value is not None):
+        targets_markup = (
+            '<div class="overlay-control-group">'
+            '<div class="overlay-control-group__title">Automatic brightness targets</div>'
+            + _render_control(
+                kind="day_brightness",
+                label="Day target",
+                description="Backlight level the sunrise schedule aims for.",
+                supported=True,
+                value=day_value,
+            )
+            + _render_control(
+                kind="night_brightness",
+                label="Night target",
+                description="Backlight level the sunset schedule aims for.",
+                supported=True,
+                value=night_value,
+            )
+            + "</div>"
+        )
+
+    fonts = card.get("fonts")
+    font_markup = ""
+    if isinstance(fonts, list) and fonts:
+        current_font = str(card.get("font") or fonts[0])
+        options = "".join(
+            f'<option value="{html_escape(str(name), quote=True)}"{_css_font_style(str(name))}'
+            f"{' selected' if str(name) == current_font else ''}>{html_escape(str(name))}</option>"
+            for name in fonts
+        )
+        select_style = _css_font_style(current_font)
+        font_markup = f"""
+  <div class="overlay-control">
+    <div class="overlay-control__header">
+      <div>
+        <div class="overlay-control__label">Overlay font</div>
+        <div class="overlay-control__description">Typeface used across the overlay.</div>
+      </div>
+    </div>
+    <select class="overlay-control__select" data-font-select aria-label="Overlay font"{select_style}>
+      {options}
+    </select>
+  </div>
+""".strip()
+
+    actions: list[str] = []
+    if card.get("home_supported"):
+        actions.append(
+            '<button class="overlay-button overlay-button--ghost" data-config-action="go_home">'
+            '<span aria-hidden="true">\U0001f3e0</span> Go home</button>'
+        )
+    if card.get("reboot_supported"):
+        # Two taps on purpose: this card is a touchscreen on a wall, and a single stray
+        # press should never be able to restart the room. The JS arms it, then fires.
+        actions.append(
+            '<button class="overlay-button overlay-button--danger" data-reboot-button '
+            'data-confirm-label="Tap again to reboot">'
+            '<span aria-hidden="true">\u21bb</span> Reboot</button>'
+        )
+    actions_markup = f'<div class="overlay-device-actions">{"".join(actions)}</div>' if actions else ""
+
     return f"""
 <div class="overlay-card overlay-info-card overlay-info-card--device">
   <div class="overlay-info-card__header">
     <div>
       <div class="overlay-info-card__title">Device controls</div>
-      <div class="overlay-info-card__subtitle">Manual brightness and volume.</div>
+      <div class="overlay-info-card__subtitle">Brightness, volume, font, and power.</div>
     </div>
     <button class="overlay-info-card__close" data-info-card-close aria-label="Close device controls">&times;</button>
   </div>
   <div class="overlay-info-card__body overlay-device-controls">
     {brightness_markup}
+    {targets_markup}
     {volume_markup}
+    {font_markup}
+    {actions_markup}
   </div>
 </div>
 """.strip()

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -1913,10 +1913,28 @@ def _build_update_info_overlay(snapshot: OverlaySnapshot, card: dict[str, Any]) 
 """.strip()
 
 
+# The project's first published year. The card renders this through the current year, so
+# the notice stops going stale every January the way the hardcoded "2025" did.
+COPYRIGHT_START_YEAR = 2025
+
+# Curated subset shown on the config card — deliberately not every dependency, which
+# wouldn't fit. Names must stay in step with pyproject's runtime dependencies: a dropped or
+# renamed package renders here as a bare name with no version, silently, which is why
+# tests/test_overlay.py asserts each one is still declared.
+KEY_LIBRARIES = ("astral", "httpx", "icalendar", "paho-mqtt", "websockets", "wyoming")
+
+
+def _copyright_years(now: datetime | None = None) -> str:
+    current = (now or datetime.now()).year
+    if current <= COPYRIGHT_START_YEAR:
+        return str(COPYRIGHT_START_YEAR)
+    return f"{COPYRIGHT_START_YEAR}-{current}"
+
+
 def _get_library_versions() -> str:
     """Get versions of key libraries, formatted for display."""
-    libraries = ["astral", "httpx", "icalendar", "paho-mqtt", "websockets", "wyoming"]
     versions = []
+    libraries = KEY_LIBRARIES
     for lib in libraries:
         try:
             ver = get_package_version(lib)
@@ -2057,6 +2075,7 @@ def _build_help_info_overlay() -> str:
 
 def _build_config_info_overlay() -> str:
     library_versions = _get_library_versions()
+    copyright_years = _copyright_years()
     safe_version = html_escape(__version__)
     return f"""
 <div class="overlay-card overlay-info-card overlay-info-card--config">
@@ -2102,7 +2121,7 @@ def _build_config_info_overlay() -> str:
       </div>
       <div class="overlay-config-about__section">
         <div class="overlay-config-about__label">License</div>
-        <div class="overlay-config-about__value">MIT License &copy; 2025 Jeffrey Culverhouse</div>
+        <div class="overlay-config-about__value">MIT License &copy; {copyright_years} Jeffrey Culverhouse</div>
       </div>
       <div class="overlay-config-about__section">
         <div class="overlay-config-about__label">Key Libraries</div>

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -2269,7 +2269,8 @@ def _build_device_controls_info_overlay(card: dict[str, Any]) -> str:
         <div class="overlay-control__description">Typeface used across the overlay.</div>
       </div>
     </div>
-    <select class="overlay-control__select" data-font-select aria-label="Overlay font"{select_style}>
+    <select class="overlay-control__select" data-font-select size="6"
+            aria-label="Overlay font"{select_style}>
       {options}
     </select>
   </div>

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -449,6 +449,12 @@ class OverlayStateManager:
                     if fonts:
                         normalized["fonts"] = fonts
                         normalized["font"] = str(card.get("font") or fonts[0])
+                clock_fonts_payload = card.get("clock_fonts")
+                if isinstance(clock_fonts_payload, list):
+                    clock_fonts = [str(name) for name in clock_fonts_payload if str(name).strip()]
+                    if clock_fonts:
+                        normalized["clock_fonts"] = clock_fonts
+                        normalized["clock_font"] = str(card.get("clock_font") or clock_fonts[0])
                 normalized["home_supported"] = bool(card.get("home_supported"))
                 normalized["reboot_supported"] = bool(card.get("reboot_supported"))
             if not normalized:
@@ -634,6 +640,9 @@ class OverlayTheme:
     ticker_label_mode: str = "auto"  # "name" | "ticker" | "auto" (name for indices, symbol otherwise)
     # Minutes a brand-new weather alert gets a banner before collapsing to the pill.
     # 0 disables banners entirely; the pill still carries every active alert.
+    # Empty means the clock inherits font_family. The clock is the one element rendered
+    # at 100px+, where a face chosen to be legible in a 14px badge often looks wrong.
+    clock_font_family: str = ""
     weather_alert_banner_minutes: int = BANNER_ALWAYS
     # Seconds each alert holds the banner when several are active; 0 shows only the most
     # urgent. Floor of 5s is enforced client-side.
@@ -1283,6 +1292,7 @@ def _theme_css(theme: OverlayTheme) -> str:
         f"  --overlay-alert-bg: {theme.alert_background};\n"
         f"  --overlay-accent-color: {theme.accent_color};\n"
         f"  --overlay-font-family: {theme.font_family};\n"
+        f"  --overlay-clock-font-family: {theme.clock_font_family or theme.font_family};\n"
         "}"
     )
 
@@ -2251,30 +2261,46 @@ def _build_device_controls_info_overlay(card: dict[str, Any]) -> str:
             + "</div>"
         )
 
-    fonts = card.get("fonts")
-    font_markup = ""
-    if isinstance(fonts, list) and fonts:
-        current_font = str(card.get("font") or fonts[0])
+    def _render_font_picker(*, entries: Any, current: Any, attribute: str, label: str, description: str) -> str:
+        if not isinstance(entries, list) or not entries:
+            return ""
+        current_font = str(current or entries[0])
         options = "".join(
             f'<option value="{html_escape(str(name), quote=True)}"{_css_font_style(str(name))}'
             f"{' selected' if str(name) == current_font else ''}>{html_escape(str(name))}</option>"
-            for name in fonts
+            for name in entries
         )
-        select_style = _css_font_style(current_font)
-        font_markup = f"""
+        return f"""
   <div class="overlay-control">
     <div class="overlay-control__header">
       <div>
-        <div class="overlay-control__label">Overlay font</div>
-        <div class="overlay-control__description">Typeface used across the overlay.</div>
+        <div class="overlay-control__label">{html_escape(label)}</div>
+        <div class="overlay-control__description">{html_escape(description)}</div>
       </div>
     </div>
-    <select class="overlay-control__select" data-font-select size="6"
-            aria-label="Overlay font"{select_style}>
+    <select class="overlay-control__select" {attribute} size="6"
+            aria-label="{html_escape(label, quote=True)}"{_css_font_style(current_font)}>
       {options}
     </select>
   </div>
 """.strip()
+
+    # Two pickers, because the clock is the one element rendered at 100px+ and a face
+    # chosen to stay legible in a 14px badge often looks wrong that large.
+    font_markup = _render_font_picker(
+        entries=card.get("fonts"),
+        current=card.get("font"),
+        attribute="data-font-select",
+        label="Overlay font",
+        description="Typeface for everything except the clock.",
+    )
+    clock_font_markup = _render_font_picker(
+        entries=card.get("clock_fonts"),
+        current=card.get("clock_font"),
+        attribute="data-clock-font-select",
+        label="Clock font",
+        description="Typeface for the big clock.",
+    )
 
     actions: list[str] = []
     if card.get("home_supported"):
@@ -2306,6 +2332,7 @@ def _build_device_controls_info_overlay(card: dict[str, Any]) -> str:
     {targets_markup}
     {volume_markup}
     {font_markup}
+    {clock_font_markup}
     {actions_markup}
   </div>
 </div>

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -2085,25 +2085,9 @@ def _build_config_info_overlay() -> str:
   </div>
   <div class="overlay-info-card__body">
     <div class="overlay-config-logo">
-      <svg viewBox="0 0 200 90" xmlns="http://www.w3.org/2000/svg"
-           role="img" aria-label="Graystorm Pulse logo"
-           style="width: 180px; height: auto; margin: 0 auto 1rem; display: block;">
-        <defs>
-          <linearGradient id="pulseGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" style="stop-color:#ff6b35;stop-opacity:1" />
-            <stop offset="50%" style="stop-color:#ffd700;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#00d4ff;stop-opacity:1" />
-          </linearGradient>
-        </defs>
-        <path d="M 30 30 L 70 30 L 85 10 L 100 50 L 115 30 L 170 30"
-              stroke="url(#pulseGradient)"
-              stroke-width="3"
-              fill="none"
-              stroke-linecap="round"
-              stroke-linejoin="round"/>
-        <text x="100" y="75" font-family="Arial, sans-serif" font-size="11" font-weight="bold"
-              fill="rgba(255,255,255,0.9)" text-anchor="middle">GRAYSTORM PULSE</text>
-      </svg>
+      <div class="overlay-config-logo__mark" role="img" aria-label="Graystorm Pulse">
+        <span class="overlay-config-logo__gray">Graystorm</span><span class="overlay-config-logo__pulse">Pulse</span>
+      </div>
     </div>
     <div class="overlay-card__actions">
       <button class="overlay-button" data-config-action="show_sounds">

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -365,6 +365,17 @@ html, body {{
         console.log(`Overlay updated (v${{currentVersion}} -> v${{newVersion}})`);
         currentVersion = newVersion;
 
+        // Remember where the open card was scrolled to. Replacing the DOM resets
+        // scrollTop, so any state change while somebody is reading a long card snapped
+        // them back to the top -- most often their own scrolling did it, because a finger
+        // dragged down the card crosses the sliders and nudges one.
+        const previousCard = overlayContainer.querySelector('.overlay-info-card');
+        const previousBody = overlayContainer.querySelector('.overlay-info-card__body');
+        const previousScroll = previousBody ? previousBody.scrollTop : 0;
+        // Keyed on the card's classes so switching to a different card still opens at the
+        // top; only the same card being re-rendered underneath you keeps its place.
+        const previousCardKey = previousCard ? previousCard.className : '';
+
         // Replace overlay content without touching the iframe
         while (overlayContainer.firstChild) {{
           overlayContainer.removeChild(overlayContainer.firstChild);
@@ -380,6 +391,12 @@ html, body {{
         // the :root --overlay-* declarations onto the element's inline style is enough:
         // they are the whole of what the theme controls, and inline wins over the sheet.
         applyThemeVariables(doc);
+
+        const nextCard = overlayContainer.querySelector('.overlay-info-card');
+        const nextBody = overlayContainer.querySelector('.overlay-info-card__body');
+        if (nextBody && previousScroll > 0 && nextCard && nextCard.className === previousCardKey) {{
+          nextBody.scrollTop = previousScroll;
+        }}
 
         // Update data-version attribute on the container (used by polling)
         overlayContainer.dataset.version = newVersion;

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -79,6 +79,10 @@ class OverlayHttpServer:
         on_set_volume: Callable[[int], bool] | None = None,
         on_set_brightness: Callable[[int], bool] | None = None,
         get_device_levels: Callable[[], dict[str, Any]] | None = None,
+        on_set_font: Callable[[str], bool] | None = None,
+        on_set_brightness_target: Callable[[str, int], bool] | None = None,
+        on_go_home: Callable[[], bool] | None = None,
+        on_reboot: Callable[[], bool] | None = None,
         on_media_control: Callable[[str], None] | None = None,
     ) -> None:
         self.state = state
@@ -104,6 +108,10 @@ class OverlayHttpServer:
         self._on_set_volume = on_set_volume
         self._on_set_brightness = on_set_brightness
         self._get_device_levels = get_device_levels
+        self._on_set_font = on_set_font
+        self._on_set_brightness_target = on_set_brightness_target
+        self._on_go_home = on_go_home
+        self._on_reboot = on_reboot
         self._on_media_control = on_media_control
         self._sound_settings = SoundSettings.with_defaults(
             custom_dir=(Path(sounds_dir).expanduser() if (sounds_dir := os.environ.get("PULSE_SOUNDS_DIR")) else None),
@@ -185,6 +193,20 @@ class OverlayHttpServer:
             payload["brightness"] = max(0, min(100, int(brightness_value)))
         if volume_supported and isinstance(volume_value, int | float):
             payload["volume"] = max(0, min(100, int(volume_value)))
+        for key in ("day_brightness", "night_brightness"):
+            target = device_levels.get(key)
+            # Gated on brightness_supported: a display with no backlight can't act on a
+            # day/night schedule, so offering to set one would be a dead control.
+            if brightness_supported and isinstance(target, int | float):
+                payload[key] = max(0, min(100, int(target)))
+        fonts = device_levels.get("fonts")
+        if isinstance(fonts, list):
+            font_options = [str(name) for name in fonts if str(name).strip()]
+            if font_options:
+                payload["fonts"] = font_options
+                payload["font"] = str(device_levels.get("font") or font_options[0])
+        payload["home_supported"] = bool(device_levels.get("home_supported"))
+        payload["reboot_supported"] = bool(device_levels.get("reboot_supported"))
         return payload
 
     def _render_framed_overlay(self, target_url: str) -> str:
@@ -636,6 +658,47 @@ html, body {{
                     change = outer.state.update_info_card(outer._device_controls_payload())
                     if outer._on_state_change:
                         outer._on_state_change(change)
+                elif action == "set_font":
+                    choice = str(data.get("font") or "").strip()
+                    if not choice or not outer._on_set_font:
+                        self.send_error(HTTPStatus.BAD_REQUEST, "Missing font")
+                        return
+                    if not outer._on_set_font(choice):
+                        self.send_error(HTTPStatus.BAD_REQUEST, "Unknown font")
+                        return
+                    change = outer.state.update_info_card(outer._device_controls_payload())
+                    if outer._on_state_change:
+                        outer._on_state_change(change)
+                elif action in {"set_day_brightness", "set_night_brightness"}:
+                    kind = "day" if action == "set_day_brightness" else "night"
+                    try:
+                        target_value = max(0, min(100, int(float(data.get("value")))))  # type: ignore[arg-type]
+                    except (TypeError, ValueError):
+                        self.send_error(HTTPStatus.BAD_REQUEST, "Missing or invalid value")
+                        return
+                    if not outer._on_set_brightness_target:
+                        self.send_error(HTTPStatus.SERVICE_UNAVAILABLE, "Brightness targets unavailable")
+                        return
+                    outer._on_set_brightness_target(kind, target_value)
+                    change = outer.state.update_info_card(outer._device_controls_payload())
+                    if outer._on_state_change:
+                        outer._on_state_change(change)
+                elif action == "go_home":
+                    if not outer._on_go_home:
+                        self.send_error(HTTPStatus.SERVICE_UNAVAILABLE, "Home navigation unavailable")
+                        return
+                    outer._on_go_home()
+                    change = outer.state.update_info_card(None)
+                    if outer._on_state_change:
+                        outer._on_state_change(change)
+                elif action == "reboot_device":
+                    # The confirm step lives in the card (two taps); by the time this
+                    # arrives the user has already said yes twice.
+                    if not outer._on_reboot:
+                        self.send_error(HTTPStatus.SERVICE_UNAVAILABLE, "Reboot unavailable")
+                        return
+                    self._log("overlay: reboot requested from device controls")
+                    outer._on_reboot()
                 elif action == "toggle_earmuffs":
                     self._log("overlay: toggle_earmuffs requested")
                     if not outer._on_toggle_earmuffs:

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -80,6 +80,7 @@ class OverlayHttpServer:
         on_set_brightness: Callable[[int], bool] | None = None,
         get_device_levels: Callable[[], dict[str, Any]] | None = None,
         on_set_font: Callable[[str], bool] | None = None,
+        on_set_clock_font: Callable[[str], bool] | None = None,
         on_set_brightness_target: Callable[[str, int], bool] | None = None,
         on_go_home: Callable[[], bool] | None = None,
         on_reboot: Callable[[], bool] | None = None,
@@ -109,6 +110,7 @@ class OverlayHttpServer:
         self._on_set_brightness = on_set_brightness
         self._get_device_levels = get_device_levels
         self._on_set_font = on_set_font
+        self._on_set_clock_font = on_set_clock_font
         self._on_set_brightness_target = on_set_brightness_target
         self._on_go_home = on_go_home
         self._on_reboot = on_reboot
@@ -205,6 +207,12 @@ class OverlayHttpServer:
             if font_options:
                 payload["fonts"] = font_options
                 payload["font"] = str(device_levels.get("font") or font_options[0])
+        clock_fonts = device_levels.get("clock_fonts")
+        if isinstance(clock_fonts, list):
+            clock_options = [str(name) for name in clock_fonts if str(name).strip()]
+            if clock_options:
+                payload["clock_fonts"] = clock_options
+                payload["clock_font"] = str(device_levels.get("clock_font") or clock_options[0])
         payload["home_supported"] = bool(device_levels.get("home_supported"))
         payload["reboot_supported"] = bool(device_levels.get("reboot_supported"))
         return payload
@@ -712,6 +720,17 @@ html, body {{
                         self.send_error(HTTPStatus.BAD_REQUEST, "Missing font")
                         return
                     if not outer._on_set_font(choice):
+                        self.send_error(HTTPStatus.BAD_REQUEST, "Unknown font")
+                        return
+                    change = outer.state.update_info_card(outer._device_controls_payload())
+                    if outer._on_state_change:
+                        outer._on_state_change(change)
+                elif action == "set_clock_font":
+                    choice = str(data.get("font") or "").strip()
+                    if not choice or not outer._on_set_clock_font:
+                        self.send_error(HTTPStatus.BAD_REQUEST, "Missing font")
+                        return
+                    if not outer._on_set_clock_font(choice):
                         self.send_error(HTTPStatus.BAD_REQUEST, "Unknown font")
                         return
                     change = outer.state.update_info_card(outer._device_controls_payload())

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -309,6 +309,29 @@ html, body {{
   let errorCount = 0;
   const MAX_ERRORS = 5;
 
+  // Only --overlay-* custom properties are copied; the rest of the stylesheet is static
+  // and identical between renders, so replacing it wholesale would be churn for nothing.
+  // Parsed by hand rather than with a regex: this whole script lives inside a Python
+  // f-string, where every brace and backslash has to be doubled, and a regex full of them
+  // is a trap for the next person editing it.
+  function applyThemeVariables(doc) {{
+    const style = doc.querySelector('style');
+    if (!style) return;
+    const text = style.textContent || '';
+    const rootAt = text.indexOf(':root');
+    if (rootAt < 0) return;
+    const open = text.indexOf('{{', rootAt);
+    const close = text.indexOf('}}', open);
+    if (open < 0 || close < 0) return;
+    text.slice(open + 1, close).split(';').forEach((declaration) => {{
+      const colon = declaration.indexOf(':');
+      if (colon < 0) return;
+      const name = declaration.slice(0, colon).trim();
+      if (name.indexOf('--overlay-') !== 0) return;
+      document.documentElement.style.setProperty(name, declaration.slice(colon + 1).trim());
+    }});
+  }}
+
   async function refreshOverlay() {{
     try {{
       const response = await fetch('/overlay', {{
@@ -349,6 +372,14 @@ html, body {{
 
         // Append the entire pulse-overlay-root element to preserve its CSS classes and structure
         overlayContainer.appendChild(newRoot);
+
+        // Carry over the theme custom properties. This loop swaps body markup only and
+        // never touches the page's <style>, so a theme change served by the backend --
+        // picking a new font, most visibly -- was rendered into HTML nobody read, and the
+        // display kept its boot-time font until the page happened to reload. Copying just
+        // the :root --overlay-* declarations onto the element's inline style is enough:
+        // they are the whole of what the theme controls, and inline wins over the sheet.
+        applyThemeVariables(doc);
 
         // Update data-version attribute on the container (used by polling)
         overlayContainer.dataset.version = newVersion;

--- a/tests/test_kiosk_listener.py
+++ b/tests/test_kiosk_listener.py
@@ -1,0 +1,79 @@
+"""Tests for helpers in bin/kiosk-mqtt-listener.py.
+
+The listener is a script rather than a package module, so it is loaded by path. Only pure
+helpers are exercised here — nothing that touches MQTT, audio, or the display.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_LISTENER = Path(__file__).resolve().parent.parent / "bin" / "kiosk-mqtt-listener.py"
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("kiosk_mqtt_listener", _LISTENER)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["kiosk_mqtt_listener"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def listener() -> ModuleType:
+    return _load()
+
+
+# -- font stack fallbacks -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        "Inter",  # the shipped default, not installed on a Pi
+        "DejaVu Serif",  # contains "serif" but is a real family, not a generic
+        "Liberation Serif",
+        "Noto Sans Mono",  # contains neither "monospace" nor a generic
+    ],
+)
+def test_stack_without_a_generic_gets_one_appended(listener, configured):
+    """A stack ending in a real family has nowhere to go when that family is missing.
+
+    Substring matching got this wrong: "DejaVu Serif" contains "serif", so it looked like
+    it already had a generic and was left without a fallback.
+    """
+    result = listener._with_generic_fallback(configured)
+    assert result.startswith(configured)
+    assert result.endswith('sans-serif, "Noto Color Emoji"')
+
+
+@pytest.mark.parametrize(
+    "configured",
+    ['"Inter", sans-serif', "monospace", "Georgia, serif", '"Menlo", monospace'],
+)
+def test_stack_that_already_ends_in_a_generic_is_untouched(listener, configured):
+    assert listener._with_generic_fallback(configured) == configured
+
+
+def test_empty_stack_falls_back_to_the_shipped_default(listener):
+    assert listener._with_generic_fallback("") == listener.DEFAULT_FONT_STACK
+
+
+# -- font list filtering ------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["D050000L", "Standard Symbols PS", "Noto Color Emoji", "Z003"])
+def test_symbol_families_are_not_offered(listener, name):
+    """Choosing one renders the overlay as gibberish."""
+    assert listener._is_non_text_font(name)
+
+
+@pytest.mark.parametrize("name", ["DejaVu Sans", "Liberation Sans", "Nimbus Roman", "URW Gothic"])
+def test_text_families_are_offered(listener, name):
+    assert not listener._is_non_text_font(name)

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -13,6 +13,7 @@ from pulse.overlay import (
     OverlayStateManager,
     OverlayTheme,
     _build_config_info_overlay,
+    _build_device_controls_info_overlay,
     _build_help_info_overlay,
     _build_now_playing_card,
     _copyright_years,
@@ -20,6 +21,7 @@ from pulse.overlay import (
     parse_clock_config,
     render_overlay_html,
 )
+from pulse.overlay_assets import OVERLAY_JS
 from pulse.weather_alerts import BANNER_ALWAYS
 
 
@@ -1107,6 +1109,92 @@ class ConfigCardAboutTests(unittest.TestCase):
         self.assertEqual(_copyright_years(datetime(2026, 8, 21, tzinfo=UTC)), "2025-2026")
         self.assertEqual(_copyright_years(datetime(2031, 1, 1, tzinfo=UTC)), "2025-2031")
         self.assertIn(f"&copy; {_copyright_years()} ", _build_config_info_overlay())
+
+
+class DeviceControlsCardTests(unittest.TestCase):
+    """Controls the device already exposed over MQTT but had no on-screen equivalent."""
+
+    def _card(self, **overrides) -> dict:
+        card = {
+            "brightness_supported": True,
+            "volume_supported": True,
+            "brightness": 70,
+            "volume": 45,
+            "day_brightness": 85,
+            "night_brightness": 25,
+            "fonts": ["System default", "Inter", "JetBrains Mono"],
+            "font": "Inter",
+            "home_supported": True,
+            "reboot_supported": True,
+        }
+        card.update(overrides)
+        return card
+
+    def test_renders_day_and_night_targets(self) -> None:
+        html = _build_device_controls_info_overlay(self._card())
+        self.assertIn('data-control-slider="day_brightness"', html)
+        self.assertIn('data-control-slider="night_brightness"', html)
+        self.assertIn("Day target", html)
+        self.assertIn("Night target", html)
+
+    def test_targets_hidden_when_the_display_has_no_backlight(self) -> None:
+        """A display with no backlight can't act on a schedule; the control would be dead."""
+        html = _build_device_controls_info_overlay(
+            self._card(brightness_supported=False, day_brightness=None, night_brightness=None)
+        )
+        self.assertNotIn('data-control-slider="day_brightness"', html)
+
+    def test_font_select_marks_the_current_font(self) -> None:
+        html = _build_device_controls_info_overlay(self._card())
+        self.assertIn("data-font-select", html)
+        inter = re.search(r"<option value=\"Inter\"[^>]*>", html)
+        self.assertIsNotNone(inter)
+        self.assertIn("selected", inter.group(0))  # type: ignore[union-attr]
+        self.assertIn("JetBrains Mono", html)
+
+    def test_font_options_preview_in_their_own_face(self) -> None:
+        html = _build_device_controls_info_overlay(self._card(fonts=["System default", "DejaVu Sans"]))
+        self.assertIn("style=\"font-family: 'DejaVu Sans', sans-serif\"", html)
+        # "System default" is a sentinel, not a font, so it has nothing to preview.
+        self.assertNotIn("font-family: 'System default'", html)
+
+    def test_font_names_with_css_punctuation_get_no_preview(self) -> None:
+        """Names come from fontconfig, so they are not trusted input for a style attribute."""
+        hostile = "ev'il\"; } body {"
+        html = _build_device_controls_info_overlay(self._card(fonts=["ok", hostile], font="ok"))
+        options = re.findall(r"<option[^>]*>", html)
+        hostile_option = next(opt for opt in options if "ev" in opt)
+        # Rendered as a choice, but with no style attribute to break out of.
+        self.assertNotIn("style=", hostile_option)
+        safe_option = next(opt for opt in options if 'value="ok"' in opt)
+        self.assertIn("font-family: 'ok'", safe_option)
+
+    def test_no_font_select_without_options(self) -> None:
+        html = _build_device_controls_info_overlay(self._card(fonts=[]))
+        self.assertNotIn("data-font-select", html)
+
+    def test_home_and_reboot_buttons_are_gated_on_support(self) -> None:
+        html = _build_device_controls_info_overlay(self._card())
+        self.assertIn('data-config-action="go_home"', html)
+        self.assertIn("data-reboot-button", html)
+        bare = _build_device_controls_info_overlay(self._card(home_supported=False, reboot_supported=False))
+        self.assertNotIn('data-config-action="go_home"', bare)
+        self.assertNotIn("data-reboot-button", bare)
+
+    def test_reboot_button_carries_a_confirm_step(self) -> None:
+        """A stray touch on a wall display must not be able to restart the room."""
+        html = _build_device_controls_info_overlay(self._card())
+        self.assertIn("data-confirm-label", html)
+
+    def test_every_slider_kind_maps_to_its_own_action(self) -> None:
+        """The mapping was a ternary defaulting to set_volume, so a new slider changed the
+        volume instead of what it said. Every rendered kind must have an explicit action."""
+        html = _build_device_controls_info_overlay(self._card())
+        kinds = set(re.findall(r'data-control-slider="([^"]+)"', html))
+        self.assertTrue(kinds)
+        js = OVERLAY_JS.split("DEVICE_CONTROL_ACTIONS = {", 1)[1].split("}", 1)[0]
+        unmapped = sorted(kind for kind in kinds if f"{kind}:" not in js)
+        self.assertEqual(unmapped, [], f"sliders with no explicit action: {unmapped}")
 
 
 class WeatherAlertOverlayTests(OverlayRenderTests):

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -760,18 +760,21 @@ class ConfigInfoCardTests(unittest.TestCase):
         # The function should handle this gracefully
         self.assertIsInstance(result, str)
 
-    def test_build_config_info_overlay_contains_logo(self) -> None:
-        """Test that the config overlay includes the SVG logo."""
+    def test_build_config_info_overlay_contains_wordmark(self) -> None:
+        """The logo is a CSS wordmark now, not an inline SVG."""
         html = _build_config_info_overlay()
-        self.assertIn("<svg", html)
-        self.assertIn("pulseGradient", html)
-        self.assertIn("GRAYSTORM PULSE", html)
+        self.assertIn("overlay-config-logo__mark", html)
+        self.assertIn("Graystorm", html)
+        self.assertIn("Pulse", html)
+        # The old SVG was mostly empty space above 11px of text; it should not come back.
+        self.assertNotIn("<svg", html)
+        self.assertNotIn("pulseGradient", html)
 
     def test_build_config_info_overlay_has_accessibility_attributes(self) -> None:
-        """Test that the SVG logo has proper accessibility attributes."""
+        """The wordmark still announces itself as one image, not stray styled words."""
         html = _build_config_info_overlay()
         self.assertIn('role="img"', html)
-        self.assertIn('aria-label="Graystorm Pulse logo"', html)
+        self.assertIn('aria-label="Graystorm Pulse"', html)
 
     def test_build_config_info_overlay_contains_about_section(self) -> None:
         """Test that the About section is present."""

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1203,6 +1203,22 @@ class DeviceControlsCardTests(unittest.TestCase):
         html = _build_device_controls_info_overlay(self._card())
         self.assertIn("data-confirm-label", html)
 
+    def test_change_listener_is_cleaned_up_on_reinit(self) -> None:
+        """initialize() runs on every refresh, so a listener it adds must also be removed."""
+        self.assertIn("root.addEventListener('change', changeHandler)", OVERLAY_JS)
+        self.assertIn("oldRoot.removeEventListener('change', changeHandler)", OVERLAY_JS)
+        # Registered for cleanup alongside the click/input handlers.
+        registry = OVERLAY_JS.split("PulseOverlay.eventHandlers = {", 1)[1].split("}", 1)[0]
+        self.assertIn("changeHandler", registry)
+        # Never on document: that survives re-init and accumulates a copy per refresh.
+        self.assertNotIn("document.addEventListener('change'", OVERLAY_JS)
+
+    def test_failed_reboot_request_disarms_the_button(self) -> None:
+        """Left armed, the next single tap would reboot with no confirmation at all."""
+        catch_block = OVERLAY_JS.split("action: 'reboot_device'", 1)[1].split("return;", 1)[0]
+        self.assertIn("dataset.armed = 'false'", catch_block)
+        self.assertIn("overlay-button--armed", catch_block)
+
     def test_every_slider_kind_maps_to_its_own_action(self) -> None:
         """The mapping was a ternary defaulting to set_volume, so a new slider changed the
         volume instead of what it said. Every rendered kind must have an explicit action."""

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -19,6 +19,7 @@ from pulse.overlay import (
     _build_now_playing_card,
     _copyright_years,
     _get_library_versions,
+    _theme_css,
     parse_clock_config,
     render_overlay_html,
 )
@@ -1170,6 +1171,21 @@ class DeviceControlsCardTests(unittest.TestCase):
         safe_option = next(opt for opt in options if 'value="ok"' in opt)
         self.assertIn("font-family: 'ok'", safe_option)
 
+    def test_clock_font_picker_is_separate_from_the_overlay_font(self) -> None:
+        """The clock is rendered at 100px+; a face picked for a 14px badge often looks wrong."""
+        html = _build_device_controls_info_overlay(
+            self._card(clock_fonts=["Same as overlay", "Liberation Sans"], clock_font="Liberation Sans")
+        )
+        self.assertIn("data-clock-font-select", html)
+        self.assertIn("data-font-select", html)
+        clock_block = html.split("data-clock-font-select", 1)[1].split("</select>", 1)[0]
+        self.assertIn('value="Liberation Sans" ', clock_block)
+        self.assertIn("selected", clock_block)
+
+    def test_clock_font_picker_absent_without_options(self) -> None:
+        html = _build_device_controls_info_overlay(self._card(clock_fonts=[]))
+        self.assertNotIn("data-clock-font-select", html)
+
     def test_no_font_select_without_options(self) -> None:
         html = _build_device_controls_info_overlay(self._card(fonts=[]))
         self.assertNotIn("data-font-select", html)
@@ -1211,9 +1227,71 @@ class OverlayThemeConstructionTests(unittest.TestCase):
 
     def test_every_theme_field_is_passed_by_the_builder(self) -> None:
         listener = Path(__file__).resolve().parent.parent / "bin" / "kiosk-mqtt-listener.py"
-        body = listener.read_text().split("OverlayTheme(", 1)[1].split(")", 1)[0]
+        # Balance the parens rather than splitting on the first ")": argument values are
+        # themselves calls (clock_font_family=self._resolve_clock_font_stack()), so a naive
+        # split truncates the argument list and the check silently passes on a short body.
+        tail = listener.read_text().split("OverlayTheme(", 1)[1]
+        depth, end = 1, len(tail)
+        for index, char in enumerate(tail):
+            depth += (char == "(") - (char == ")")
+            if depth == 0:
+                end = index
+                break
+        body = tail[:end]
         missing = sorted(f.name for f in dataclasses.fields(OverlayTheme) if f"{f.name}=" not in body)
         self.assertEqual(missing, [], f"theme fields never set by the builder: {missing}")
+
+
+class ClockFontThemeTests(unittest.TestCase):
+    def _theme(self, **kw) -> OverlayTheme:
+        base = dict(
+            ambient_background="rgba(0,0,0,0.3)",
+            alert_background="rgba(0,0,0,0.6)",
+            text_color="#FFF",
+            accent_color="#88C0D0",
+            font_family='"Nimbus Sans"',
+        )
+        base.update(kw)
+        return OverlayTheme(**base)  # type: ignore[arg-type]
+
+    def test_clock_font_falls_back_to_the_overlay_font(self) -> None:
+        css = _theme_css(self._theme())
+        self.assertIn('--overlay-clock-font-family: "Nimbus Sans"', css)
+
+    def test_clock_font_overrides_independently(self) -> None:
+        css = _theme_css(self._theme(clock_font_family='"Liberation Sans"'))
+        self.assertIn('--overlay-clock-font-family: "Liberation Sans"', css)
+        self.assertIn('--overlay-font-family: "Nimbus Sans"', css)
+
+    def test_clock_markup_consumes_the_clock_variable(self) -> None:
+        """The variable is pointless if nothing reads it."""
+        html = render_overlay_html(
+            OverlaySnapshot(
+                version=1,
+                clocks=(ClockConfig("clock0", "Local", None),),
+                now_playing="",
+                now_playing_state="",
+                now_playing_image="",
+                timers=(),
+                alarms=(),
+                reminders=(),
+                calendar_events=(),
+                active_alarm=None,
+                active_timer=None,
+                active_reminder=None,
+                notifications=(),
+                timer_positions={},
+                info_card=None,
+                last_reason="test",
+                generated_at=0.0,
+                schedule_snapshot=None,
+                earmuffs_enabled=False,
+                update_available=False,
+            ),
+            self._theme(clock_font_family='"Liberation Sans"'),
+        )
+        styles = html.split("</style>", 1)[0]
+        self.assertIn("var(--overlay-clock-font-family", styles)
 
 
 class WeatherAlertOverlayTests(OverlayRenderTests):

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import re
 import time
 import unittest
@@ -1195,6 +1196,24 @@ class DeviceControlsCardTests(unittest.TestCase):
         js = OVERLAY_JS.split("DEVICE_CONTROL_ACTIONS = {", 1)[1].split("}", 1)[0]
         unmapped = sorted(kind for kind in kinds if f"{kind}:" not in js)
         self.assertEqual(unmapped, [], f"sliders with no explicit action: {unmapped}")
+
+
+class OverlayThemeConstructionTests(unittest.TestCase):
+    def test_theme_is_built_in_exactly_one_place(self) -> None:
+        """Two construction sites meant every new theme field had to be added twice.
+
+        It wasn't: the font-change path rebuilt OverlayTheme without the weather-alert
+        fields, so choosing a font silently reset the banner mode to its default.
+        """
+        listener = Path(__file__).resolve().parent.parent / "bin" / "kiosk-mqtt-listener.py"
+        sites = listener.read_text().count("OverlayTheme(")
+        self.assertEqual(sites, 1, f"OverlayTheme built in {sites} places; keep it to one builder")
+
+    def test_every_theme_field_is_passed_by_the_builder(self) -> None:
+        listener = Path(__file__).resolve().parent.parent / "bin" / "kiosk-mqtt-listener.py"
+        body = listener.read_text().split("OverlayTheme(", 1)[1].split(")", 1)[0]
+        missing = sorted(f.name for f in dataclasses.fields(OverlayTheme) if f"{f.name}=" not in body)
+        self.assertEqual(missing, [], f"theme fields never set by the builder: {missing}")
 
 
 class WeatherAlertOverlayTests(OverlayRenderTests):

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -4,8 +4,10 @@ import re
 import time
 import unittest
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 from pulse.overlay import (
+    KEY_LIBRARIES,
     ClockConfig,
     OverlaySnapshot,
     OverlayStateManager,
@@ -13,6 +15,7 @@ from pulse.overlay import (
     _build_config_info_overlay,
     _build_help_info_overlay,
     _build_now_playing_card,
+    _copyright_years,
     _get_library_versions,
     parse_clock_config,
     render_overlay_html,
@@ -1069,6 +1072,38 @@ class NowPlayingAlbumArtRenderTests(NowPlayingCardTests):
         self.assertIsNotNone(result)
         _, html = result  # type: ignore[misc]
         self.assertNotIn("overlay-now-playing__art", html)
+
+
+class ConfigCardAboutTests(unittest.TestCase):
+    """The About box holds two things that rot silently if nobody looks."""
+
+    def test_key_libraries_are_all_still_declared_dependencies(self) -> None:
+        """A dropped or renamed package renders as a bare name with no version, silently."""
+        import tomllib
+
+        from pulse.overlay import KEY_LIBRARIES
+
+        root = Path(__file__).resolve().parent.parent
+        with (root / "pyproject.toml").open("rb") as handle:
+            project = tomllib.load(handle)["project"]
+        declared = {
+            re.split(r"[\[><=!~;\s]", dep, maxsplit=1)[0].strip().lower() for dep in project.get("dependencies", [])
+        }
+        undeclared = sorted(lib for lib in KEY_LIBRARIES if lib.lower() not in declared)
+        self.assertEqual(undeclared, [], f"config card lists non-dependencies: {undeclared}")
+
+    def test_key_libraries_all_resolve_to_a_version(self) -> None:
+        html = _build_config_info_overlay()
+        for lib in KEY_LIBRARIES:
+            # Rendered as "name x.y.z"; a bare name means the lookup failed.
+            self.assertRegex(html, rf"{re.escape(lib)} \d")
+
+    def test_copyright_runs_through_the_current_year(self) -> None:
+        """The hardcoded year went stale the moment 2026 arrived."""
+        self.assertEqual(_copyright_years(datetime(2025, 6, 1, tzinfo=UTC)), "2025")
+        self.assertEqual(_copyright_years(datetime(2026, 8, 21, tzinfo=UTC)), "2025-2026")
+        self.assertEqual(_copyright_years(datetime(2031, 1, 1, tzinfo=UTC)), "2025-2031")
+        self.assertIn(f"&copy; {_copyright_years()} ", _build_config_info_overlay())
 
 
 class WeatherAlertOverlayTests(OverlayRenderTests):


### PR DESCRIPTION
Two things on the config card's About box that rot silently, spotted while looking at the card.

## Copyright

Read `2025`, which went stale the moment 2026 arrived.

- `LICENSE` → `2025-2026`, static. A license notice should state real publication years.
- The card now computes `2025`–current year, so it stops needing an annual edit.

## Key Libraries

The card lists a curated subset of dependencies rather than all eleven, which is right for the space — but the names were an unguarded literal, and a dropped or renamed package would render as a bare name with no version, silently.

**All six are still declared and installed**, so the card is accurate today:

| library | version | declared |
| --- | --- | --- |
| astral | 3.2 | ✅ |
| httpx | 0.28.1 | ✅ |
| icalendar | 7.2.2 | ✅ |
| paho-mqtt | 2.1.0 | ✅ |
| websockets | 17.0.1 | ✅ |
| wyoming | 1.10.0 | ✅ |

Not shown, by choice: `openlocationcode`, `packaging`, `psutil`, `recurring-ical-events`, `websocket`.

The list is now `KEY_LIBRARIES`, with tests asserting every entry is still a declared runtime dependency in `pyproject.toml` and still resolves to a version at render time. Both tests were verified to fail against a deliberately broken list before being kept — the previous PR shipped a guard test that passed with its own bug reintroduced, so that check is now routine.

Note the `Nov 2025` dates in the README are deliberately unchanged: those are dated component prices, accurate as historical statements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds overlay HTTP actions that can reboot the device and persist brightness/font prefs, plus a persistence-key remap so existing overlay_font values write to a new config var. Confirmation is client-side only.
> 
> **Overview**
> **Device controls** on the wall display now match what Home Assistant already exposed: day/night brightness targets, overlay and clock fonts, Go home, and a two-tap reboot that auto-disarms after five seconds.
> 
> Font picks persist to `PULSE_OVERLAY_FONT` / `PULSE_OVERLAY_CLOCK_FONT` instead of rewriting `PULSE_OVERLAY_FONT_FAMILY`, so “System default” stays the configured stack. The clock can inherit or use its own face. Installed-font lists drop symbol/emoji families, CSS stacks always get a generic fallback, and theme construction is centralized so a font change no longer drops weather-alert fields.
> 
> Overlay refresh now copies `--overlay-*` variables (so a font pick actually shows) and preserves card scroll. Sliders use `touch-action: pan-y` so scrolling a long card does not drag brightness. The config card swaps the SVG logo for a compact wordmark and computes copyright years; `KEY_LIBRARIES` is guarded by tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b07534a0a57502882b0e4d47695923acbc4d491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->