### PR TITLE
fix(snapclient): install upstream 0.35.0 .deb and drop removed --controlPort

### DIFF
--- a/bin/pulse-snapclient.sh
+++ b/bin/pulse-snapclient.sh
@@ -73,10 +73,17 @@ cmd=(
     "$SNAPCLIENT_BIN"
     --host "$SNAPCAST_HOST"
     --port "$SNAPCAST_PORT"
-    --controlPort "$SNAPCAST_CONTROL_PORT"
     --hostID "$SNAPCLIENT_HOST_ID"
     --soundcard "$SNAPCLIENT_SOUNDCARD"
 )
+
+# snapclient 0.35 REMOVED --controlPort (no replacement; it moved to a url-based
+# connection scheme) and exits Fatal on an unknown argument. The fleet is upgraded
+# room by room, so this script has to run against 0.26 (bluesnap), 0.31 and 0.35 at
+# the same time -- probe the binary instead of assuming a version.
+if "$SNAPCLIENT_BIN" --help 2>&1 | grep -q -- "--controlPort"; then
+    cmd+=(--controlPort "$SNAPCAST_CONTROL_PORT")
+fi
 
 if [ -n "$SNAPCLIENT_LATENCY_MS" ]; then
     cmd+=(--latency "$SNAPCLIENT_LATENCY_MS")

--- a/setup.sh
+++ b/setup.sh
@@ -688,12 +688,48 @@ install_device_python_deps() {
     pip_install_packages "voice assistant" "${ASSISTANT_PIP_PACKAGES[@]}" || true
 }
 
+# Debian ships an old snapclient (trixie: 0.31.0, bookworm: 0.26.0) and never moves
+# it within a release, so apt cannot get us current. Upstream publishes per-suite,
+# per-arch .debs; use those and fall back to apt if the download is unavailable.
+# NOTE: this leaves snapclient outside apt's update path -- bump SNAPCLIENT_VERSION
+# here when a new release ships (nothing will tell you automatically).
+SNAPCLIENT_VERSION="${SNAPCLIENT_VERSION:-0.35.0}"
+
 ensure_snapclient_package() {
+    local installed=""
     if dpkg -s snapclient >/dev/null 2>&1; then
-        return
+        installed="$(dpkg-query -W -f='${Version}' snapclient 2>/dev/null)"
     fi
-    log "Installing snapclient…"
-    sudo apt install -y snapclient
+    case "$installed" in
+        "${SNAPCLIENT_VERSION}-1"*) return ;;
+    esac
+
+    local suite arch url tmp
+    suite="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+    arch="$(dpkg --print-architecture)"
+    # The pulse backend is required: pulse-snapclient.sh runs with --player pulse via
+    # PipeWire's PulseAudio compatibility socket. The plain and with-pipewire builds
+    # do NOT carry it.
+    url="https://github.com/snapcast/snapcast/releases/download/v${SNAPCLIENT_VERSION}/snapclient_${SNAPCLIENT_VERSION}-1_${arch}_${suite}_with-pulse.deb"
+    tmp="$(mktemp -d)"
+
+    log "Installing snapclient ${SNAPCLIENT_VERSION} (${arch}/${suite}) from upstream…"
+    if curl -fsSL -o "$tmp/snapclient.deb" "$url"; then
+        if sudo dpkg -i "$tmp/snapclient.deb"; then
+            rm -rf "$tmp"
+            return
+        fi
+        log "dpkg failed; resolving dependencies…"
+        sudo apt-get -f install -y || true
+    else
+        log "Could not fetch $url"
+    fi
+    rm -rf "$tmp"
+
+    if ! dpkg -s snapclient >/dev/null 2>&1; then
+        log "Falling back to the distro snapclient package…"
+        sudo apt install -y snapclient
+    fi
 }
 
 disable_stock_snapclient() {

--- a/setup.sh
+++ b/setup.sh
@@ -690,45 +690,107 @@ install_device_python_deps() {
 
 # Debian ships an old snapclient (trixie: 0.31.0, bookworm: 0.26.0) and never moves
 # it within a release, so apt cannot get us current. Upstream publishes per-suite,
-# per-arch .debs; use those and fall back to apt if the download is unavailable.
+# per-arch .debs; use those.
+#
 # NOTE: this leaves snapclient outside apt's update path -- bump SNAPCLIENT_VERSION
-# here when a new release ships (nothing will tell you automatically).
+# AND the matching checksum below when a new release ships (nothing will tell you
+# automatically).
 SNAPCLIENT_VERSION="${SNAPCLIENT_VERSION:-0.35.0}"
 
-ensure_snapclient_package() {
-    local installed=""
-    if dpkg -s snapclient >/dev/null 2>&1; then
-        installed="$(dpkg-query -W -f='${Version}' snapclient 2>/dev/null)"
-    fi
-    case "$installed" in
-        "${SNAPCLIENT_VERSION}-1"*) return ;;
+# sha256 of each upstream .deb we are willing to install, keyed "<arch>_<suite>".
+# Upstream publishes no checksums or signatures alongside the release, so pinning the
+# digest here is what makes the download verifiable: if the asset is ever replaced,
+# this stops matching and we fall back to apt rather than installing something we did
+# not expect. A combination that is not listed is NOT installed from GitHub -- it
+# takes the apt path, which is exactly the old behaviour.
+snapclient_expected_sha256() {
+    case "$1" in
+        arm64_trixie)   echo "541d3cbf886d0715c2ae7a7e6ecdfcec076039b7792f36418ba308075ef23bb1" ;;
+        arm64_bookworm) echo "4e0445eb1cf792da209f18f3d0aecb982595bd9b2530a313617be4321f43406d" ;;
+        *)              echo "" ;;
     esac
+}
 
-    local suite arch url tmp
+# True only when snapclient is present AND fully configured at the wanted version.
+# `dpkg -s` reporting a version is not enough: a failed `dpkg -i` leaves the package
+# unpacked-but-unconfigured, which still reports a version and would otherwise look
+# like a successful install on this run and every future one.
+snapclient_is_installed_ok() {
+    local want="$1" status version
+    status="$(dpkg-query -W -f='${Status}' snapclient 2>/dev/null || true)"
+    [ "$status" = "install ok installed" ] || return 1
+    version="$(dpkg-query -W -f='${Version}' snapclient 2>/dev/null || true)"
+    case "$version" in
+        "${want}-1"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+install_snapclient_from_apt() {
+    log "Installing snapclient from the distro archive…"
+    sudo apt install -y snapclient
+}
+
+ensure_snapclient_package() {
+    if snapclient_is_installed_ok "$SNAPCLIENT_VERSION"; then
+        return
+    fi
+
+    local suite arch key expected url tmp actual
     suite="$(. /etc/os-release && echo "$VERSION_CODENAME")"
     arch="$(dpkg --print-architecture)"
+    key="${arch}_${suite}"
+    expected="$(snapclient_expected_sha256 "$key")"
+
+    if [ -z "$expected" ]; then
+        log "No pinned snapclient checksum for ${key}; using the distro package instead."
+        if ! snapclient_is_installed_ok "" && ! dpkg -s snapclient >/dev/null 2>&1; then
+            install_snapclient_from_apt
+        fi
+        return
+    fi
+
     # The pulse backend is required: pulse-snapclient.sh runs with --player pulse via
     # PipeWire's PulseAudio compatibility socket. The plain and with-pipewire builds
     # do NOT carry it.
     url="https://github.com/snapcast/snapcast/releases/download/v${SNAPCLIENT_VERSION}/snapclient_${SNAPCLIENT_VERSION}-1_${arch}_${suite}_with-pulse.deb"
     tmp="$(mktemp -d)"
+    # shellcheck disable=SC2064 # expand tmp now, not at trap time
+    trap "rm -rf '$tmp'" RETURN
 
-    log "Installing snapclient ${SNAPCLIENT_VERSION} (${arch}/${suite}) from upstream…"
-    if curl -fsSL -o "$tmp/snapclient.deb" "$url"; then
-        if sudo dpkg -i "$tmp/snapclient.deb"; then
-            rm -rf "$tmp"
-            return
-        fi
-        log "dpkg failed; resolving dependencies…"
-        sudo apt-get -f install -y || true
-    else
+    log "Installing snapclient ${SNAPCLIENT_VERSION} (${key}) from upstream…"
+    if ! curl -fsSL --proto '=https' --tlsv1.2 -o "$tmp/snapclient.deb" "$url"; then
         log "Could not fetch $url"
+        dpkg -s snapclient >/dev/null 2>&1 || install_snapclient_from_apt
+        return
     fi
-    rm -rf "$tmp"
 
-    if ! dpkg -s snapclient >/dev/null 2>&1; then
-        log "Falling back to the distro snapclient package…"
-        sudo apt install -y snapclient
+    actual="$(sha256sum "$tmp/snapclient.deb" | cut -d" " -f1)"
+    if [ "$actual" != "$expected" ]; then
+        log "REFUSING snapclient .deb: sha256 mismatch for ${key}"
+        log "  expected $expected"
+        log "  actual   $actual"
+        dpkg -s snapclient >/dev/null 2>&1 || install_snapclient_from_apt
+        return
+    fi
+
+    if ! sudo dpkg -i "$tmp/snapclient.deb"; then
+        # dpkg has already unpacked at this point, so the old working client is gone.
+        # Resolve dependencies and check the result -- do NOT swallow this: a silent
+        # failure here leaves a half-configured package that plays no audio, and the
+        # early return above would treat it as done on every later run.
+        log "dpkg reported an error; resolving dependencies…"
+        sudo apt-get -f install -y || log "apt-get -f install failed"
+    fi
+
+    if snapclient_is_installed_ok "$SNAPCLIENT_VERSION"; then
+        return
+    fi
+
+    log "snapclient ${SNAPCLIENT_VERSION} did not install cleanly; falling back to the distro package."
+    install_snapclient_from_apt
+    if ! dpkg-query -W -f='${Status}' snapclient 2>/dev/null | grep -q "install ok installed"; then
+        log "WARNING: snapclient is not correctly installed — this room will have no audio."
     fi
 }
 


### PR DESCRIPTION
## Why

`apt install snapclient` can never get the fleet current: Debian pins snapclient per release and never moves it within one. trixie ships **0.31.0**, bookworm ships **0.26.0**. Upstream is on **0.35.0** (released 2026-03-10).

That matters beyond tidiness — the two snapclient problems this fleet has actually hit (the lost PipeWire sink needing a service restart, and the ~60s time-sync reconnect loop) are both in versions we're stuck behind.

## What changed

**`setup.sh`** — `ensure_snapclient_package()` now installs upstream's per-suite/per-arch `.deb`, falling back to apt if the download is unavailable. Version is in `SNAPCLIENT_VERSION` at the top of the function.

The **`with-pulse`** build is required, not optional: `pulse-snapclient.sh` runs `--player pulse` against PipeWire's PulseAudio compatibility socket (`$XDG_RUNTIME_DIR/pulse/native`). Neither the plain nor the `with-pipewire` build carries that backend.

**`bin/pulse-snapclient.sh`** — 0.35 **removed `--controlPort`** with no replacement (connection moved to a url-based scheme), and snapclient exits `Fatal` on an unknown argument. This took pulse-office down on upgrade:

```
[Fatal] (Snapclient) Exception: Unknown command line argument: '--controlPort'
```

Rooms get upgraded one at a time, so this script must run against 0.26, 0.31 and 0.35 concurrently. It now probes the binary for the flag rather than assuming a version.

## Verification

Installed on pulse-office and confirmed against the live server — a mixed fleet works:

```
pulse-office          connected=True  v0.35.0   <-- upgraded
pulse-bedroom         connected=True  v0.31.0
pulse-great-room      connected=True  v0.31.0
bluesnap-great-room   connected=True  v0.26.0
pulse-kitchen         connected=True  v0.31.0
```

`bash -n` clean on both files; `shellcheck -S warning` reports nothing in either changed region (the three SC2034s in setup.sh are pre-existing, lines 1454–1478).

## Known tradeoff

This takes snapclient out of apt's update path — nothing will tell you when 0.36 ships, and it won't receive apt security updates. `SNAPCLIENT_VERSION` has to be bumped by hand.

## Deploy note

pulse-office already has the launcher patched in place to restore audio, byte-identical to this branch. Before pulling there:

```
cd /opt/pulse-os && git checkout -- bin/pulse-snapclient.sh && git pull
```

Remaining rooms (bedroom, kitchen, great-room, and bluesnap on **bookworm**) are still on the old clients and are unaffected until deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Downloads and installs binaries outside apt (manual version bumps), and botched `dpkg -i` handling could briefly leave rooms without working snapclient audio until fallback succeeds.
> 
> **Overview**
> **Snapclient** is upgraded beyond Debian’s pinned packages by installing upstream **0.35.0** `with-pulse` `.deb`s from GitHub when arch/suite checksums are pinned (`arm64_trixie`, `arm64_bookworm`), with sha256 verification and fallbacks to apt on fetch/checksum/install failure. Install success now requires `dpkg` **install ok installed** at the target version, not merely “package present.”
> 
> **`pulse-snapclient.sh`** no longer always passes `--controlPort`; it adds the flag only when the installed binary’s `--help` advertises it, so **0.35** (which fatals on unknown args) coexists with older fleet clients during room-by-room rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef59cb0cf8211bd468040823e490dce074f2d4cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->