### PR TITLE
fix(overlay): apply the configured theme on load, and make the clock card legible

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1018,6 +1018,29 @@ body {
   color: var(--overlay-accent-color);
 }
 
+/* The clock card is the ONLY card rendered without a background plate -- every other
+   card carries --ambient or --alert, so its text is read against a known dark scrim.
+   The clock sits directly on the wallpaper, which can be any photo at any luminance,
+   so colour alone cannot make it legible: the accent disappeared over a bright sunlit
+   shot, and white would disappear over a pale one just as badly. The time and date
+   only get away with being unshadowed because they are enormous (up to 6.5rem); the
+   title is 0.95rem and had no such margin.
+
+   So: the title joins its siblings in white rather than the accent, and all three get
+   a shadow so the card holds up over an arbitrary background. The accent still marks
+   titles on the backed cards, where it reads fine. */
+.overlay-card--clock .overlay-card__title {
+  color: var(--overlay-text-color, #ffffff);
+}
+
+.overlay-card--clock .overlay-card__title,
+.overlay-card--clock .overlay-clock__time,
+.overlay-card--clock .overlay-clock__date {
+  text-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.85),
+    0 0 14px rgba(0, 0, 0, 0.55);
+}
+
 /* The clock gets its own family. It is the one thing on screen rendered at 100px+, where a
    face picked for legibility in a 14px badge often reads badly, so the two are chosen
    separately. Falls back to the overlay font when no clock font is set. */

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -1256,7 +1256,14 @@ def render_overlay_html(
         f'data-info-endpoint="{info_endpoint_attr}"'
     )
 
-    css_block = f"{_theme_css(theme)}\n{OVERLAY_CSS}"
+    # Theme AFTER the static sheet, not before. Both blocks target :root with the same
+    # specificity, so whichever comes last wins -- with the theme first, OVERLAY_CSS's
+    # :root defaults silently overrode every configured colour and font on initial
+    # render. It only ever looked right because the refresh loop copies the theme onto
+    # documentElement's inline style, and that runs solely when the overlay CONTENT
+    # version changes: so a display showed its configured accent until the next reload,
+    # then reverted to the built-in default until some card happened to appear.
+    css_block = f"{OVERLAY_CSS}\n{_theme_css(theme)}"
     html_document = f"""<!DOCTYPE html>
 <html lang="en">
 <head>

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -326,7 +326,13 @@ html, body {{
     const style = doc.querySelector('style');
     if (!style) return;
     const text = style.textContent || '';
-    const rootAt = text.indexOf(':root');
+    // LAST :root, not the first. The document carries two: the static stylesheet's
+    // defaults come first, and the theme block is appended after it so it wins the
+    // cascade (see the css_block ordering in overlay.py). Taking the first one here
+    // would copy the built-in DEFAULTS onto documentElement's inline style -- and
+    // inline beats the sheet, so it would defeat the very ordering that makes the
+    // configured theme apply at all.
+    const rootAt = text.lastIndexOf(':root');
     if (rootAt < 0) return;
     const open = text.indexOf('{{', rootAt);
     const close = text.indexOf('}}', open);

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -37,6 +37,42 @@ class OverlayRenderTests(unittest.TestCase):
             show_notification_bar=True,
         )
 
+    def test_theme_css_wins_over_the_static_stylesheet(self) -> None:
+        """The theme block must come AFTER OVERLAY_CSS in the rendered document.
+
+        Both declare :root with identical specificity, so source order decides. With
+        the theme emitted first, OVERLAY_CSS's :root defaults silently overrode every
+        configured colour on initial render, and the display only picked the real theme
+        up when the refresh loop next copied it onto documentElement -- which happens
+        solely on an overlay CONTENT change. Net effect: a kiosk showed its configured
+        accent until the page reloaded, then reverted to the built-in default until
+        some card happened to appear.
+        """
+        from pulse.overlay_assets import OVERLAY_CSS
+
+        theme = OverlayTheme(
+            ambient_background="rgba(0,0,0,0.32)",
+            alert_background="rgba(0,0,0,0.65)",
+            text_color="#FFFFFF",
+            accent_color="#ff5c5c",
+            show_notification_bar=True,
+        )
+        html = render_overlay_html(self._snapshot(), theme)
+
+        themed = html.rfind("--overlay-accent-color: #ff5c5c")
+        self.assertGreaterEqual(themed, 0, "themed accent missing from the document")
+
+        # The static sheet also defines --overlay-accent-color; the themed one has to
+        # come later or it loses the cascade.
+        static_default = OVERLAY_CSS[OVERLAY_CSS.find("--overlay-accent-color") :][:60]
+        self.assertIn("--overlay-accent-color", static_default)
+        static_at = html.find("--overlay-accent-color")
+        self.assertLess(
+            static_at,
+            themed,
+            "static :root default must precede the theme block, otherwise it wins",
+        )
+
     def _snapshot(self, **overrides) -> OverlaySnapshot:
         data = {
             "version": 1,


### PR DESCRIPTION
Started as "the Now Playing green is hard to read" and turned up two real bugs underneath it.

## 1. The configured theme never applied on initial render

`css_block` emitted the theme **before** the static sheet:

```python
css_block = f"{_theme_css(theme)}\n{OVERLAY_CSS}"
```

Both declare `:root` with identical specificity, so `OVERLAY_CSS`'s defaults won every time. A kiosk showed its configured accent only until the page next reloaded, then reverted to the built-in `#88C0D0` — and stayed there until some card happened to appear, because `applyThemeVariables()` runs **only** inside the `newVersion !== currentVersion` branch of the refresh loop.

That's why this looked fine in normal use: any display that had been up a while had had a content change. Every reload silently reverted it.

Fix: emit the theme last, so it wins in the sheet itself with no JS involved.

## 2. `applyThemeVariables()` read the wrong `:root`

It used `text.indexOf(':root')` — the first block. Once the theme moved to the end, the first block became the *static defaults*, so every content update copied `#88C0D0` onto `documentElement`'s inline style, and inline beats the sheet. Fixing (1) alone made this actively worse — caught it on the device mid-verification.

Now uses `lastIndexOf(':root')`.

## 3. The clock card title was illegible over the wallpaper

`.overlay-card--clock` is the only card rendered **without** a background plate — every other card carries `--ambient` or `--alert` and is read against a known dark scrim. The clock sits directly on the wallpaper, which can be any photo at any luminance, and its title was drawn in the accent colour at `0.95rem`.

Colour alone can't fix that: the accent disappears over a bright shot, and white would disappear over a pale one just as badly. The time and date only get away with being unshadowed because they're up to `6.5rem`.

So the title joins its siblings in white, and all three get a `text-shadow`. There was previously no `text-shadow` anywhere in the stylesheet. The accent still marks titles on the backed cards, where it reads fine.

## Verification

Deployed to pulse-office and checked against the live camera background:

- `getComputedStyle(...).getPropertyValue('--overlay-accent-color')` returns the configured value on a **cold load** (was `#88C0D0`)
- "PULSE OFFICE" is legible against bright sunlit concrete
- NOW PLAYING and the animated bars render in the accent

Added a regression test asserting the theme block follows the static sheet — confirmed it **fails** on the old order and passes on the new. The old behaviour was invisible to the suite.

`2131 passed`, `ruff format --check` and `ruff check` clean, `uv.lock` untouched.

## Note

Accent colour itself is per-device config (`PULSE_OVERLAY_ACCENT_COLOR` in `pulse.conf`), not part of this PR. pulse-office is set to `#ff5c5c` to match the ticker; the other three kiosks are unchanged and still on the old green, which will now actually apply on load once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CSS and stylesheet ordering changes with a targeted regression test; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes overlay theming so **per-device accent and colors apply on a cold page load**, not only after a content refresh. **`render_overlay_html`** now emits **`OVERLAY_CSS` before the theme `:root` block** so configured `--overlay-*` variables win in the stylesheet cascade; the framed overlay’s **`applyThemeVariables`** was updated to parse the **last** `:root` block so content updates don’t copy static defaults onto inline styles.
> 
> For the **clock card** (the only card without a background scrim), the location title uses **white text** and **title, time, and date** get a **dark text-shadow** so labels stay readable on bright wallpapers.
> 
> Adds a **regression test** that the themed accent declaration appears **after** the static sheet’s default in rendered HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1557f06cc7b1339d803b70fa38f42ca4c0897e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->