### PR TITLE
fix(snapclient): restart the client after a package or config change

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -731,10 +731,18 @@ install_snapclient_from_apt() {
     sudo apt install -y snapclient
 }
 
+# Set to 1 by ensure_snapclient_package when the installed package actually moved,
+# so configure_snapclient knows the running process is now stale. Replacing the
+# binary does NOT restart the client: systemd keeps the old process alive against
+# the replaced inode, so `snapclient -v` reports the new version while the client
+# still speaks the old one to the server.
+SNAPCLIENT_PACKAGE_CHANGED=0
+
 ensure_snapclient_package() {
     if snapclient_is_installed_ok "$SNAPCLIENT_VERSION"; then
         return
     fi
+    SNAPCLIENT_PACKAGE_CHANGED=1
 
     local suite arch key expected url tmp actual
     suite="$(. /etc/os-release && echo "$VERSION_CODENAME")"
@@ -821,6 +829,12 @@ configure_snapclient() {
 
     ensure_snapclient_package
 
+    # Checksum the defaults before/after so we only bounce the client when the file
+    # genuinely moved -- setup.sh runs on every update, and restarting the audio
+    # client unconditionally would cut the room off for no reason each time.
+    local config_before config_after config_changed=0
+    config_before="$(sha256sum "$config_file" 2>/dev/null | cut -d" " -f1)"
+
     sudo tee "$config_file" >/dev/null <<EOF
 SNAPCAST_HOST="${PULSE_SNAPCAST_HOST}"
 SNAPCAST_PORT="${PULSE_SNAPCAST_PORT:-1704}"
@@ -831,11 +845,31 @@ SNAPCLIENT_LATENCY_MS="${PULSE_SNAPCLIENT_LATENCY_MS:-}"
 SNAPCLIENT_EXTRA_ARGS="${PULSE_SNAPCLIENT_EXTRA_ARGS:---player pulse}"
 SNAPCLIENT_HOST_ID="${PULSE_SNAPCLIENT_HOST_ID:-}"
 EOF
+    config_after="$(sha256sum "$config_file" 2>/dev/null | cut -d" " -f1)"
+    [ "$config_before" != "$config_after" ] && config_changed=1
+
     log "Wrote Snapcast client defaults to $config_file"
 
     # Snapclient streams through PipeWire/Pulse (--player pulse). Make sure the
     # per-user audio stack is running even when Bluetooth autoconnect is disabled.
     ensure_user_systemd_session
+
+    # Pick up a new binary or new defaults. Neither lands on its own: the later
+    # `systemctl enable --now pulse-snapclient.service` is a no-op against a unit
+    # that is already running, so without this the room keeps serving audio from
+    # the OLD client. That is not cosmetic -- on the 0.31 -> 0.35 upgrade every
+    # room reported the new version on disk while snapserver still saw v0.31.0
+    # clients, because the processes predated the package.
+    #
+    # Only restart a unit that is already active: if the client is meant to be off,
+    # or has not been enabled yet, starting it here would be the wrong call.
+    if [ "$SNAPCLIENT_PACKAGE_CHANGED" = "1" ] || [ "$config_changed" = "1" ]; then
+        if systemctl is-active --quiet pulse-snapclient.service; then
+            log "Snapclient package or config changed; restarting pulse-snapclient…"
+            sudo systemctl restart pulse-snapclient.service || \
+                log "WARNING: pulse-snapclient failed to restart — this room may be silent"
+        fi
+    fi
 }
 
 setup_user_dirs() {


### PR DESCRIPTION
## The bug

`configure_snapclient` installs the snapclient package and rewrites `/etc/default/pulse-snapclient`, but never restarts `pulse-snapclient.service`. The `systemctl enable --now pulse-snapclient.service` later in the run doesn't help — it's a no-op against a unit that's already active.

Replacing the binary doesn't disturb the running process; systemd keeps it alive against the replaced inode. So the room keeps serving audio from the **old** client, indefinitely.

## This actually happened

On the 0.31.0 → 0.35.0 upgrade, all three remaining rooms looked correct:

```
pulse-kitchen      repo=v1.20.4  snapclient=v0.35.0  kiosk=active  snapcli=active
pulse-great-room   repo=v1.20.4  snapclient=v0.35.0  kiosk=active  snapcli=active
pulse-bedroom      repo=v1.20.4  snapclient=v0.35.0  kiosk=active  snapcli=active
```

But snapserver — which reports what each client announced at connect — still saw:

```
pulse-bedroom         connected=True  v0.31.0
pulse-great-room      connected=True  v0.31.0
pulse-kitchen         connected=True  v0.31.0
```

The processes predated the package (`ExecMainStartTimestamp` two days older than the install). The HA update button reported success and nothing had changed. A manual `systemctl restart` was needed, after which all three announced v0.35.0.

## The fix

- `ensure_snapclient_package` sets `SNAPCLIENT_PACKAGE_CHANGED` when the installed package actually moves
- the defaults file is checksummed either side of the write
- the client is restarted only when one of those genuinely changed

**Why gated rather than unconditional:** `setup.sh` runs on every update, and bouncing the audio client each time would cut the room off for no reason.

**Why only an already-active unit:** if the client is meant to be off, or hasn't been enabled yet, starting it here would be wrong — that's what the later `enable --now` is for. A failed restart is logged rather than swallowed, since a silent room is otherwise hard to attribute.

## Verification

`2131 passed`, `ruff format --check` and `ruff check` clean, `bash -n` and `shellcheck -S warning` clean on the changed region.

## Not included

bluesnap-great-room had the **stock** `snapclient.service` enabled and running as `_snapclient`, which cannot open the PipeWire session (`Can't open default, error: Host is down`) — a second client contending for the same device alongside the real one from `bluesnap.service`. I disabled it on the host, but deliberately did not touch `disable_stock_snapclient` here: that host has no `pulse-snapclient` unit or config at all, so `setup.sh` has evidently never run on it. The four kiosks all have the stock unit correctly disabled, and the `.deb` install preserves that state. Fixing bluesnap properly is a separate question about whether it should be under pulse-os management at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches room audio on fleet updates (conditional restart can briefly cut sound or fail loudly); behavior is gated to real package/config changes and active units only.
> 
> **Overview**
> **Fixes snapclient upgrades and config updates not taking effect** because `setup.sh` could install a new binary and rewrite `/etc/default/pulse-snapclient` while leaving the old `pulse-snapclient.service` process running (inode replacement + `enable --now` no-op on an active unit).
> 
> `ensure_snapclient_package` now sets **`SNAPCLIENT_PACKAGE_CHANGED`** when the installed package actually moves. **`configure_snapclient`** checksums the defaults file before/after the write and restarts **`pulse-snapclient.service`** only when the package or config genuinely changed **and** the unit is already active—avoiding audio drops on routine setup runs and not starting a client that was meant to stay off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd304ac9070767b881a563c5d77b7a404605515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->