### PR TITLE
feat(kiosk): pin the kiosk locale to en-US, and make the clock date a template

### DIFF
--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -89,7 +89,12 @@ window.PulseOverlay.initialize = function() {
   const hour12Attr = root.dataset.clockHour12;
   const hour12 = hour12Attr !== 'false';
   const timeOptions = { hour: hour12 ? 'numeric' : '2-digit', minute: '2-digit', hour12 };
-  const dateOptions = { weekday: 'long', month: 'long', day: 'numeric' };
+  const dateOptions = { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' };
+  // The date is assembled part by part rather than handed to Intl whole: no locale
+  // renders an ordinal day ("September 1st"), and the browser's own locale would
+  // otherwise decide day-vs-month order.
+  const ordinalRules = new Intl.PluralRules('en-US', { type: 'ordinal' });
+  const ordinalSuffixes = { one: 'st', two: 'nd', few: 'rd', other: 'th' };
 
   const clampPercent = (value) => {
     const numberValue = Number(value);
@@ -173,6 +178,22 @@ window.PulseOverlay.initialize = function() {
     }
   };
 
+  const formatClockDate = (date, tz) => {
+    let parts;
+    try {
+      parts = new Intl.DateTimeFormat('en-US', { ...dateOptions, timeZone: tz || undefined }).formatToParts(date);
+    } catch (error) {
+      parts = new Intl.DateTimeFormat('en-US', dateOptions).formatToParts(date);
+    }
+    const part = (type) => {
+      const match = parts.find((entry) => entry.type === type);
+      return match ? match.value : '';
+    };
+    const day = part('day');
+    const suffix = ordinalSuffixes[ordinalRules.select(Number(day))] || 'th';
+    return `${part('weekday')} ${part('month')} ${day}${suffix}, ${part('year')}`;
+  };
+
   const tick = () => {
     const now = new Date();
     const clockNodes = root.querySelectorAll('[data-clock]');
@@ -189,7 +210,7 @@ window.PulseOverlay.initialize = function() {
       }
       if (dateEl) {
         try {
-          dateEl.textContent = formatWithZone(now, tz, dateOptions);
+          dateEl.textContent = formatClockDate(now, tz);
         } catch (err) {
           // Silently handle timezone formatting errors
         }

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -189,17 +189,18 @@ window.PulseOverlay.initialize = function() {
     } catch (error) {
       parts = new Intl.DateTimeFormat('en-US', dateOptions).formatToParts(date);
     }
-    const part = (type) => {
-      const match = parts.find((entry) => entry.type === type);
-      return match ? match.value : '';
-    };
-    const day = part('day');
+    // Indexed in one pass rather than a find() per token: tick() runs every second.
+    const parted = {};
+    parts.forEach((entry) => {
+      parted[entry.type] = entry.value;
+    });
+    const day = parted.day || '';
     const values = {
-      weekday: part('weekday'),
-      month: part('month'),
+      weekday: parted.weekday || '',
+      month: parted.month || '',
       day,
       ordinal: `${day}${ordinalSuffixes[ordinalRules.select(Number(day))] || 'th'}`,
-      year: part('year'),
+      year: parted.year || '',
     };
     // An unknown token is left as written rather than blanked, so a typo in the config
     // shows up on the screen as itself instead of a mysterious gap.

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -95,13 +95,10 @@ window.PulseOverlay.initialize = function() {
   // otherwise decide day-vs-month order (the kiosks resolve to "Tuesday 1 September").
   const ordinalRules = new Intl.PluralRules('en-US', { type: 'ordinal' });
   const ordinalSuffixes = { one: 'st', two: 'nd', few: 'rd', other: 'th' };
-  const dateStyles = {
-    long: ({ weekday, month, day, year }) => `${weekday}, ${month} ${day}, ${year}`,
-    'long-no-year': ({ weekday, month, day }) => `${weekday}, ${month} ${day}`,
-    ordinal: ({ weekday, month, day, suffix }) => `${weekday}, ${month} ${day}${suffix}`,
-    'ordinal-year': ({ weekday, month, day, suffix, year }) => `${weekday}, ${month} ${day}${suffix}, ${year}`,
-  };
-  const dateStyle = dateStyles[root.dataset.clockDateStyle] ? root.dataset.clockDateStyle : 'long';
+  // The arrangement is a token template resolved server-side; this end only substitutes,
+  // so the preset list lives in one place (pulse/overlay.py) and cannot drift.
+  const DEFAULT_DATE_FORMAT = '{weekday}, {month} {day}, {year}';
+  const dateFormat = root.dataset.clockDateFormat || DEFAULT_DATE_FORMAT;
 
   const clampPercent = (value) => {
     const numberValue = Number(value);
@@ -197,13 +194,18 @@ window.PulseOverlay.initialize = function() {
       return match ? match.value : '';
     };
     const day = part('day');
-    return dateStyles[dateStyle]({
+    const values = {
       weekday: part('weekday'),
       month: part('month'),
       day,
+      ordinal: `${day}${ordinalSuffixes[ordinalRules.select(Number(day))] || 'th'}`,
       year: part('year'),
-      suffix: ordinalSuffixes[ordinalRules.select(Number(day))] || 'th',
-    });
+    };
+    // An unknown token is left as written rather than blanked, so a typo in the config
+    // shows up on the screen as itself instead of a mysterious gap.
+    return dateFormat.replace(/{(\w+)}/g, (token, name) =>
+      Object.prototype.hasOwnProperty.call(values, name) ? values[name] : token,
+    );
   };
 
   const tick = () => {

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -92,9 +92,16 @@ window.PulseOverlay.initialize = function() {
   const dateOptions = { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' };
   // The date is assembled part by part rather than handed to Intl whole: no locale
   // renders an ordinal day ("September 1st"), and the browser's own locale would
-  // otherwise decide day-vs-month order.
+  // otherwise decide day-vs-month order (the kiosks resolve to "Tuesday 1 September").
   const ordinalRules = new Intl.PluralRules('en-US', { type: 'ordinal' });
   const ordinalSuffixes = { one: 'st', two: 'nd', few: 'rd', other: 'th' };
+  const dateStyles = {
+    long: ({ weekday, month, day, year }) => `${weekday}, ${month} ${day}, ${year}`,
+    'long-no-year': ({ weekday, month, day }) => `${weekday}, ${month} ${day}`,
+    ordinal: ({ weekday, month, day, suffix }) => `${weekday}, ${month} ${day}${suffix}`,
+    'ordinal-year': ({ weekday, month, day, suffix, year }) => `${weekday}, ${month} ${day}${suffix}, ${year}`,
+  };
+  const dateStyle = dateStyles[root.dataset.clockDateStyle] ? root.dataset.clockDateStyle : 'long';
 
   const clampPercent = (value) => {
     const numberValue = Number(value);
@@ -190,8 +197,13 @@ window.PulseOverlay.initialize = function() {
       return match ? match.value : '';
     };
     const day = part('day');
-    const suffix = ordinalSuffixes[ordinalRules.select(Number(day))] || 'th';
-    return `${part('weekday')} ${part('month')} ${day}${suffix}, ${part('year')}`;
+    return dateStyles[dateStyle]({
+      weekday: part('weekday'),
+      month: part('month'),
+      day,
+      year: part('year'),
+      suffix: ordinalSuffixes[ordinalRules.select(Number(day))] || 'th',
+    });
   };
 
   const tick = () => {

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -31,6 +31,7 @@ from pulse.overlay import (
     OverlayChange,
     OverlayStateManager,
     OverlayTheme,
+    normalize_clock_date_style,
     parse_clock_config,
 )
 from pulse.overlay_server import OverlayHttpServer, OverlayServerConfig
@@ -106,6 +107,7 @@ class OverlayConfig:
     accent_color: str
     show_notification_bar: bool
     clock_24h: bool
+    clock_date_style: str
     font_family: str  # configured default stack; never rewritten by a pick
     font_choice: str  # overlay font picked on-screen or from HA ("" = use the default)
     clock_font_choice: str  # clock font picked separately ("" = follow the overlay font)
@@ -551,6 +553,7 @@ def load_config() -> EnvConfig:
         accent_color=os.environ.get("PULSE_OVERLAY_ACCENT_COLOR", "#88C0D0"),
         show_notification_bar=parse_bool(os.environ.get("PULSE_OVERLAY_NOTIFICATION_BAR"), True),
         clock_24h=parse_bool(os.environ.get("PULSE_OVERLAY_CLOCK_24H"), False),
+        clock_date_style=normalize_clock_date_style(os.environ.get("PULSE_OVERLAY_CLOCK_DATE_STYLE")),
         font_family=overlay_font_stack,
         font_choice=overlay_font_choice,
         clock_font_choice=overlay_clock_font_choice,
@@ -903,6 +906,7 @@ class KioskMqttListener:
                 port=self.overlay_config.port,
                 allowed_origins=self.overlay_config.allowed_origins,
                 clock_24h=self.overlay_config.clock_24h,
+                clock_date_style=self.overlay_config.clock_date_style,
                 stop_endpoint=self._overlay_stop_endpoint,
                 info_endpoint=self._overlay_info_endpoint,
                 auth_token=self.overlay_config.auth_token,

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -31,8 +31,8 @@ from pulse.overlay import (
     OverlayChange,
     OverlayStateManager,
     OverlayTheme,
-    normalize_clock_date_style,
     parse_clock_config,
+    resolve_clock_date_format,
 )
 from pulse.overlay_server import OverlayHttpServer, OverlayServerConfig
 from pulse.sound_library import SoundLibrary
@@ -107,7 +107,7 @@ class OverlayConfig:
     accent_color: str
     show_notification_bar: bool
     clock_24h: bool
-    clock_date_style: str
+    clock_date_format: str
     font_family: str  # configured default stack; never rewritten by a pick
     font_choice: str  # overlay font picked on-screen or from HA ("" = use the default)
     clock_font_choice: str  # clock font picked separately ("" = follow the overlay font)
@@ -553,7 +553,7 @@ def load_config() -> EnvConfig:
         accent_color=os.environ.get("PULSE_OVERLAY_ACCENT_COLOR", "#88C0D0"),
         show_notification_bar=parse_bool(os.environ.get("PULSE_OVERLAY_NOTIFICATION_BAR"), True),
         clock_24h=parse_bool(os.environ.get("PULSE_OVERLAY_CLOCK_24H"), False),
-        clock_date_style=normalize_clock_date_style(os.environ.get("PULSE_OVERLAY_CLOCK_DATE_STYLE")),
+        clock_date_format=resolve_clock_date_format(os.environ.get("PULSE_OVERLAY_CLOCK_DATE_FORMAT")),
         font_family=overlay_font_stack,
         font_choice=overlay_font_choice,
         clock_font_choice=overlay_clock_font_choice,
@@ -906,7 +906,7 @@ class KioskMqttListener:
                 port=self.overlay_config.port,
                 allowed_origins=self.overlay_config.allowed_origins,
                 clock_24h=self.overlay_config.clock_24h,
-                clock_date_style=self.overlay_config.clock_date_style,
+                clock_date_format=self.overlay_config.clock_date_format,
                 stop_endpoint=self._overlay_stop_endpoint,
                 info_endpoint=self._overlay_info_endpoint,
                 auth_token=self.overlay_config.auth_token,

--- a/bin/kiosk-wrap.sh
+++ b/bin/kiosk-wrap.sh
@@ -79,6 +79,19 @@ fi
 
 URL="$(append_pulse_host_param "$URL" "$HOSTNAME_FALLBACK")"
 
+# Pin the kiosk locale. Raspberry Pi OS ships en_GB.UTF-8, and Chromium inherits it
+# for every date, number and sort it renders -- a US kiosk was showing "Tuesday 1
+# September". The session env is set for anything Chromium shells out to, and --lang
+# is passed explicitly because Chromium also persists an app locale in its profile
+# from whatever it saw on first run.
+: "${PULSE_KIOSK_LOCALE:=en_US.UTF-8}"
+export LANG="$PULSE_KIOSK_LOCALE"
+export LC_ALL="$PULSE_KIOSK_LOCALE"
+# en_US.UTF-8 -> en-US, the BCP 47 form Chromium's --lang wants.
+KIOSK_UI_LANG="${PULSE_KIOSK_LOCALE%%.*}"
+KIOSK_UI_LANG="${KIOSK_UI_LANG//_/-}"
+export LANGUAGE="$KIOSK_UI_LANG"
+
 # Isolate Chromium temp files away from /tmp (tmpfs)
 export TMPDIR="$HOME/.cache/chromium-tmp"
 mkdir -p "$TMPDIR"
@@ -168,6 +181,8 @@ BROWSER="$(command -v chromium || command -v chromium-browser)"
 while true; do
   "$BROWSER" \
     --v=0 \
+    --lang="$KIOSK_UI_LANG" \
+    --accept-lang="$KIOSK_UI_LANG" \
     --remote-debugging-port=9222 \
     --remote-debugging-address=0.0.0.0 \
     --disable-application-cache \

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -46,7 +46,7 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_OVERLAY_ACCENT_COLOR` | `#88C0D0` | Accent color for highlights. |
 | `PULSE_OVERLAY_NOTIFICATION_BAR` | `true` | Toggles the badge row at the top of the overlay. |
 | `PULSE_OVERLAY_CLOCK_24H` | `false` | Forces 24-hour clock labels when `true`. |
-| `PULSE_OVERLAY_CLOCK_DATE_STYLE` | `long` | Date shown under the clock: `long` (Tuesday, September 1, 2026), `long-no-year` (Tuesday, September 1), `ordinal` (Tuesday, September 1st) or `ordinal-year` (Tuesday, September 1st, 2026). Unknown values fall back to `long`. |
+| `PULSE_OVERLAY_CLOCK_DATE_FORMAT` | `long` | Date under the clock. A preset name — `long` (Tuesday, September 1, 2026), `long-no-year`, `ordinal` (Tuesday, September 1st), `ordinal-year`, `day-first` (Tuesday 1 September 2026), `day-first-no-year` — or a template of `{weekday}` `{month}` `{day}` `{ordinal}` `{year}`, e.g. `{weekday}, {day} {month}`. Unrecognised values fall back to `long`. |
 | `PULSE_OVERLAY_AUTH_TOKEN` | _(unset)_ | Bearer token for overlay POST endpoints. When set, state-changing requests require `Authorization: Bearer <token>`. |
 
 ## Stock ticker

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -46,6 +46,7 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_OVERLAY_ACCENT_COLOR` | `#88C0D0` | Accent color for highlights. |
 | `PULSE_OVERLAY_NOTIFICATION_BAR` | `true` | Toggles the badge row at the top of the overlay. |
 | `PULSE_OVERLAY_CLOCK_24H` | `false` | Forces 24-hour clock labels when `true`. |
+| `PULSE_OVERLAY_CLOCK_DATE_STYLE` | `long` | Date shown under the clock: `long` (Tuesday, September 1, 2026), `long-no-year` (Tuesday, September 1), `ordinal` (Tuesday, September 1st) or `ordinal-year` (Tuesday, September 1st, 2026). Unknown values fall back to `long`. |
 | `PULSE_OVERLAY_AUTH_TOKEN` | _(unset)_ | Bearer token for overlay POST endpoints. When set, state-changing requests require `Authorization: Bearer <token>`. |
 
 ## Stock ticker

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -103,6 +103,14 @@ PULSE_OVERLAY_NOTIFICATION_BAR="true"
 # PULSE_OVERLAY_CLOCK_24H — set to "true" for 24-hour clock display (default 12-hour).
 PULSE_OVERLAY_CLOCK_24H="false"
 
+# PULSE_OVERLAY_CLOCK_DATE_STYLE — how the date under the clock reads. Month names and
+# weekdays are always US English, so the format does not follow the browser locale.
+#   long          Tuesday, September 1, 2026   (default)
+#   long-no-year  Tuesday, September 1
+#   ordinal       Tuesday, September 1st
+#   ordinal-year  Tuesday, September 1st, 2026
+PULSE_OVERLAY_CLOCK_DATE_STYLE="long"
+
 # PULSE_OVERLAY_AUTH_TOKEN — optional bearer token for overlay POST endpoints.
 # When set, all state-changing requests (stop/snooze, volume, brightness, updates)
 # require an "Authorization: Bearer <token>" header. Leave unset to allow

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -103,13 +103,19 @@ PULSE_OVERLAY_NOTIFICATION_BAR="true"
 # PULSE_OVERLAY_CLOCK_24H — set to "true" for 24-hour clock display (default 12-hour).
 PULSE_OVERLAY_CLOCK_24H="false"
 
-# PULSE_OVERLAY_CLOCK_DATE_STYLE — how the date under the clock reads. Month names and
-# weekdays are always US English, so the format does not follow the browser locale.
-#   long          Tuesday, September 1, 2026   (default)
-#   long-no-year  Tuesday, September 1
-#   ordinal       Tuesday, September 1st
-#   ordinal-year  Tuesday, September 1st, 2026
-PULSE_OVERLAY_CLOCK_DATE_STYLE="long"
+# PULSE_OVERLAY_CLOCK_DATE_FORMAT — how the date under the clock reads. Month and
+# weekday names are always US English, so this does not follow the device locale.
+# Either a preset name:
+#   long               Tuesday, September 1, 2026   (default)
+#   long-no-year       Tuesday, September 1
+#   ordinal            Tuesday, September 1st
+#   ordinal-year       Tuesday, September 1st, 2026
+#   day-first          Tuesday 1 September 2026
+#   day-first-no-year  Tuesday 1 September
+# or a template built from {weekday} {month} {day} {ordinal} {year}, e.g.
+#   PULSE_OVERLAY_CLOCK_DATE_FORMAT="{weekday}, {day} {month}"   Tuesday, 1 September
+# Anything unrecognised falls back to the long preset.
+PULSE_OVERLAY_CLOCK_DATE_FORMAT="long"
 
 # PULSE_OVERLAY_AUTH_TOKEN — optional bearer token for overlay POST endpoints.
 # When set, all state-changing requests (stop/snooze, volume, brightness, updates)

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -663,6 +663,25 @@ CELL_ORDER = (
 
 CLOCK_POSITION = "bottom-left"
 
+# Date styles the clock card understands. The rendering itself lives in overlay.js
+# (Intl does the month and weekday names); this list only has to agree with the keys
+# in its `dateStyles` map so an unknown value can be caught before it reaches a kiosk.
+CLOCK_DATE_STYLES = (
+    "long",  # Tuesday, September 1, 2026
+    "long-no-year",  # Tuesday, September 1
+    "ordinal",  # Tuesday, September 1st
+    "ordinal-year",  # Tuesday, September 1st, 2026
+)
+DEFAULT_CLOCK_DATE_STYLE = "long"
+
+
+def normalize_clock_date_style(value: str | None) -> str:
+    """Return a known date style, falling back to the default for anything else."""
+
+    candidate = (value or "").strip().lower()
+    return candidate if candidate in CLOCK_DATE_STYLES else DEFAULT_CLOCK_DATE_STYLE
+
+
 INFO_CARD_BLOCKED_CELLS = {
     "top-center",
     "top-right",
@@ -1193,6 +1212,7 @@ def render_overlay_html(
     theme: OverlayTheme,
     *,
     clock_hour12: bool = True,
+    clock_date_style: str = DEFAULT_CLOCK_DATE_STYLE,
     stop_endpoint: str | None = None,
     info_endpoint: str | None = None,
 ) -> str:
@@ -1252,6 +1272,7 @@ def render_overlay_html(
         f'data-version="{snapshot.version}" '
         f'data-generated-at="{int(snapshot.generated_at * 1000)}" '
         f'data-clock-hour12="{"true" if clock_hour12 else "false"}" '
+        f'data-clock-date-style="{normalize_clock_date_style(clock_date_style)}" '
         f'data-stop-endpoint="{stop_endpoint_attr}" '
         f'data-info-endpoint="{info_endpoint_attr}"'
     )

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -663,23 +663,57 @@ CELL_ORDER = (
 
 CLOCK_POSITION = "bottom-left"
 
-# Date styles the clock card understands. The rendering itself lives in overlay.js
-# (Intl does the month and weekday names); this list only has to agree with the keys
-# in its `dateStyles` map so an unknown value can be caught before it reaches a kiosk.
-CLOCK_DATE_STYLES = (
-    "long",  # Tuesday, September 1, 2026
-    "long-no-year",  # Tuesday, September 1
-    "ordinal",  # Tuesday, September 1st
-    "ordinal-year",  # Tuesday, September 1st, 2026
+# The date under the clock is a token template. Templates travel to the browser whole
+# and overlay.js only substitutes, so a new arrangement costs a config edit rather than
+# a release -- the exact wording changed four times before this one settled.
+CLOCK_DATE_TOKENS = (
+    "weekday",  # Tuesday
+    "month",  # September
+    "day",  # 1
+    "ordinal",  # 1st
+    "year",  # 2026
 )
-DEFAULT_CLOCK_DATE_STYLE = "long"
+
+# Names for the arrangements worth having on hand. Anything else can be spelled out
+# as a template, e.g. PULSE_OVERLAY_CLOCK_DATE_FORMAT="{weekday}, {day} {month}".
+CLOCK_DATE_PRESETS = {
+    "long": "{weekday}, {month} {day}, {year}",  # Tuesday, September 1, 2026
+    "long-no-year": "{weekday}, {month} {day}",  # Tuesday, September 1
+    "ordinal": "{weekday}, {month} {ordinal}",  # Tuesday, September 1st
+    "ordinal-year": "{weekday}, {month} {ordinal}, {year}",  # Tuesday, September 1st, 2026
+    "day-first": "{weekday} {day} {month} {year}",  # Tuesday 1 September 2026
+    "day-first-no-year": "{weekday} {day} {month}",  # Tuesday 1 September
+}
+DEFAULT_CLOCK_DATE_FORMAT = "long"
+
+# Long enough for any sensible arrangement of five tokens, short enough that a
+# runaway config value cannot push the clock card off the screen.
+MAX_CLOCK_DATE_FORMAT_LENGTH = 120
+
+_CLOCK_DATE_TOKEN_RE = re.compile(r"{([^{}]*)}")
 
 
-def normalize_clock_date_style(value: str | None) -> str:
-    """Return a known date style, falling back to the default for anything else."""
+def resolve_clock_date_format(value: str | None) -> str:
+    """Return the token template for a preset name or a literal template.
 
-    candidate = (value or "").strip().lower()
-    return candidate if candidate in CLOCK_DATE_STYLES else DEFAULT_CLOCK_DATE_STYLE
+    Anything unrecognised falls back to the default preset: a kiosk showing the wrong
+    arrangement is a nuisance, but one showing a raw `{month}` or a blank line is a
+    bug report.
+    """
+
+    candidate = (value or "").strip()
+    default = CLOCK_DATE_PRESETS[DEFAULT_CLOCK_DATE_FORMAT]
+    if not candidate:
+        return default
+    preset = CLOCK_DATE_PRESETS.get(candidate.lower())
+    if preset:
+        return preset
+    if len(candidate) > MAX_CLOCK_DATE_FORMAT_LENGTH:
+        return default
+    tokens = _CLOCK_DATE_TOKEN_RE.findall(candidate)
+    if tokens and all(token in CLOCK_DATE_TOKENS for token in tokens):
+        return candidate
+    return default
 
 
 INFO_CARD_BLOCKED_CELLS = {
@@ -1212,7 +1246,7 @@ def render_overlay_html(
     theme: OverlayTheme,
     *,
     clock_hour12: bool = True,
-    clock_date_style: str = DEFAULT_CLOCK_DATE_STYLE,
+    clock_date_format: str = DEFAULT_CLOCK_DATE_FORMAT,
     stop_endpoint: str | None = None,
     info_endpoint: str | None = None,
 ) -> str:
@@ -1272,7 +1306,7 @@ def render_overlay_html(
         f'data-version="{snapshot.version}" '
         f'data-generated-at="{int(snapshot.generated_at * 1000)}" '
         f'data-clock-hour12="{"true" if clock_hour12 else "false"}" '
-        f'data-clock-date-style="{normalize_clock_date_style(clock_date_style)}" '
+        f'data-clock-date-format="{html_escape(resolve_clock_date_format(clock_date_format), quote=True)}" '
         f'data-stop-endpoint="{stop_endpoint_attr}" '
         f'data-info-endpoint="{info_endpoint_attr}"'
     )

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -34,7 +34,7 @@ from pulse.audio import play_sound, play_volume_feedback
 from pulse.sound_library import SoundLibrary, SoundSettings
 
 from .overlay import (
-    DEFAULT_CLOCK_DATE_STYLE,
+    DEFAULT_CLOCK_DATE_FORMAT,
     OverlayChange,
     OverlayStateManager,
     OverlayTheme,
@@ -51,7 +51,7 @@ class OverlayServerConfig:
     port: int
     allowed_origins: tuple[str, ...] = ("*",)
     clock_24h: bool = False
-    clock_date_style: str = DEFAULT_CLOCK_DATE_STYLE
+    clock_date_format: str = DEFAULT_CLOCK_DATE_FORMAT
     stop_endpoint: str = "/overlay/stop"
     info_endpoint: str = "/overlay/info-card"
     auth_token: str | None = None
@@ -233,7 +233,7 @@ class OverlayHttpServer:
             snapshot,
             self.theme,
             clock_hour12=not self.config.clock_24h,
-            clock_date_style=self.config.clock_date_style,
+            clock_date_format=self.config.clock_date_format,
             stop_endpoint=self.config.stop_endpoint,
             info_endpoint=self.config.info_endpoint,
         )
@@ -828,7 +828,7 @@ html, body {{
                     snapshot,
                     outer.theme,
                     clock_hour12=not outer.config.clock_24h,
-                    clock_date_style=outer.config.clock_date_style,
+                    clock_date_format=outer.config.clock_date_format,
                     stop_endpoint=outer.config.stop_endpoint,
                     info_endpoint=outer.config.info_endpoint,
                 ).encode("utf-8")

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -33,7 +33,13 @@ from urllib.parse import parse_qs, unquote, urlparse
 from pulse.audio import play_sound, play_volume_feedback
 from pulse.sound_library import SoundLibrary, SoundSettings
 
-from .overlay import OverlayChange, OverlayStateManager, OverlayTheme, render_overlay_html
+from .overlay import (
+    DEFAULT_CLOCK_DATE_STYLE,
+    OverlayChange,
+    OverlayStateManager,
+    OverlayTheme,
+    render_overlay_html,
+)
 from .overlay_assets import OVERLAY_JS
 
 Logger = Callable[[str], None]
@@ -45,6 +51,7 @@ class OverlayServerConfig:
     port: int
     allowed_origins: tuple[str, ...] = ("*",)
     clock_24h: bool = False
+    clock_date_style: str = DEFAULT_CLOCK_DATE_STYLE
     stop_endpoint: str = "/overlay/stop"
     info_endpoint: str = "/overlay/info-card"
     auth_token: str | None = None
@@ -226,6 +233,7 @@ class OverlayHttpServer:
             snapshot,
             self.theme,
             clock_hour12=not self.config.clock_24h,
+            clock_date_style=self.config.clock_date_style,
             stop_endpoint=self.config.stop_endpoint,
             info_endpoint=self.config.info_endpoint,
         )
@@ -820,6 +828,7 @@ html, body {{
                     snapshot,
                     outer.theme,
                     clock_hour12=not outer.config.clock_24h,
+                    clock_date_style=outer.config.clock_date_style,
                     stop_endpoint=outer.config.stop_endpoint,
                     info_endpoint=outer.config.info_endpoint,
                 ).encode("utf-8")

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pulse.overlay import (
+    CLOCK_DATE_STYLES,
     KEY_LIBRARIES,
     ClockConfig,
     OverlaySnapshot,
@@ -20,6 +21,7 @@ from pulse.overlay import (
     _copyright_years,
     _get_library_versions,
     _theme_css,
+    normalize_clock_date_style,
     parse_clock_config,
     render_overlay_html,
 )
@@ -1706,3 +1708,43 @@ class WeatherAlertStateTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ClockDateStyleTests(unittest.TestCase):
+    """The style is chosen in Python but rendered in overlay.js, so the two must agree."""
+
+    def setUp(self) -> None:
+        self.theme = OverlayTheme(
+            ambient_background="rgba(0,0,0,0.32)",
+            alert_background="rgba(0,0,0,0.65)",
+            text_color="#FFFFFF",
+            accent_color="#88C0D0",
+            show_notification_bar=True,
+        )
+
+    def _snapshot(self) -> OverlaySnapshot:
+        return OverlayStateManager().snapshot()
+
+    def test_every_style_reaches_the_markup(self) -> None:
+        for style in CLOCK_DATE_STYLES:
+            with self.subTest(style=style):
+                html = render_overlay_html(self._snapshot(), self.theme, clock_date_style=style)
+                self.assertIn(f'data-clock-date-style="{style}"', html)
+
+    def test_unknown_and_empty_styles_fall_back_to_long(self) -> None:
+        for value in ("", "   ", "gibberish", None):
+            with self.subTest(value=value):
+                self.assertEqual(normalize_clock_date_style(value), "long")
+
+    def test_style_matching_ignores_case_and_padding(self) -> None:
+        self.assertEqual(normalize_clock_date_style("  Ordinal-Year "), "ordinal-year")
+
+    def test_default_style_is_rendered_without_an_explicit_argument(self) -> None:
+        html = render_overlay_html(self._snapshot(), self.theme)
+        self.assertIn('data-clock-date-style="long"', html)
+
+    def test_javascript_implements_exactly_the_declared_styles(self) -> None:
+        """A style Python accepts but overlay.js cannot render would silently show `long`."""
+        block = OVERLAY_JS.split("const dateStyles = {", 1)[1].split("};", 1)[0]
+        in_js = set(re.findall(r"^\s*'?([a-z-]+)'?:", block, re.MULTILINE))
+        self.assertEqual(in_js, set(CLOCK_DATE_STYLES))

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pulse.overlay import (
-    CLOCK_DATE_STYLES,
+    CLOCK_DATE_PRESETS,
     KEY_LIBRARIES,
     ClockConfig,
     OverlaySnapshot,
@@ -21,9 +21,9 @@ from pulse.overlay import (
     _copyright_years,
     _get_library_versions,
     _theme_css,
-    normalize_clock_date_style,
     parse_clock_config,
     render_overlay_html,
+    resolve_clock_date_format,
 )
 from pulse.overlay_assets import OVERLAY_JS
 from pulse.weather_alerts import BANNER_ALWAYS
@@ -1710,8 +1710,8 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class ClockDateStyleTests(unittest.TestCase):
-    """The style is chosen in Python but rendered in overlay.js, so the two must agree."""
+class ClockDateFormatTests(unittest.TestCase):
+    """The template is resolved in Python and substituted in overlay.js."""
 
     def setUp(self) -> None:
         self.theme = OverlayTheme(
@@ -1725,26 +1725,70 @@ class ClockDateStyleTests(unittest.TestCase):
     def _snapshot(self) -> OverlaySnapshot:
         return OverlayStateManager().snapshot()
 
-    def test_every_style_reaches_the_markup(self) -> None:
-        for style in CLOCK_DATE_STYLES:
-            with self.subTest(style=style):
-                html = render_overlay_html(self._snapshot(), self.theme, clock_date_style=style)
-                self.assertIn(f'data-clock-date-style="{style}"', html)
+    def _rendered_format(self, value: str | None = None) -> str:
+        kwargs = {} if value is None else {"clock_date_format": value}
+        html = render_overlay_html(self._snapshot(), self.theme, **kwargs)  # type: ignore[arg-type]
+        match = re.search(r'data-clock-date-format="([^"]*)"', html)
+        assert match is not None, "the clock date format never reached the markup"
+        return match.group(1)
 
-    def test_unknown_and_empty_styles_fall_back_to_long(self) -> None:
-        for value in ("", "   ", "gibberish", None):
+    def test_every_preset_resolves_to_its_template(self) -> None:
+        for name, template in CLOCK_DATE_PRESETS.items():
+            with self.subTest(preset=name):
+                self.assertEqual(resolve_clock_date_format(name), template)
+
+    def test_presets_reach_the_markup(self) -> None:
+        for name, template in CLOCK_DATE_PRESETS.items():
+            with self.subTest(preset=name):
+                self.assertEqual(self._rendered_format(name), template)
+
+    def test_a_custom_template_passes_through(self) -> None:
+        """The British arrangement is a config edit, not a code change."""
+        self.assertEqual(
+            self._rendered_format("{weekday}, {day} {month}"),
+            "{weekday}, {day} {month}",
+        )
+
+    def test_preset_names_tolerate_case_and_padding(self) -> None:
+        self.assertEqual(
+            resolve_clock_date_format("  Day-First "),
+            CLOCK_DATE_PRESETS["day-first"],
+        )
+
+    def test_unusable_values_fall_back_to_the_default_preset(self) -> None:
+        default = CLOCK_DATE_PRESETS["long"]
+        for value in (None, "", "   ", "just words", "{nonsense} {day}", "{}"):
             with self.subTest(value=value):
-                self.assertEqual(normalize_clock_date_style(value), "long")
+                self.assertEqual(resolve_clock_date_format(value), default)
 
-    def test_style_matching_ignores_case_and_padding(self) -> None:
-        self.assertEqual(normalize_clock_date_style("  Ordinal-Year "), "ordinal-year")
+    def test_an_overlong_template_falls_back(self) -> None:
+        """A runaway config value must not push the clock card off the screen."""
+        self.assertEqual(
+            resolve_clock_date_format("{weekday} " + "x" * 200),
+            CLOCK_DATE_PRESETS["long"],
+        )
 
-    def test_default_style_is_rendered_without_an_explicit_argument(self) -> None:
-        html = render_overlay_html(self._snapshot(), self.theme)
-        self.assertIn('data-clock-date-style="long"', html)
+    def test_the_default_is_used_without_an_explicit_argument(self) -> None:
+        self.assertEqual(self._rendered_format(), CLOCK_DATE_PRESETS["long"])
 
-    def test_javascript_implements_exactly_the_declared_styles(self) -> None:
-        """A style Python accepts but overlay.js cannot render would silently show `long`."""
-        block = OVERLAY_JS.split("const dateStyles = {", 1)[1].split("};", 1)[0]
-        in_js = set(re.findall(r"^\s*'?([a-z-]+)'?:", block, re.MULTILINE))
-        self.assertEqual(in_js, set(CLOCK_DATE_STYLES))
+    def test_a_template_cannot_break_out_of_the_attribute(self) -> None:
+        rendered = render_overlay_html(
+            self._snapshot(),
+            self.theme,
+            clock_date_format='{day}" onload="alert(1)',
+        )
+        self.assertNotIn('onload="alert(1)"', rendered)
+
+    def test_javascript_default_matches_the_python_default(self) -> None:
+        """The JS fallback only shows when the attribute is missing; it must still agree."""
+        match = re.search(r"const DEFAULT_DATE_FORMAT = '([^']*)'", OVERLAY_JS)
+        assert match is not None, "overlay.js no longer declares a default date format"
+        self.assertEqual(match.group(1), CLOCK_DATE_PRESETS["long"])
+
+    def test_javascript_substitutes_every_declared_token(self) -> None:
+        """A token Python advertises but the JS cannot fill would render as itself."""
+        from pulse.overlay import CLOCK_DATE_TOKENS
+
+        block = OVERLAY_JS.split("const values = {", 1)[1].split("};", 1)[0]
+        in_js = set(re.findall(r"^\s*([a-z]+)[,:]", block, re.MULTILINE))
+        self.assertEqual(in_js, set(CLOCK_DATE_TOKENS))


### PR DESCRIPTION
## The bug

The clock read **Tuesday 1 September** — day-first, no year — on kiosks sitting in a US house.

Not a formatting bug. Raspberry Pi OS ships `LANG=en_GB.UTF-8`, all four kiosks still had it, and `en_US.UTF-8` was never even generated. `bin/kiosk-wrap.sh` set no locale, so Chromium took the OS default and baked it in. Confirmed live over CDP on pulse-kitchen:

```json
{"resolved":"en-GB","navLang":"en-GB","navLangs":["en-GB","en-US","en"],
 "sample":"Tuesday 1 September"}
```

`assets/overlay/overlay.js` then made it worse by passing `undefined` as the locale to `Intl.DateTimeFormat`, handing the arrangement to whatever the browser happened to resolve, with no year in the options.

## The fix, in two layers

**1. Pin the kiosk locale.** `kiosk-wrap.sh` exports `LANG`/`LC_ALL`/`LANGUAGE` and passes `--lang` / `--accept-lang` to Chromium — the flags matter because Chromium *also* persists an app locale in its profile from whatever it saw on first run, so fixing the OS default alone would not dislodge it. Override per device with `PULSE_KIOSK_LOCALE` (default `en_US.UTF-8`).

**2. Make the arrangement a config value,** `PULSE_OVERLAY_CLOCK_DATE_FORMAT` — a preset name or a template of `{weekday}` `{month}` `{day}` `{ordinal}` `{year}`:

| Value | Renders |
| --- | --- |
| `long` (default) | Tuesday, September 1, 2026 |
| `long-no-year` | Tuesday, September 1 |
| `ordinal` | Tuesday, September 1st |
| `ordinal-year` | Tuesday, September 1st, 2026 |
| `day-first` | Tuesday 1 September 2026 |
| `day-first-no-year` | Tuesday 1 September |
| `{weekday}, {day} {month}` | Tuesday, 1 September |

Templates resolve server-side and `overlay.js` only substitutes, so the preset list lives in exactly one place and cannot drift between the two ends. Month and weekday names come from an explicit `en-US`, so the display no longer depends on a device's locale even if one gets reimaged. Ordinals come from `Intl.PluralRules` — no combination of `Intl.DateTimeFormat` options produces `1st`.

Unrecognised, empty, or overlong (>120 char) values fall back to `long`: a kiosk showing the wrong arrangement is a nuisance, one showing a raw `{month}` or a blank line is a bug report. An unknown token *inside* an otherwise valid template renders as itself, so a typo is visible rather than a mysterious gap.

## Plumbing

Follows the existing `PULSE_OVERLAY_CLOCK_24H` path: env → `OverlayConfig` (`bin/kiosk-mqtt-listener.py`) → `OverlayServerConfig` → `data-clock-date-format` on the overlay root → `overlay.js`.

## Tests

`ClockDateFormatTests` covers every preset resolving and reaching the markup, custom templates passing through, case/padding tolerance on preset names, the fallback for empty/garbage/unknown-token/overlong values, the no-argument default, and an attribute-escaping attempt. Two tests guard the Python↔JS seam: the JS fallback template must equal the Python default, and the JS `values` map must fill exactly the tokens Python advertises — a token on one side only would silently render as itself.

All six presets plus `{weekday}, {day} {month}` were rendered through the real `overlay.js` logic against templates resolved by the real Python resolver, covering 1st/2nd/3rd, the 11th–13th teens exception, 22nd, 30th, a missing attribute, an unknown token and an invalid timezone. Full suite: 2141 passed.

## Not included

Setting `LANG=en_US.UTF-8` on the four kiosks themselves (`locale-gen` + `update-locale`) is a host change, not a repo change, and still needs doing — the wrapper's `--lang` makes the *display* correct regardless, but the shell environment on each Pi is still en_GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d2PANrZncd668vf8zEhJS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and configuration only for kiosk overlay clocks; no auth, data, or payment paths. Wrong locale or format is visible but bounded by safe fallbacks.
> 
> **Overview**
> Fixes US kiosks showing **Tuesday 1 September** (no year) by pinning Chromium to **en-US** and making the clock date line independent of browser locale.
> 
> **Kiosk session:** `kiosk-wrap.sh` sets `LANG`/`LC_ALL`/`LANGUAGE` from `PULSE_KIOSK_LOCALE` (default `en_US.UTF-8`) and passes `--lang` / `--accept-lang` so profile-stored Chromium locale does not keep `en-GB` from Raspberry Pi OS.
> 
> **Clock date:** New `PULSE_OVERLAY_CLOCK_DATE_FORMAT` — preset names (`long`, `ordinal`, `day-first`, etc.) or a `{weekday}` `{month}` `{day}` `{ordinal}` `{year}` template. Python resolves presets via `resolve_clock_date_format()` and exposes the template on `data-clock-date-format`; `overlay.js` builds the string with fixed **en-US** `formatToParts`, ordinal suffixes, and token substitution (invalid/overlong config falls back to `long`).
> 
> Wiring matches `PULSE_OVERLAY_CLOCK_24H` (env → overlay config → HTTP server → HTML). Docs, sample config, and `ClockDateFormatTests` cover presets, escaping, and Python/JS default parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e150e09ae5ca5820ce6a6edae76eb6fd01200a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->