### PR TITLE
fix(overlay): step the clock date down a size instead of wrapping it

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1059,6 +1059,19 @@ body {
   font-size: clamp(1.3rem, 3vw, 2.2rem);
   font-weight: 400;
   opacity: 0.85;
+  /* The clock sits in a fixed grid cell (403px on a 1280x720 kiosk) and the longest
+     date it can render -- "Wednesday, September 30, 2026" -- is wider than that. A
+     wrapped date pushes the card into two ragged lines, so it steps down a size
+     instead; overlay.js adds the classes below when the text does not fit. */
+  white-space: nowrap;
+}
+
+.overlay-clock__date--tight {
+  font-size: clamp(1.2rem, 2.6vw, 1.9rem);
+}
+
+.overlay-clock__date--tighter {
+  font-size: clamp(1.1rem, 2.3vw, 1.7rem);
 }
 
 .overlay-card--ambient {

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -209,6 +209,22 @@ window.PulseOverlay.initialize = function() {
     );
   };
 
+  // Step the date down a size rather than let it wrap: the clock sits in a fixed grid
+  // cell, and the longest date the templates can produce is wider than that cell on a
+  // 1280x720 kiosk. Measuring beats counting characters -- the overlay font is
+  // proportional and configurable, so "Wednesday" and "May 1st" are not comparable by
+  // length. Only runs when the text changes, i.e. once a day, not on every tick.
+  const dateFitClasses = ['overlay-clock__date--tight', 'overlay-clock__date--tighter'];
+  const fitClockDate = (el) => {
+    el.classList.remove(...dateFitClasses);
+    for (const className of dateFitClasses) {
+      if (el.scrollWidth <= el.clientWidth) {
+        return;
+      }
+      el.classList.add(className);
+    }
+  };
+
   const tick = () => {
     const now = new Date();
     const clockNodes = root.querySelectorAll('[data-clock]');
@@ -225,7 +241,11 @@ window.PulseOverlay.initialize = function() {
       }
       if (dateEl) {
         try {
-          dateEl.textContent = formatClockDate(now, tz);
+          const dateText = formatClockDate(now, tz);
+          if (dateEl.textContent !== dateText) {
+            dateEl.textContent = dateText;
+            fitClockDate(dateEl);
+          }
         } catch (err) {
           // Silently handle timezone formatting errors
         }

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -25,7 +25,7 @@ from pulse.overlay import (
     render_overlay_html,
     resolve_clock_date_format,
 )
-from pulse.overlay_assets import OVERLAY_JS
+from pulse.overlay_assets import OVERLAY_CSS, OVERLAY_JS
 from pulse.weather_alerts import BANNER_ALWAYS
 
 
@@ -1792,3 +1792,46 @@ class ClockDateFormatTests(unittest.TestCase):
         block = OVERLAY_JS.split("const values = {", 1)[1].split("};", 1)[0]
         in_js = set(re.findall(r"^\s*([a-z]+)[,:]", block, re.MULTILINE))
         self.assertEqual(in_js, set(CLOCK_DATE_TOKENS))
+
+
+class ClockDateFitTests(unittest.TestCase):
+    """The date steps down a size rather than wrapping; the two ends must agree."""
+
+    @staticmethod
+    def _rule_body(selector: str) -> str:
+        """Every top-level rule for exactly this selector, concatenated.
+
+        The stylesheet splits `.overlay-clock__date` across several rules and also
+        mentions it inside compound selectors, so a naive substring search reads the
+        wrong block.
+        """
+        pattern = re.compile(rf"^{re.escape(selector)}\s*\{{([^}}]*)\}}", re.MULTILINE)
+        return "\n".join(pattern.findall(OVERLAY_CSS))
+
+    def _fit_classes(self) -> list[str]:
+        block = OVERLAY_JS.split("const dateFitClasses = [", 1)[1].split("]", 1)[0]
+        return re.findall(r"'([^']+)'", block)
+
+    @staticmethod
+    def _clamp_max_rem(body: str) -> float:
+        match = re.search(r"font-size:\s*clamp\([^,]+,[^,]+,\s*([\d.]+)rem\)", body)
+        assert match is not None, f"no clamped font-size in rule body: {body!r}"
+        return float(match.group(1))
+
+    def test_the_date_never_wraps(self) -> None:
+        self.assertIn("white-space: nowrap", self._rule_body(".overlay-clock__date"))
+
+    def test_every_step_down_class_is_styled(self) -> None:
+        """A class the JS adds with no rule behind it would silently do nothing."""
+        classes = self._fit_classes()
+        self.assertTrue(classes, "overlay.js no longer declares any step-down classes")
+        for class_name in classes:
+            with self.subTest(class_name=class_name):
+                self.assertTrue(self._rule_body(f".{class_name}").strip())
+
+    def test_the_steps_get_progressively_smaller(self) -> None:
+        """Applied in order, so a later class that is not smaller would never help."""
+        sizes = [self._clamp_max_rem(self._rule_body(".overlay-clock__date"))]
+        sizes += [self._clamp_max_rem(self._rule_body(f".{name}")) for name in self._fit_classes()]
+        self.assertEqual(sizes, sorted(sizes, reverse=True))
+        self.assertEqual(len(set(sizes)), len(sizes), "two steps render at the same size")


### PR DESCRIPTION
## The problem

Found on pulse-office right after the #252 rollout: **`Tuesday, September 1, 2026` wrapped onto two lines.**

The clock card sits in a fixed grid cell — 403px on a 1280x720 kiosk — and the date element fills it. Measured on the device against its own font at the base `2.2rem`:

| String | Width | Fits 403px? |
| --- | --- | --- |
| `Wednesday, September 30, 2026` (`long` worst case) | 521px | no |
| `Wednesday, September 30th` (`ordinal` worst case) | 453px | no |
| `Wednesday, September 30` (`long-no-year` worst) | 423px | no |
| `Tuesday, September 1st` (today, `ordinal`) | 379px | yes |

So this was not specific to the year: **every preset has days that overflow the cell.** Switching the fleet to `ordinal` hides it today and it would come back on, say, September 30th.

## The fix

`.overlay-clock__date` is now `white-space: nowrap`, and `overlay.js` measures `scrollWidth` against `clientWidth` after the text changes, applying up to two progressively smaller steps (`--tight` 1.9rem, `--tighter` 1.7rem).

Measuring rather than counting characters: the overlay font is proportional and user-configurable (`PULSE_OVERLAY_CLOCK_FONT`), so `Wednesday` and `May 1st` are not comparable by length. The fitter runs only when the rendered string actually changes — once a day — not on every tick.

An unfittable custom template overhangs on one line rather than being clipped or wrapped; a slight overhang is more readable than a truncated date.

## Verified on the device

Injected the candidate CSS and fitter into the live pulse-office kiosk over CDP:

| String | Class applied | Font | Result |
| --- | --- | --- | --- |
| `Tuesday, September 1st` | (base) | 35.2px | one line, no overflow |
| `Wednesday, September 30th` | `--tight` | 30.4px | one line, no overflow |
| `Wednesday, September 30, 2026` | `--tighter` | 27.2px | one line, no overflow |
| `Wednesday, September 30` | `--tight` | 30.4px | one line, no overflow |
| `Wednesday 30 September 2026` | `--tighter` | 27.2px | one line, no overflow |

## Tests

`ClockDateFitTests` guards the CSS↔JS seam the same way #252 guards the Python↔JS one: the date must be `nowrap`, every class the JS applies must have a rule behind it, and the steps must be strictly decreasing — a step that is not smaller than the one before would never help. Full suite: 2144 passed.

Deploying this needs a page reload per kiosk, not just a service restart (overlay CSS ships with the loaded page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d2PANrZncd668vf8zEhJS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Kiosk overlay presentation only; no backend, auth, or data paths. Worst case is a slightly oversized single-line date if both steps are insufficient.
> 
> **Overview**
> Fixes long clock dates wrapping onto two ragged lines in the fixed bottom-left grid cell on 1280×720 kiosks.
> 
> **CSS** sets `.overlay-clock__date` to `white-space: nowrap` and adds two smaller presets (`--tight`, `--tighter`) via stepped `clamp()` font sizes.
> 
> **JavaScript** runs `fitClockDate` after the formatted date string changes (typically once per day): it compares `scrollWidth` to `clientWidth` and applies those classes in order until the text fits or both steps are exhausted—measurement instead of character counting so custom fonts and date templates stay accurate.
> 
> **Tests** (`ClockDateFitTests`) lock the CSS↔JS contract: nowrap on the base rule, every JS step class has a stylesheet rule, and max `rem` sizes strictly decrease.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3914ed6a229f8019a450f44a359346c13c6f94ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->