### PR TITLE
fix(overlay): fit the clock date on the narrower 1280x800 cell, and document PULSE_KIOSK_LOCALE

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -1071,7 +1071,11 @@ body {
 }
 
 .overlay-clock__date--tighter {
-  font-size: clamp(1.1rem, 2.3vw, 1.7rem);
+  font-size: clamp(1.1rem, 2.3vw, 1.6rem);
+}
+
+.overlay-clock__date--tightest {
+  font-size: clamp(1rem, 2vw, 1.4rem);
 }
 
 .overlay-card--ambient {

--- a/assets/overlay/overlay.js
+++ b/assets/overlay/overlay.js
@@ -214,7 +214,11 @@ window.PulseOverlay.initialize = function() {
   // 1280x720 kiosk. Measuring beats counting characters -- the overlay font is
   // proportional and configurable, so "Wednesday" and "May 1st" are not comparable by
   // length. Only runs when the text changes, i.e. once a day, not on every tick.
-  const dateFitClasses = ['overlay-clock__date--tight', 'overlay-clock__date--tighter'];
+  const dateFitClasses = [
+    'overlay-clock__date--tight',
+    'overlay-clock__date--tighter',
+    'overlay-clock__date--tightest',
+  ];
   const fitClockDate = (el) => {
     el.classList.remove(...dateFitClasses);
     for (const className of dateFitClasses) {

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -24,6 +24,7 @@ This guide lists every `pulse.conf` variable, its default value from `pulse.conf
 | `PULSE_WATCHDOG_URL` | `http://homeassistant.local:8123/static/icons/favicon.ico` | Lightweight URL Chromium fetches to prove connectivity. |
 | `PULSE_WATCHDOG_LIMIT` | `5` | Consecutive watchdog fetch failures before Chromium is restarted. |
 | `PULSE_WATCHDOG_INTERVAL` | `60` | Seconds between watchdog fetches. |
+| `PULSE_KIOSK_LOCALE` | `en_US.UTF-8` | Locale exported to the kiosk session and passed to Chromium as `--lang` / `--accept-lang` (converted to BCP 47, so `en_US.UTF-8` becomes `en-US`). Raspberry Pi OS ships `en_GB.UTF-8`, which Chromium otherwise uses for every date, number and sort it renders. Generate the locale on the device first: `sudo locale-gen <locale> && sudo update-locale LANG=<locale>`. |
 | `CHROMIUM_DEVTOOLS_URL` | `http://localhost:9222/json` | Remote debugging endpoint for kiosk automation. |
 | `CHROMIUM_DEVTOOLS_TIMEOUT` | `3` | Timeout (seconds) for DevTools HTTP/WebSocket operations. |
 

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -43,6 +43,13 @@ PULSE_WATCHDOG_LIMIT=5
 # PULSE_WATCHDOG_INTERVAL — seconds between watchdog fetches.
 PULSE_WATCHDOG_INTERVAL=60
 
+# PULSE_KIOSK_LOCALE — locale the kiosk session and Chromium run under. Raspberry Pi OS
+# images ship en_GB.UTF-8, which Chromium then uses for every date, number and sort it
+# renders. Set here rather than relying on the OS default, and generate it on the device
+# first (sudo locale-gen <locale> && sudo update-locale LANG=<locale>). The BCP 47 form
+# is derived for Chromium's --lang, so en_US.UTF-8 becomes en-US.
+PULSE_KIOSK_LOCALE="en_US.UTF-8"
+
 # CHROMIUM_DEVTOOLS_URL — DevTools discovery endpoint for kiosk navigation/debug (default points to local Chromium).
 CHROMIUM_DEVTOOLS_URL="http://localhost:9222/json"
 


### PR DESCRIPTION
## Follow-up to #253

Two loose ends the rollout turned up.

### 1. The `long` preset overhung pulse-kitchen's cell

The reload sweep after #253 found one residual: on **pulse-kitchen** the `long` preset's worst case still overhung, while fitting on the other three kiosks.

Kitchen is a 1280x**800** panel — the others are 720p — and its clock cell is **400px** against their 403px. Measured on both devices in the shipped clock font:

| Step | `Wednesday, September 30, 2026` | Fits 400px (kitchen)? | Fits 403px (others)? |
| --- | --- | --- | --- |
| `--tighter` at 1.7rem (before) | 403px | no | yes, exactly |
| `--tighter` at 1.6rem (now) | 379px | yes | yes |
| new `--tightest` at 1.4rem | 332px | yes | yes |

Three pixels, and only on a preset the fleet doesn't currently use — but the shipped default shouldn't overhang on hardware we actually run, and 403-into-403 was never real headroom.

`--tighter` drops 1.7rem → 1.6rem, and a third step `--tightest` at 1.4rem catches anything longer, such as a custom template. The existing `ClockDateFitTests` already require every class the JS applies to be styled and the steps to be strictly decreasing, so the new step is covered without new tests.

### 2. `PULSE_KIOSK_LOCALE` was undocumented

It shipped in #252 with a working default but never reached `pulse.conf.sample` or `docs/config-reference.md` — so the single knob deciding how every date, number and sort on a kiosk renders was discoverable only by reading `kiosk-wrap.sh`. Now documented in both, including the `locale-gen` step: setting the variable alone does nothing if the device has never generated that locale, which was true of all four kiosks here.

Full suite: 2144 passed. Needs a page reload per kiosk to take effect, same as #253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d2PANrZncd668vf8zEhJS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side overlay typography and config documentation only; no auth, data, or server logic changes in the diff.
> 
> **Overview**
> **Overlay clock date** on 1280×800 panels (400px-wide cell) could still overhang after the previous fit logic. This PR tightens the middle step and adds one more.
> 
> The `--tighter` date class max size drops from **1.7rem to 1.6rem**, and a new **`--tightest`** step (**1.4rem** max) is wired into the existing `fitClockDate` loop in `overlay.js` so long `long`-preset strings (and custom templates) measure down until they fit without wrapping.
> 
> Separately, **`PULSE_KIOSK_LOCALE`** is documented in `pulse.conf.sample` and `docs/config-reference.md` (default `en_US.UTF-8`, session/Chromium `--lang`, Pi locale-gen note). Kiosk reload needed for overlay CSS/JS; locale needs a kiosk session restart when changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613f88a8162469696f5957f6585d7e10e912776f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->