### PR TITLE
fix(calendar): stop a slow feed from erasing its own events

### DIFF
--- a/pulse/assistant/calendar_sync.py
+++ b/pulse/assistant/calendar_sync.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
@@ -17,6 +18,28 @@ from icalendar import Calendar, Component  # type: ignore[import-untyped]
 from .config import CalendarConfig
 
 LOGGER = logging.getLogger("pulse.calendar_sync")
+
+# Budget for one feed: fetch, parse and window expansion. A ~19 MB Google work export
+# measures roughly 17s + 14s + 1s on a Pi 4, so this leaves room for a bad day without
+# letting one feed hold the sweep open indefinitely.
+FEED_SYNC_TIMEOUT = 90.0
+
+# Google re-stamps DTSTAMP and reorders lines on every export, so a feed's raw bytes
+# never repeat even when nothing in the calendar changed -- a plain hash of the body
+# would never match. Sorting the non-volatile lines gives a key that moves only when
+# the calendar does: measured at 0.4s against a 19 MB feed, against ~14s to re-parse it.
+_VOLATILE_ICS_PREFIXES = (b"DTSTAMP", b"LAST-MODIFIED", b"CREATED", b"SEQUENCE")
+
+
+def _content_digest(body: bytes) -> str:
+    """Digest an ICS body, ignoring per-export churn, folding and line ordering."""
+
+    # Unfold first (RFC 5545 continuation lines). Google re-wraps long ATTENDEE
+    # properties at different octet boundaries between exports, which moved ~434 lines
+    # of an unchanged work calendar and defeated a line-level digest on its own.
+    unfolded = body.replace(b"\r\n ", b"").replace(b"\r\n\t", b"")
+    lines = sorted(line for line in unfolded.split(b"\r\n") if not line.startswith(_VOLATILE_ICS_PREFIXES))
+    return hashlib.sha256(b"\n".join(lines)).hexdigest()
 
 
 def _now() -> datetime:
@@ -94,6 +117,14 @@ class _FeedState:
     label: str | None = None
     active_keys: set[str] = field(default_factory=set)
     owner_tokens: set[str] = field(default_factory=set)
+    # Digest of the body behind `calendar`, so an unchanged feed is not re-parsed.
+    # A 19 MB work export costs ~14s of CPU to parse on a Pi; the window it feeds
+    # moves every cycle, but the bytes usually do not.
+    body_hash: str | None = None
+    calendar: Component | None = None
+    # This feed's contribution to the overlay snapshot. Held per feed so one slow
+    # or failing feed drops only its own events instead of blanking the badge.
+    window: dict[str, CalendarReminder] = field(default_factory=dict)
 
 
 class CalendarSyncService:
@@ -131,7 +162,6 @@ class CalendarSyncService:
         self._last_sync_completed: datetime | None = None
         self._retry_tasks: dict[str, asyncio.Task] = {}
         self._failed_feeds: set[str] = set()
-        self._windowed_events: dict[str, CalendarReminder] = {}
 
     async def start(self) -> None:
         if not self._config.feeds:
@@ -140,11 +170,13 @@ class CalendarSyncService:
         if self._runner:
             return
         self._stop_event.clear()
-        # Keep per-request timeouts tight so a slow network (e.g., while music
-        # is streaming) cannot stall the sync loop.
+        # Generous enough for a large export -- a full Google work calendar runs to
+        # ~19 MB and takes ~17s to fetch on a Pi -- while still bounded, so a slow
+        # network (e.g. while music is streaming) cannot stall the sync loop. Every
+        # value here must stay under FEED_SYNC_TIMEOUT.
         self._client = httpx.AsyncClient(
             follow_redirects=True,
-            timeout=httpx.Timeout(25.0, connect=8.0, read=18.0, write=12.0, pool=12.0),
+            timeout=httpx.Timeout(75.0, connect=8.0, read=45.0, write=12.0, pool=12.0),
         )
         self._runner = asyncio.create_task(self._run_loop())
 
@@ -171,12 +203,16 @@ class CalendarSyncService:
 
     async def _run_loop(self) -> None:
         refresh_seconds = max(1, self._config.refresh_minutes) * 60
+        # Derived from the per-feed budget rather than fixed: a flat cap below
+        # FEED_SYNC_TIMEOUT x feeds can kill a sweep before a single feed has used
+        # its own allowance, which is what a 30s cap over a 60s per-feed budget did.
+        loop_timeout = FEED_SYNC_TIMEOUT * max(1, len(self._feed_states)) + 30.0
         while not self._stop_event.is_set():
             try:
-                await asyncio.wait_for(self._sync_once(), timeout=30.0)
+                await asyncio.wait_for(self._sync_once(), timeout=loop_timeout)
             except TimeoutError:
                 # Avoid noisy tracebacks when a slow sync exceeds the loop budget
-                self._logger.warning("[calendar] Calendar sync loop timed out after 30s; continuing")
+                self._logger.warning("[calendar] Calendar sync loop timed out after %.0fs; continuing", loop_timeout)
             except Exception:
                 self._logger.exception("[calendar] Calendar sync loop failed; continuing")
             try:
@@ -201,17 +237,28 @@ class CalendarSyncService:
         now = _now()
         self._last_sync_started = now
         self._prune_triggered(now)
-        self._windowed_events.clear()
+        # Each feed replaces its own slice on success (see _schedule_reminders). A feed
+        # that times out or errors keeps the slice it had, so one slow calendar no
+        # longer deletes its own events from the overlay -- the symptom was a work
+        # calendar's events vanishing from the badge while its reminders still fired.
         for state in self._feed_states.values():
             feed_label = self._feed_label(state)
             try:
-                await asyncio.wait_for(self._sync_feed(state, now), timeout=60.0)
+                await asyncio.wait_for(self._sync_feed(state, now), timeout=FEED_SYNC_TIMEOUT)
             except TimeoutError:
-                self._logger.warning("[calendar] Calendar sync timed out for feed '%s'", feed_label)
+                self._logger.warning(
+                    "[calendar] Calendar sync timed out for feed '%s'; keeping its %d known event(s)",
+                    feed_label,
+                    len(state.window),
+                )
             except Exception:
-                self._logger.exception("[calendar] Calendar sync failed for feed '%s'", feed_label)
+                self._logger.exception(
+                    "[calendar] Calendar sync failed for feed '%s'; keeping its %d known event(s)",
+                    feed_label,
+                    len(state.window),
+                )
         try:
-            await self._emit_event_snapshot()
+            await self._emit_event_snapshot(now)
         except Exception:
             self._logger.exception("[calendar] Calendar snapshot emit failed")
         else:
@@ -248,17 +295,30 @@ class CalendarSyncService:
         self._cancel_retry(state.url)
         state.etag = response.headers.get("etag") or state.etag
         state.last_modified = response.headers.get("last-modified") or state.last_modified
-        try:
-            calendar = Calendar.from_ical(response.content)
-        except Exception as exc:
-            self._logger.warning("[calendar] Calendar parse failed for '%s': %s", feed_label, exc)
-            self._schedule_retry(state.url)
-            return
+        # Parsing is the expensive half -- a ~19 MB export costs ~14s of CPU -- and these
+        # feeds carry no ETag or Last-Modified, so the content is digested instead: an
+        # unchanged calendar reuses the parse and only its window is expanded again.
+        digest = await asyncio.to_thread(_content_digest, response.content)
+        if state.body_hash == digest and state.calendar is not None:
+            calendar = state.calendar
+        else:
+            try:
+                # Off the event loop: 14s of blocking parse would otherwise stall
+                # reminders, MQTT and the overlay for the whole duration.
+                calendar = await asyncio.to_thread(Calendar.from_ical, response.content)
+            except Exception as exc:
+                self._logger.warning("[calendar] Calendar parse failed for '%s': %s", feed_label, exc)
+                self._schedule_retry(state.url)
+                return
+            state.calendar = calendar
+            state.body_hash = digest
         calendar_name = calendar.get("X-WR-CALNAME")
         if calendar_name:
             state.calendar_name = str(calendar_name)
             state.label = state.calendar_name
-        reminders = self._collect_reminders(calendar, state, now)
+        # Expansion reads only the parsed calendar, the feed's owner tokens and config,
+        # so it is safe to run in a worker thread alongside the loop.
+        reminders = await asyncio.to_thread(self._collect_reminders, calendar, state, now)
         if not reminders:
             self._logger.debug(
                 "[calendar] Calendar feed '%s' produced no reminders at %s",
@@ -561,6 +621,9 @@ class CalendarSyncService:
     ) -> None:
         lookahead_end = now + timedelta(hours=self._config.lookahead_hours)
         valid_keys: set[str] = set()
+        # Built here and swapped into the feed state at the end: the slice is replaced
+        # only by a pass that got this far, never emptied by one that failed earlier.
+        window: dict[str, CalendarReminder] = {}
         # First pass: collect all valid reminders and their trigger times per UID
         valid_reminders: list[CalendarReminder] = []
         uids_to_schedule: dict[str, dict[str, set[datetime]]] = {}  # uid -> {source_url: {trigger_times}}
@@ -576,9 +639,9 @@ class CalendarSyncService:
             include_in_window = reminder.start <= lookahead_end or reminder.trigger_time <= lookahead_end
             if include_in_window and not reminder.declined:
                 window_key = self._window_key(reminder)
-                existing = self._windowed_events.get(window_key)
+                existing = window.get(window_key)
                 if not existing or reminder.trigger_time < existing.trigger_time:
-                    self._windowed_events[window_key] = reminder
+                    window[window_key] = reminder
             trigger_time = reminder.trigger_time
             if trigger_time < now - timedelta(minutes=1):
                 skipped_past_triggers += 1
@@ -623,6 +686,7 @@ class CalendarSyncService:
             self._scheduled_reminders.pop(key, None)
             self._key_to_feed.pop(key, None)
         state.active_keys = {key for key in valid_keys if key in self._scheduled}
+        state.window = window
         if reminders and not valid_reminders:
             self._logger.warning(
                 "[calendar] Calendar feed '%s' had %d reminder(s) but none were scheduled "
@@ -730,8 +794,20 @@ class CalendarSyncService:
             self._key_to_feed.pop(key, None)
             state.active_keys.discard(key)
 
-    async def _emit_event_snapshot(self) -> None:
-        ordered = sorted(self._windowed_events.values(), key=lambda reminder: (reminder.start, reminder.trigger_time))
+    async def _emit_event_snapshot(self, now: datetime | None = None) -> None:
+        now = now or _now()
+        # Merge every feed's slice, dropping anything that has since ended. A slice held
+        # over from a failed sync decays on its own this way, rather than pinning an
+        # event to the badge until that feed succeeds again.
+        merged: dict[str, CalendarReminder] = {}
+        for state in self._feed_states.values():
+            for window_key, reminder in state.window.items():
+                if (reminder.end or reminder.start) <= now:
+                    continue
+                existing = merged.get(window_key)
+                if not existing or reminder.trigger_time < existing.trigger_time:
+                    merged[window_key] = reminder
+        ordered = sorted(merged.values(), key=lambda reminder: (reminder.start, reminder.trigger_time))
         if not ordered:
             self._logger.debug(
                 "[calendar] No upcoming calendar events found within the next %d hour(s)",

--- a/pulse/assistant/calendar_sync.py
+++ b/pulse/assistant/calendar_sync.py
@@ -32,14 +32,49 @@ _VOLATILE_ICS_PREFIXES = (b"DTSTAMP", b"LAST-MODIFIED", b"CREATED", b"SEQUENCE")
 
 
 def _content_digest(body: bytes) -> str:
-    """Digest an ICS body, ignoring per-export churn, folding and line ordering."""
+    """Digest an ICS body, ignoring per-export churn, folding and component ordering.
+
+    Components are digested individually and only those digests are sorted, so a line
+    keeps its association with the event it came from: moving a SUMMARY or DTSTART
+    between two events changes the result, even though the file's set of lines has not.
+    """
 
     # Unfold first (RFC 5545 continuation lines). Google re-wraps long ATTENDEE
     # properties at different octet boundaries between exports, which moved ~434 lines
     # of an unchanged work calendar and defeated a line-level digest on its own.
     unfolded = body.replace(b"\r\n ", b"").replace(b"\r\n\t", b"")
-    lines = sorted(line for line in unfolded.split(b"\r\n") if not line.startswith(_VOLATILE_ICS_PREFIXES))
-    return hashlib.sha256(b"\n".join(lines)).hexdigest()
+    component_digests: list[bytes] = []
+    calendar_lines: list[bytes] = []
+    current: list[bytes] | None = None
+    depth = 0
+    for line in unfolded.split(b"\r\n"):
+        if line.startswith(_VOLATILE_ICS_PREFIXES):
+            continue
+        if line.startswith(b"BEGIN:VCALENDAR") or line.startswith(b"END:VCALENDAR"):
+            continue
+        if line.startswith(b"BEGIN:"):
+            depth += 1
+            if depth == 1:
+                current = []
+        if current is not None:
+            # Nested components (a VALARM inside its VEVENT) stay part of the block, so
+            # a reminder moving between events also changes the digest.
+            current.append(line)
+        else:
+            calendar_lines.append(line)
+        if line.startswith(b"END:"):
+            depth = max(0, depth - 1)
+            if depth == 0 and current is not None:
+                component_digests.append(hashlib.sha256(b"\n".join(current)).digest())
+                current = None
+    if current:  # unterminated component: keep its content rather than dropping it
+        component_digests.append(hashlib.sha256(b"\n".join(current)).digest())
+    digest = hashlib.sha256()
+    for line in sorted(calendar_lines):
+        digest.update(line + b"\n")
+    for component in sorted(component_digests):
+        digest.update(component)
+    return digest.hexdigest()
 
 
 def _now() -> datetime:
@@ -258,7 +293,9 @@ class CalendarSyncService:
                     len(state.window),
                 )
         try:
-            await self._emit_event_snapshot(now)
+            # No `now` argument: a sweep can run for half a minute over a large feed,
+            # and events that ended during it must not linger in the snapshot.
+            await self._emit_event_snapshot()
         except Exception:
             self._logger.exception("[calendar] Calendar snapshot emit failed")
         else:
@@ -286,32 +323,40 @@ class CalendarSyncService:
         if response.status_code == 304:
             # Successful response (not modified) - clear any retry
             self._cancel_retry(state.url)
-            return
-        if response.status_code >= 400:
+            if state.calendar is None:
+                return
+            # Fall through to re-expand the cached calendar. The lookahead window moves
+            # even when the feed does not, so returning here would freeze this feed's
+            # slice: events entering the window later would never appear and their
+            # reminders would never be scheduled until the body happened to change.
+            calendar = state.calendar
+        elif response.status_code >= 400:
             self._logger.warning("[calendar] Calendar fetch returned %s for '%s'", response.status_code, feed_label)
             self._schedule_retry(state.url)
             return
-        # Successful fetch - clear any retry
-        self._cancel_retry(state.url)
-        state.etag = response.headers.get("etag") or state.etag
-        state.last_modified = response.headers.get("last-modified") or state.last_modified
-        # Parsing is the expensive half -- a ~19 MB export costs ~14s of CPU -- and these
-        # feeds carry no ETag or Last-Modified, so the content is digested instead: an
-        # unchanged calendar reuses the parse and only its window is expanded again.
-        digest = await asyncio.to_thread(_content_digest, response.content)
-        if state.body_hash == digest and state.calendar is not None:
-            calendar = state.calendar
         else:
-            try:
-                # Off the event loop: 14s of blocking parse would otherwise stall
-                # reminders, MQTT and the overlay for the whole duration.
-                calendar = await asyncio.to_thread(Calendar.from_ical, response.content)
-            except Exception as exc:
-                self._logger.warning("[calendar] Calendar parse failed for '%s': %s", feed_label, exc)
-                self._schedule_retry(state.url)
-                return
-            state.calendar = calendar
-            state.body_hash = digest
+            # Successful fetch - clear any retry
+            self._cancel_retry(state.url)
+            state.etag = response.headers.get("etag") or state.etag
+            state.last_modified = response.headers.get("last-modified") or state.last_modified
+            # Parsing is the expensive half -- a ~19 MB export costs ~14s of CPU -- and
+            # these feeds carry no ETag or Last-Modified, so the content is digested
+            # instead: an unchanged calendar reuses the parse and only its window is
+            # expanded again.
+            digest = await asyncio.to_thread(_content_digest, response.content)
+            if state.body_hash == digest and state.calendar is not None:
+                calendar = state.calendar
+            else:
+                try:
+                    # Off the event loop: 14s of blocking parse would otherwise stall
+                    # reminders, MQTT and the overlay for the whole duration.
+                    calendar = await asyncio.to_thread(Calendar.from_ical, response.content)
+                except Exception as exc:
+                    self._logger.warning("[calendar] Calendar parse failed for '%s': %s", feed_label, exc)
+                    self._schedule_retry(state.url)
+                    return
+                state.calendar = calendar
+                state.body_hash = digest
         calendar_name = calendar.get("X-WR-CALNAME")
         if calendar_name:
             state.calendar_name = str(calendar_name)

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -1759,3 +1759,149 @@ def test_the_content_digest_survives_refolded_lines() -> None:
     )
     # Same property, wrapped at a different column: one logical line either way.
     assert _content_digest(folded_one) == _content_digest(folded_two)
+
+
+def test_the_content_digest_notices_data_moving_between_events() -> None:
+    """Review catch: a digest over a bag of lines misses a swap between two events.
+
+    The file's set of lines is identical either way, so only per-component hashing
+    distinguishes them -- otherwise a real edit reuses a stale parse.
+    """
+    from pulse.assistant.calendar_sync import _content_digest
+
+    def ics(first_summary: bytes, second_summary: bytes) -> bytes:
+        return (
+            b"BEGIN:VCALENDAR\r\n"
+            b"BEGIN:VEVENT\r\nUID:a\r\nDTSTART:20260101T090000Z\r\nSUMMARY:" + first_summary + b"\r\nEND:VEVENT\r\n"
+            b"BEGIN:VEVENT\r\nUID:b\r\nDTSTART:20260101T100000Z\r\nSUMMARY:" + second_summary + b"\r\nEND:VEVENT\r\n"
+            b"END:VCALENDAR\r\n"
+        )
+
+    assert _content_digest(ics(b"Standup", b"Review")) != _content_digest(ics(b"Review", b"Standup"))
+
+
+def test_the_content_digest_notices_an_alarm_moving_between_events() -> None:
+    """A VALARM belongs to its event, so moving it must invalidate the cache."""
+    from pulse.assistant.calendar_sync import _content_digest
+
+    alarm = b"BEGIN:VALARM\r\nACTION:DISPLAY\r\nTRIGGER:-PT30M\r\nEND:VALARM\r\n"
+    on_first = (
+        b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:a\r\n" + alarm + b"END:VEVENT\r\n"
+        b"BEGIN:VEVENT\r\nUID:b\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+    on_second = (
+        b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:a\r\nEND:VEVENT\r\n"
+        b"BEGIN:VEVENT\r\nUID:b\r\n" + alarm + b"END:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+    assert _content_digest(on_first) != _content_digest(on_second)
+
+
+def test_the_content_digest_still_ignores_component_order() -> None:
+    """Reordering whole events is export churn, not an edit."""
+    from pulse.assistant.calendar_sync import _content_digest
+
+    one = (
+        b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:a\r\nSUMMARY:Standup\r\nEND:VEVENT\r\n"
+        b"BEGIN:VEVENT\r\nUID:b\r\nSUMMARY:Review\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+    two = (
+        b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:b\r\nSUMMARY:Review\r\nEND:VEVENT\r\n"
+        b"BEGIN:VEVENT\r\nUID:a\r\nSUMMARY:Standup\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+    assert _content_digest(one) == _content_digest(two)
+
+
+@pytest.mark.anyio
+async def test_a_304_still_rebuilds_the_window() -> None:
+    """Review catch: the lookahead moves even when the feed does not.
+
+    With per-feed slices persisting, returning early on 304 would freeze a feed's
+    events -- ones entering the window later would never appear or be scheduled.
+    """
+    config = _make_config()
+    svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger)
+    state = svc._feed_states[config.feeds[0]]
+
+    # An event four hours out, and a first pass that parses and windows it.
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_ok_response(_ics_with_event("later-1", hours_ahead=4)))
+    svc._client = client
+    await svc._sync_once()
+    assert {r.uid for r in svc.cached_events()} == {"later-1"}
+
+    # Now the server answers 304 and the slice is deliberately emptied: only a genuine
+    # re-expansion of the cached calendar can put the event back.
+    state.window.clear()
+    not_modified = MagicMock()
+    not_modified.status_code = 304
+    not_modified.headers = {}
+    client.get = AsyncMock(return_value=not_modified)
+    await svc._sync_once()
+
+    assert {r.uid for r in svc.cached_events()} == {"later-1"}, (
+        "a 304 must re-expand the cached calendar, not freeze the feed's slice"
+    )
+
+    for task in list(svc._scheduled.values()):
+        task.cancel()
+
+
+@pytest.mark.anyio
+async def test_a_304_without_a_cached_calendar_is_a_no_op() -> None:
+    """Nothing parsed yet means there is nothing to re-expand."""
+    config = _make_config()
+    svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger)
+    state = svc._feed_states[config.feeds[0]]
+    state.etag = '"abc"'
+
+    not_modified = MagicMock()
+    not_modified.status_code = 304
+    not_modified.headers = {}
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=not_modified)
+    svc._client = client
+
+    await svc._sync_feed(state, datetime.now(UTC).astimezone())
+    assert state.window == {}
+    assert state.etag == '"abc"'
+
+
+@pytest.mark.anyio
+async def test_the_snapshot_uses_the_clock_at_emission() -> None:
+    """Review catch: a sweep over a 19 MB feed runs for ~35s.
+
+    Emitting against the timestamp captured at the start would keep events that ended
+    during the sweep on screen.
+    """
+    config = _make_config()
+    emitted: list[list] = []
+
+    async def capture(events) -> None:
+        emitted.append(list(events))
+
+    svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger, snapshot_callback=capture)
+    state = svc._feed_states[config.feeds[0]]
+    now = datetime.now(UTC).astimezone()
+    # Ended one minute ago: in window had we used a `now` captured before the sweep.
+    state.window["ending"] = CalendarReminder(
+        uid="ending",
+        summary="Ends mid-sweep",
+        description=None,
+        location=None,
+        start=now - timedelta(hours=1),
+        end=now - timedelta(minutes=1),
+        all_day=False,
+        trigger_time=now - timedelta(hours=2),
+        calendar_name=None,
+        source_url=config.feeds[0],
+    )
+
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=httpx.ReadTimeout("slow"))
+    svc._client = client
+    await svc._sync_once()
+
+    assert emitted and emitted[-1] == [], "an event that ended during the sweep must not be emitted"
+
+    for task in list(svc._retry_tasks.values()):
+        task.cancel()

--- a/tests/test_calendar_sync.py
+++ b/tests/test_calendar_sync.py
@@ -204,7 +204,7 @@ END:VCALENDAR
             await asyncio.sleep(0)
 
         asyncio.run(_run_schedule())
-        windowed = list(self.service._windowed_events.values())
+        windowed = list(self.feed_state.window.values())
         self.assertEqual(len(windowed), 1)
         self.assertEqual(windowed[0].uid, "event-accepted")
 
@@ -283,7 +283,7 @@ END:VCALENDAR
             await asyncio.sleep(0)
 
         asyncio.run(_run_schedule())
-        windowed = list(self.service._windowed_events.values())
+        windowed = list(self.feed_state.window.values())
         self.assertEqual(len(windowed), 1)
         self.assertEqual(windowed[0].uid, reminder.uid)
 
@@ -1133,7 +1133,7 @@ async def test_emit_event_snapshot_calls_callback() -> None:
         calendar_name=None,
         source_url="https://example.com/cal.ics",
     )
-    svc._windowed_events["key1"] = reminder
+    svc._feed_states[config.feeds[0]].window["key1"] = reminder
     await svc._emit_event_snapshot()
     snapshot_cb.assert_awaited_once()
     args = snapshot_cb.call_args[0][0]
@@ -1145,7 +1145,7 @@ async def test_emit_event_snapshot_calls_callback() -> None:
 async def test_emit_event_snapshot_no_callback() -> None:
     config = _make_config()
     svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger, snapshot_callback=None)
-    svc._windowed_events.clear()
+    svc._feed_states[config.feeds[0]].window.clear()
     # Should not raise
     await svc._emit_event_snapshot()
     assert svc._latest_events == []
@@ -1169,7 +1169,7 @@ async def test_emit_event_snapshot_callback_exception_logged() -> None:
         calendar_name=None,
         source_url="https://example.com/cal.ics",
     )
-    svc._windowed_events["k"] = reminder
+    svc._feed_states[config.feeds[0]].window["k"] = reminder
     # Should not raise (exception is logged)
     await svc._emit_event_snapshot()
 
@@ -1576,3 +1576,186 @@ class TestKeyMethods(unittest.TestCase):
         )
         rk = svc._reminder_key(r)
         assert trigger.isoformat() in rk
+
+
+# ---------------------------------------------------------------------------
+# Large / slow feeds: one feed must not blank another's events
+# ---------------------------------------------------------------------------
+
+
+def _ics_with_event(uid: str, hours_ahead: int = 6) -> bytes:
+    start = (datetime.now(UTC) + timedelta(hours=hours_ahead)).strftime("%Y%m%dT%H%M%SZ")
+    return (
+        "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Pulse Test//EN\r\n"
+        f"BEGIN:VEVENT\r\nUID:{uid}\r\nDTSTART:{start}\r\nSUMMARY:{uid}\r\n"
+        "END:VEVENT\r\nEND:VCALENDAR\r\n"
+    ).encode()
+
+
+def _ok_response(body: bytes) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.content = body
+    response.headers = {}
+    return response
+
+
+@pytest.mark.anyio
+async def test_a_failing_feed_keeps_its_events_in_the_snapshot() -> None:
+    """A slow work calendar used to delete its own events from the badge.
+
+    _sync_once cleared one shared window and only feeds returning 200 refilled it, so a
+    feed that timed out silently dropped every event it had contributed.
+    """
+    config = _make_config(feeds=("https://example.com/work.ics", "https://example.com/home.ics"))
+    svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger)
+    work, home = (svc._feed_states[url] for url in config.feeds)
+
+    bodies = {config.feeds[0]: _ics_with_event("work-1"), config.feeds[1]: _ics_with_event("home-1")}
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=lambda url, **_: _ok_response(bodies[url]))
+    svc._client = client
+
+    await svc._sync_once()
+    assert {r.uid for r in svc.cached_events()} == {"work-1", "home-1"}
+
+    # Now the work feed times out the way a 19 MB export does on a bad day.
+    async def _slow_or_ok(url, **_):
+        if url == config.feeds[0]:
+            raise httpx.ReadTimeout("too slow")
+        return _ok_response(bodies[url])
+
+    client.get = AsyncMock(side_effect=_slow_or_ok)
+    await svc._sync_once()
+
+    assert {r.uid for r in svc.cached_events()} == {"work-1", "home-1"}, (
+        "the work feed's events must survive its own fetch failure"
+    )
+    assert len(work.window) == 1
+    assert len(home.window) == 1
+
+    for task in list(svc._retry_tasks.values()):
+        task.cancel()
+    for task in list(svc._scheduled.values()):
+        task.cancel()
+
+
+@pytest.mark.anyio
+async def test_an_unchanged_feed_is_not_reparsed() -> None:
+    """Parsing a ~19 MB export costs ~14s of CPU; identical bytes must reuse it."""
+    config = _make_config()
+    svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger)
+    state = svc._feed_states[config.feeds[0]]
+    body = _ics_with_event("cached-1")
+
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_ok_response(body))
+    svc._client = client
+
+    real_from_ical = Calendar.from_ical
+    with patch.object(Calendar, "from_ical", side_effect=real_from_ical) as parse:
+        await svc._sync_once()
+        await svc._sync_once()
+        assert parse.call_count == 1, "identical bytes were parsed twice"
+
+    # The window is still rebuilt each pass, so it tracks the moving lookahead.
+    assert {r.uid for r in svc.cached_events()} == {"cached-1"}
+    assert state.body_hash is not None
+
+    with patch.object(Calendar, "from_ical", side_effect=real_from_ical) as parse:
+        client.get = AsyncMock(return_value=_ok_response(_ics_with_event("cached-2")))
+        await svc._sync_once()
+        assert parse.call_count == 1, "changed bytes must be parsed again"
+    assert {r.uid for r in svc.cached_events()} == {"cached-2"}
+
+    for task in list(svc._scheduled.values()):
+        task.cancel()
+
+
+@pytest.mark.anyio
+async def test_the_snapshot_drops_events_that_have_ended() -> None:
+    """Slices held over from a failed sync must decay instead of pinning stale events."""
+    config = _make_config()
+    svc = CalendarSyncService(config=config, trigger_callback=_noop_trigger)
+    state = svc._feed_states[config.feeds[0]]
+    now = datetime.now(UTC).astimezone()
+    state.window["past"] = CalendarReminder(
+        uid="past",
+        summary="Over",
+        description=None,
+        location=None,
+        start=now - timedelta(hours=2),
+        end=now - timedelta(hours=1),
+        all_day=False,
+        trigger_time=now - timedelta(hours=3),
+        calendar_name=None,
+        source_url=config.feeds[0],
+    )
+    state.window["future"] = CalendarReminder(
+        uid="future",
+        summary="Upcoming",
+        description=None,
+        location=None,
+        start=now + timedelta(hours=1),
+        end=now + timedelta(hours=2),
+        all_day=False,
+        trigger_time=now,
+        calendar_name=None,
+        source_url=config.feeds[0],
+    )
+
+    await svc._emit_event_snapshot(now)
+    assert [r.uid for r in svc.cached_events()] == ["future"]
+
+
+def test_the_loop_budget_exceeds_the_per_feed_budget() -> None:
+    """The loop cap was 30s over a 60s per-feed cap, so no feed could use its own."""
+    from pulse.assistant.calendar_sync import FEED_SYNC_TIMEOUT
+
+    feeds = ("https://example.com/a.ics", "https://example.com/b.ics", "https://example.com/c.ics")
+    svc = CalendarSyncService(config=_make_config(feeds=feeds), trigger_callback=_noop_trigger)
+    loop_timeout = FEED_SYNC_TIMEOUT * max(1, len(svc._feed_states)) + 30.0
+    assert loop_timeout > FEED_SYNC_TIMEOUT * len(feeds)
+
+
+def test_the_content_digest_ignores_per_export_churn() -> None:
+    """Google re-stamps and reorders every export; only real edits may change the key."""
+    from pulse.assistant.calendar_sync import _content_digest
+
+    first = (
+        b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:a\r\nDTSTAMP:20260101T000000Z\r\n"
+        b"SUMMARY:Standup\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:b\r\nDTSTAMP:20260101T000000Z\r\n"
+        b"SUMMARY:Review\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+    # Same calendar, re-exported: new DTSTAMPs and the two events swapped.
+    second = (
+        b"BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:b\r\nDTSTAMP:20260202T111111Z\r\n"
+        b"SUMMARY:Review\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:a\r\nDTSTAMP:20260202T111111Z\r\n"
+        b"SUMMARY:Standup\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+    )
+    assert _content_digest(first) == _content_digest(second)
+
+    edited = second.replace(b"SUMMARY:Review", b"SUMMARY:Review (moved)")
+    assert _content_digest(edited) != _content_digest(second)
+
+
+def test_the_content_digest_survives_refolded_lines() -> None:
+    """Google re-wraps long ATTENDEE properties at different octet boundaries.
+
+    On a real work calendar that moved ~434 lines of an otherwise unchanged export,
+    which defeated a digest taken over the physical lines.
+    """
+    from pulse.assistant.calendar_sync import _content_digest
+
+    folded_one = (
+        b"BEGIN:VEVENT\r\nUID:a\r\n"
+        b"ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;CN=Jeff Cu\r\n"
+        b" lverhouse:mailto:jeff@example.com\r\nEND:VEVENT\r\n"
+    )
+    folded_two = (
+        b"BEGIN:VEVENT\r\nUID:a\r\n"
+        b"ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;CN=Jeff\r\n"
+        b"  Culverhouse:mailto:jeff@example.com\r\nEND:VEVENT\r\n"
+    )
+    # Same property, wrapped at a different column: one logical line either way.
+    assert _content_digest(folded_one) == _content_digest(folded_two)


### PR DESCRIPTION
## The symptom

pulse-office's overlay showed **2 calendar events** where it used to show 11, and sometimes no calendar badge at all — while reminders for those same events kept firing on time.

## What was happening

Office syncs three feeds; the other kiosks sync one. Measured on the device:

| Feed | Size | Fetch | Parse | Expand | Total |
| --- | --- | --- | --- | --- | --- |
| work (Google export) | 19 MB | 16.6s | 14.1s | 1.2s | **31.9s** |
| personal | 693 KiB | 1.4s | 1.0s | 0.3s | 2.7s |
| HOA | 1 KiB | 0.2s | 0.0s | 0.0s | 0.3s |

The work export is the entire calendar history — 6,701 VEVENTs back to 2015, 84,277 ATTENDEE lines, 47% of the payload description text. Google's secret-address ICS takes no date-range parameter, so all of it arrives every poll.

Against that, three defects compounded:

1. **Timeout inversion.** `_run_loop` capped `_sync_once` at 30s while `_sync_once` granted each feed 60s. The inner budget was unreachable, and the work feed alone needs 31.9s. Loki shows the resulting warning firing 26–107 times a day for at least nine days.
2. **A failed feed deleted its own events.** `_sync_once` cleared one shared `_windowed_events` up front and only feeds returning 200 refilled it. When the work feed timed out, its 9 events vanished from the badge, leaving the 2 from the small feed — exactly what was on screen. Reminders survived because they are scheduled per feed and persist across syncs.
3. **Parsing blocked the event loop** for ~14s every 5 minutes, stalling reminders, MQTT and the overlay.

## The fix

- The loop budget is now `FEED_SYNC_TIMEOUT * len(feeds) + 30`, so it can never be lower than the per-feed budget it supervises. Client timeouts were raised to let a 19 MB body land (read 18s → 45s) and kept under the per-feed cap.
- Each feed owns its window slice, swapped in only by a pass that completed. A feed that times out keeps its last known events; the snapshot merges all slices and drops events that have since ended, so a stale slice decays instead of pinning an event to the badge.
- Parse and window expansion moved to a worker thread, and an unchanged feed reuses its parse.

### The cache key

These feeds send no ETag or Last-Modified, and Google's export never repeats byte-for-byte: it re-stamps `DTSTAMP`, reorders lines, and re-wraps folded `ATTENDEE` properties at different octet boundaries — that last one alone moved ~434 lines of an otherwise identical calendar. So the key unfolds (RFC 5545) first, then digests the sorted non-volatile lines. Verified stable across four consecutive fetches of the real feed, at 0.4s versus 14s to re-parse. Holding one parsed work calendar costs ~102 MiB; the kiosks are 16 GiB Pi 5s with ~15 GiB free.

## Verified against the real feeds

Ran the patched module on pulse-office in a throwaway copy, touching nothing deployed:

| Pass | Wall time | Parses | Snapshot |
| --- | --- | --- | --- |
| cold | 38.4s | 3 | 10 events (8 work + 2 personal) |
| warm | **19.5s** | **0** | 10 events |

Worst event-loop stall across both passes: **1.7s**, down from ~14s of hard blocking. Earlier in the day the same run produced 11 — the window moves as events end.

## Tests

New coverage for each defect: a feed whose fetch fails keeps its events in the snapshot; identical bytes are parsed once and changed bytes re-parsed; ended events drop out of a held-over slice; the loop budget must exceed the per-feed budget times the feed count; and the digest ignores re-stamping, reordering and refolding while still changing on a real edit. Full suite: 2150 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d2PANrZncd668vf8zEhJS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core calendar sync timing, caching, and overlay merge logic; incorrect digest or 304 handling could show stale events or miss updates, but behavior is heavily tested and failures degrade to last-known slice rather than emptying the badge.
> 
> **Overview**
> Fixes the overlay showing far fewer calendar events when a large ICS feed (e.g. ~19 MB Google work export) is slow or times out, while reminders still fire.
> 
> **Per-feed overlay state** replaces a single global window cleared at the start of each sync. Each feed keeps its last successful `window` slice on timeout or error; the badge merges all slices and filters out events that have already ended at emit time.
> 
> **Timeouts and budgets** align with large feeds: `FEED_SYNC_TIMEOUT` (90s) per feed, HTTP read timeout raised, and the sync loop cap scales as `FEED_SYNC_TIMEOUT × feed count + 30` so it cannot be shorter than the per-feed allowance.
> 
> **Performance**: ICS digest (`_content_digest`) skips re-parsing when export churn (DTSTAMP, reordering, refolding) hides real changes; parse and reminder expansion run via `asyncio.to_thread`. **304 Not Modified** still re-expands the cached calendar so the moving lookahead window stays correct.
> 
> Tests cover digest behavior, parse cache, failed-feed retention, 304 re-expansion, and snapshot timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85f22a45925d13ca676c857e84029438b782ed2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->