### PR TITLE
fix(deps): move device-constraints off .txt so dependabot stops rewriting it

### DIFF
--- a/config/device-constraints.pip
+++ b/config/device-constraints.pip
@@ -1,8 +1,15 @@
 # Version constraints for the Python packages installed on a device by setup.sh.
 #
 # GENERATED — do not edit by hand. Regenerate with:
-#   uv export --frozen --no-dev --no-hashes --no-emit-project > config/device-constraints.txt
+#   uv export --frozen --no-dev --no-hashes --no-emit-project > config/device-constraints.pip
 # tests/test_device_constraints.py fails if this drifts from uv.lock.
+#
+# THE .pip EXTENSION IS DELIBERATE — do not rename this back to .txt. Dependabot's Python
+# file fetcher globs every '*.txt' and '*.in' file in a scanned directory and treats it as
+# a requirements file it may rewrite. While this was device-constraints.txt, every weekly
+# uv PR bumped the pins here independently of the uv resolution, so the file and uv.lock
+# disagreed and the guard test below failed on each one (see PRs #247, #257). pip's -c flag
+# does not care about the extension, so moving off .txt costs nothing and ends the churn.
 #
 # Used as a pip CONSTRAINTS file (-c), not a requirements file: it pins versions for
 # whatever gets installed without itself installing anything. That matters because the

--- a/setup.sh
+++ b/setup.sh
@@ -645,7 +645,7 @@ ASSISTANT_PIP_PACKAGES=(wyoming recurring-ical-events)
 # site and that shadows apt: icalendar is exactly this case, resolving to the pip 7.2.2
 # copy on a device that also has python3-icalendar 6.0.1. Untouched apt packages keep
 # Debian's version only because nothing being installed asked for a different one.
-DEVICE_CONSTRAINTS="$REPO_DIR/config/device-constraints.txt"
+DEVICE_CONSTRAINTS="$REPO_DIR/config/device-constraints.pip"
 
 pip_install_packages() {
     local label="$1"

--- a/tests/test_device_constraints.py
+++ b/tests/test_device_constraints.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parent.parent
-CONSTRAINTS = ROOT / "config" / "device-constraints.txt"
+CONSTRAINTS = ROOT / "config" / "device-constraints.pip"
 SETUP = ROOT / "setup.sh"
 
 EXPORT_COMMAND = ["uv", "export", "--frozen", "--no-dev", "--no-hashes", "--no-emit-project"]
@@ -57,8 +57,8 @@ def test_constraints_file_matches_the_lockfile():
     exported = [line for line in result.stdout.splitlines() if line.strip() and not line.startswith("#")]
     committed = [line for line in CONSTRAINTS.read_text().splitlines() if line.strip() and not line.startswith("#")]
     assert committed == exported, (
-        "config/device-constraints.txt is stale; regenerate with:\n  " + " ".join(EXPORT_COMMAND) + " > "
-        "config/device-constraints.txt"
+        "config/device-constraints.pip is stale; regenerate with:\n  " + " ".join(EXPORT_COMMAND) + " > "
+        "config/device-constraints.pip"
     )
 
 


### PR DESCRIPTION
## Why

Dependabot's Python file fetcher globs every `*.txt` and `*.in` file in a scanned directory and treats it as a requirements file it may rewrite. `config/device-constraints.txt` matched, so **every weekly uv PR** bumped the pins in it independently of the uv resolution. The file and `uv.lock` then disagreed and `test_constraints_file_matches_the_lockfile` failed — most recently on #257, and before that #247.

That isn't cosmetic. This file is the pip **constraints** file `setup.sh` feeds the kiosks, so merging dependabot's version as-is would pin the fleet to a closure CI never resolved or tested.

## What

Rename to `config/device-constraints.pip`, which dependabot does not glob.

- `setup.sh` — the `DEVICE_CONSTRAINTS` path
- `tests/test_device_constraints.py` — the path and the failure message's regenerate hint
- the file's own preamble — the regenerate command, plus a note explaining why the extension is deliberate so it doesn't get renamed back

pip's `-c` flag doesn't care about the extension, so nothing about how `setup.sh` consumes the file changes. **The pinned content is byte-identical** — the rename shows as 85% similarity only because of the preamble edits.

## Verification

- `pytest tests/test_device_constraints.py` — 7 passed (the guard still checks against the same `uv.lock`)
- Full suite — 2156 passed
- `ruff 0.16.5 check` / `format --check` — clean
- `shellcheck setup.sh` — no new findings (the three SC2034s at lines 1550–1574 are pre-existing and untouched)

## Follow-up, not in this PR

`config/apt/manual-packages.txt` is the other tracked `.txt` and is in the same exposure class — a bare newline-separated list that a requirements parser would accept. Dependabot has never touched it, presumably because the entries are unpinned apt names that don't resolve on PyPI, so I left it alone rather than widen this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d2PANrZncd668vf8zEhJS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Path and documentation rename only; fleet Python pins and install logic are unchanged.
> 
> **Overview**
> Renames the fleet pip constraints export from `config/device-constraints.txt` to **`config/device-constraints.pip`** so Dependabot no longer treats it as a requirements file and rewrites pins on weekly uv PRs (which had been drifting from `uv.lock` and failing `test_constraints_file_matches_the_lockfile`).
> 
> **`setup.sh`** now points `DEVICE_CONSTRAINTS` at the `.pip` path; **`tests/test_device_constraints.py`** uses the same path and updates the stale-file regenerate hint. The constraints file preamble documents the deliberate extension and the correct `uv export` redirect target. **Pinned package lines are unchanged** — pip’s `-c` flag is extension-agnostic, so kiosk install behavior is the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae22741221997a46d49b0f458b3a266ef05d5532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->