### PR TITLE
fix(assistant): drop deprecated websockets names before they are removed

### DIFF
--- a/bin/tools/test-ha-websocket.py
+++ b/bin/tools/test-ha-websocket.py
@@ -211,7 +211,7 @@ async def test_websocket_connection():
     except websockets.exceptions.InvalidURI as exc:
         print(f"ERROR: Invalid WebSocket URI: {exc}")
         return False
-    except websockets.exceptions.InvalidStatusCode as exc:
+    except websockets.exceptions.InvalidStatus as exc:
         print(f"ERROR: WebSocket connection failed: {exc}")
         return False
     except Exception as exc:

--- a/pulse/assistant/home_assistant.py
+++ b/pulse/assistant/home_assistant.py
@@ -33,11 +33,9 @@ import httpx
 try:
     import websockets
     from websockets.asyncio.client import ClientConnection
-    from websockets.exceptions import WebSocketException
 except ImportError:
     websockets = None  # type: ignore[assignment]
     ClientConnection = None  # type: ignore[assignment,misc]
-    WebSocketException = None  # type: ignore[assignment,misc]
 
 from .config import HomeAssistantConfig
 
@@ -186,7 +184,7 @@ class HomeAssistantClient:
             payload["language"] = language
         return await self._request("POST", "/api/conversation/process", json=payload)
 
-    async def _resolve_pipeline_id(self, ws: ClientConnection | Any, pipeline_name_or_id: str) -> str:
+    async def _resolve_pipeline_id(self, ws: ClientConnection, pipeline_name_or_id: str) -> str:
         """Resolve pipeline name to ID via WebSocket."""
         # If it looks like a UUID/ID (long alphanumeric string), assume it's already an ID
         if len(pipeline_name_or_id) > 20 and pipeline_name_or_id.replace("-", "").replace("_", "").isalnum():

--- a/pulse/assistant/home_assistant.py
+++ b/pulse/assistant/home_assistant.py
@@ -32,11 +32,11 @@ import httpx
 
 try:
     import websockets
-    from websockets.client import WebSocketClientProtocol  # type: ignore[attr-defined]
+    from websockets.asyncio.client import ClientConnection
     from websockets.exceptions import WebSocketException
 except ImportError:
     websockets = None  # type: ignore[assignment]
-    WebSocketClientProtocol = None  # type: ignore[assignment,misc]
+    ClientConnection = None  # type: ignore[assignment,misc]
     WebSocketException = None  # type: ignore[assignment,misc]
 
 from .config import HomeAssistantConfig
@@ -186,7 +186,7 @@ class HomeAssistantClient:
             payload["language"] = language
         return await self._request("POST", "/api/conversation/process", json=payload)
 
-    async def _resolve_pipeline_id(self, ws: WebSocketClientProtocol | Any, pipeline_name_or_id: str) -> str:
+    async def _resolve_pipeline_id(self, ws: ClientConnection | Any, pipeline_name_or_id: str) -> str:
         """Resolve pipeline name to ID via WebSocket."""
         # If it looks like a UUID/ID (long alphanumeric string), assume it's already an ID
         if len(pipeline_name_or_id) > 20 and pipeline_name_or_id.replace("-", "").replace("_", "").isalnum():


### PR DESCRIPTION
## Why

The `websockets 17.1` bump in #257 surfaced a `DeprecationWarning` on every test run. Two legacy names were still in use, and both will break outright when upstream removes them.

## What

**`pulse/assistant/home_assistant.py`** — `websockets.client.WebSocketClientProtocol` → `websockets.asyncio.client.ClientConnection`.

It was only ever a type annotation on `_resolve_pipeline_id`. `websockets.connect` already resolves to `websockets.asyncio.client`, so `ClientConnection` is genuinely the type that `async with websockets.connect(...) as ws` yields — verified, not assumed:

```
>>> websockets.connect.__module__
'websockets.asyncio.client'
```

The `# type: ignore[attr-defined]` goes away too, since this is a real export rather than a shim.

**`bin/tools/test-ha-websocket.py`** — `websockets.exceptions.InvalidStatusCode` → `InvalidStatus`. Same deprecation class, caught while checking whether anything else used legacy names. The handler only prints the exception, so the rename needs no other change (the new class carries `.response` rather than `.status_code`, which nothing here touches).

No behaviour change: the `try`/`except ImportError` fallback keeps its shape, and the tests that patch `pulse.assistant.home_assistant.websockets` are unaffected.

## Verification

- Full suite — 2156 passed, and warnings drop **3 → 2**. The remaining two are unrelated `AsyncMock` `RuntimeWarning`s in `test_event_handlers.py`.
- `python -W error::DeprecationWarning -c "from pulse.assistant.home_assistant import ..."` — imports clean, nothing raised
- `mypy pulse/assistant/home_assistant.py` — no issues
- `ruff 0.16.5 check` / `format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d2PANrZncd668vf8zEhJS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only compatibility with the websockets library; no auth, protocol, or Home Assistant API logic changes.
> 
> **Overview**
> Updates Home Assistant WebSocket code for **websockets 17.x** by replacing symbols that now emit deprecation warnings and will be removed upstream.
> 
> In `pulse/assistant/home_assistant.py`, the `_resolve_pipeline_id` WebSocket parameter is typed as `ClientConnection` from `websockets.asyncio.client` instead of the legacy `WebSocketClientProtocol` shim; the unused `WebSocketException` import is dropped. In `bin/tools/test-ha-websocket.py`, connection failures are caught with `InvalidStatus` instead of `InvalidStatusCode`.
> 
> **No runtime behavior change**—only names aligned with what `websockets.connect` already returns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ea1e13c57478ed3b90767c8d2540b8022b2a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->