### PR TITLE
feat(kiosk): send the kiosk home when Home Assistant comes back

### DIFF
--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -396,6 +396,14 @@ def log(message: str) -> None:
 BACKLIGHT_DEFAULT_DAY = 85
 BACKLIGHT_DEFAULT_NIGHT = 25
 
+# Home Assistant recovery: an HA restart leaves the kiosk browser stranded on a
+# stale or errored dashboard and it never recovers on its own. These bound the
+# unreachable -> reachable transition that triggers an automatic reload.
+HA_RECOVERY_MIN_OUTAGE_SECONDS = 120
+HA_RECOVERY_SETTLE_SECONDS = 45
+HA_RECOVERY_MIN_INTERVAL_SECONDS = 600
+HA_RECOVERY_PROBE_TIMEOUT_SECONDS = 5
+
 
 def _parse_backlight_conf() -> dict[str, str]:
     """Parse the backlight config file into a dict of key/value pairs."""
@@ -827,6 +835,12 @@ class KioskMqttListener:
         self._last_now_playing_error: float = 0.0
         self._last_now_playing_art_key: str = ""
         self._last_now_playing_art: str = ""
+        self._ha_unreachable_since: float | None = None
+        self._ha_pending_home_since: float | None = None
+        self._ha_pending_outage: float = 0.0
+        # None, not 0.0: time.monotonic() starts near boot, so a 0.0 sentinel would
+        # make the rate limiter suppress the FIRST legitimate reload for 10 minutes.
+        self._last_ha_recovery_home: float | None = None
         self.assistant_topics = config.assistant_topics
         self.overlay_config = config.overlay
         self.overlay_state: OverlayStateManager | None = None
@@ -1272,6 +1286,9 @@ class KioskMqttListener:
                     except Exception as exc:  # noqa: BLE001
                         self.log(f"watchdog: assistant restart failed: {exc}")
 
+            # Check Home Assistant reachability: reload the dashboard when HA returns
+            self._check_ha_recovery(now)
+
             # Check own MQTT connectivity: reboot if broker unreachable
             offline_seconds = now - self._last_mqtt_ok
             if offline_seconds < grace_seconds:
@@ -1288,6 +1305,86 @@ class KioskMqttListener:
                 self.log(f"watchdog: reboot attempt failed: {exc}")
             finally:
                 self.reboot_lock.release()
+
+    def _probe_home_assistant(self) -> bool:
+        """Return True if Home Assistant's authenticated API is answering.
+
+        Uses /api/, HA's own health endpoint, which returns {"message": "API running."}
+        for a valid long-lived token. This must be called WITH the token -- an
+        unauthenticated poll of /api/ returns 401 and would report a healthy HA as
+        permanently down.
+        """
+        url = f"{self.config.ha_base_url.rstrip('/')}/api/"
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {self.config.ha_token}",
+                "Accept": "application/json",
+            },
+        )
+        open_kwargs: dict[str, Any] = {"timeout": HA_RECOVERY_PROBE_TIMEOUT_SECONDS}
+        if self._ha_ssl_context is not None:
+            open_kwargs["context"] = self._ha_ssl_context
+        try:
+            with urllib.request.urlopen(request, **open_kwargs) as response:  # type: ignore[arg-type]  # nosec B310 - timeout in kwargs
+                return 200 <= int(getattr(response, "status", 0)) < 300
+        except Exception:  # noqa: BLE001 - any failure means "not reachable"
+            return False
+
+    def _check_ha_recovery(self, now: float) -> None:
+        """Send the kiosk home once Home Assistant comes back after an outage.
+
+        A Home Assistant restart leaves the kiosk browser sitting on a stale or
+        errored dashboard; the page does not recover on its own and has to be
+        reloaded by hand. This watches for an unreachable -> reachable transition
+        and then issues the same hard reload the HOME command performs.
+
+        Deliberately conservative, because a spurious reload is user-visible:
+          * the outage must last HA_RECOVERY_MIN_OUTAGE_SECONDS, so a single failed
+            probe or a brief network blip does not trigger a reload;
+          * after HA answers again we wait HA_RECOVERY_SETTLE_SECONDS before
+            reloading, because /api/ starts answering before the frontend is ready
+            to serve the dashboard -- reloading too early just re-strands the kiosk;
+          * at most one reload per HA_RECOVERY_MIN_INTERVAL_SECONDS, so a flapping
+            HA cannot put the kiosk into a reload loop.
+        """
+        if not self.config.ha_base_url or not self.config.ha_token:
+            return
+
+        if not self._probe_home_assistant():
+            if self._ha_unreachable_since is None:
+                self._ha_unreachable_since = now
+            # A fresh outage cancels any reload still waiting to settle.
+            self._ha_pending_home_since = None
+            return
+
+        # Reachable. First success after an outage only starts the settle timer.
+        if self._ha_unreachable_since is not None:
+            outage = now - self._ha_unreachable_since
+            self._ha_unreachable_since = None
+            if outage >= HA_RECOVERY_MIN_OUTAGE_SECONDS:
+                self._ha_pending_home_since = now
+                self._ha_pending_outage = outage
+                self.log(f"watchdog: Home Assistant reachable again after {int(outage)}s; will reload shortly")
+            return
+
+        if self._ha_pending_home_since is None:
+            return
+        if now - self._ha_pending_home_since < HA_RECOVERY_SETTLE_SECONDS:
+            return
+
+        outage = self._ha_pending_outage
+        self._ha_pending_home_since = None
+        self._ha_pending_outage = 0.0
+        if (
+            self._last_ha_recovery_home is not None
+            and now - self._last_ha_recovery_home < HA_RECOVERY_MIN_INTERVAL_SECONDS
+        ):
+            self.log("watchdog: skipping HA-recovery reload, one was issued recently")
+            return
+        self._last_ha_recovery_home = now
+        self.log(f"watchdog: Home Assistant was unreachable for {int(outage)}s; sending kiosk home")
+        self.handle_home()
 
     def _collect_telemetry_metrics(self) -> dict[str, int | float | str]:
         metrics: dict[str, int | float | str] = {}

--- a/tests/test_kiosk_listener.py
+++ b/tests/test_kiosk_listener.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
@@ -77,3 +77,106 @@ def test_symbol_families_are_not_offered(listener, name):
 @pytest.mark.parametrize("name", ["DejaVu Sans", "Liberation Sans", "Nimbus Roman", "URW Gothic"])
 def test_text_families_are_offered(listener, name):
     assert not listener._is_non_text_font(name)
+
+
+# -- Home Assistant recovery state machine ------------------------------------
+#
+# _check_ha_recovery decides whether an HA outage should trigger a dashboard
+# reload. It is driven here against a stub rather than a real listener so no
+# MQTT, DevTools or HTTP is involved -- only the state machine is under test.
+
+
+class _Recorder:
+    """Minimal stand-in exposing just what _check_ha_recovery touches."""
+
+    def __init__(self, listener, reachable: bool = True):
+        self.config = SimpleNamespace(ha_base_url="http://ha.example", ha_token="tok")
+        self.reachable = reachable
+        self.homes = 0
+        self.logs: list[str] = []
+        self._ha_unreachable_since = None
+        self._ha_pending_home_since = None
+        self._ha_pending_outage = 0.0
+        self._last_ha_recovery_home = None
+        self._check_ha_recovery = listener.KioskMqttListener._check_ha_recovery.__get__(self)
+
+    def _probe_home_assistant(self) -> bool:
+        return self.reachable
+
+    def handle_home(self) -> None:
+        self.homes += 1
+
+    def log(self, message: str) -> None:
+        self.logs.append(message)
+
+
+def _outage(listener, *, seconds: float, settle: float):
+    """Run one full down->up cycle and return the stub after settling."""
+    r = _Recorder(listener)
+    r.reachable = False
+    r._check_ha_recovery(0.0)  # outage starts
+    r._check_ha_recovery(seconds)  # still down
+    r.reachable = True
+    r._check_ha_recovery(seconds)  # first success -> starts settle timer
+    r._check_ha_recovery(seconds + settle)
+    return r
+
+
+def test_restart_length_outage_sends_the_kiosk_home(listener):
+    r = _outage(listener, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert r.homes == 1
+
+
+def test_brief_blip_does_not_reload(listener):
+    # Shorter than HA_RECOVERY_MIN_OUTAGE_SECONDS: a single failed probe or a
+    # momentary network wobble must never reload a working dashboard.
+    r = _outage(
+        listener,
+        seconds=listener.HA_RECOVERY_MIN_OUTAGE_SECONDS - 1,
+        settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1,
+    )
+    assert r.homes == 0
+
+
+def test_reload_waits_for_the_settle_window(listener):
+    # /api/ answers before the frontend can serve the dashboard, so reloading on
+    # the first successful probe would just re-strand the kiosk.
+    r = _outage(listener, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS - 1)
+    assert r.homes == 0
+
+
+def test_outage_during_settle_cancels_the_pending_reload(listener):
+    r = _Recorder(listener)
+    r.reachable = False
+    r._check_ha_recovery(0.0)
+    r.reachable = True
+    r._check_ha_recovery(300.0)  # pending reload armed
+    r.reachable = False
+    r._check_ha_recovery(310.0)  # HA drops again -> cancel
+    r.reachable = True
+    r._check_ha_recovery(320.0)  # too brief to re-arm
+    r._check_ha_recovery(999.0)
+    assert r.homes == 0
+
+
+def test_flapping_ha_cannot_cause_a_reload_loop(listener):
+    r = _outage(listener, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert r.homes == 1
+    base = 300 + listener.HA_RECOVERY_SETTLE_SECONDS + 1
+    # A second full outage inside the rate limit must not reload again.
+    r.reachable = False
+    r._check_ha_recovery(base + 1)
+    r._check_ha_recovery(base + 300)
+    r.reachable = True
+    r._check_ha_recovery(base + 300)
+    r._check_ha_recovery(base + 300 + listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert r.homes == 1
+
+
+def test_no_ha_credentials_means_no_probing(listener):
+    r = _Recorder(listener)
+    r.config = SimpleNamespace(ha_base_url="", ha_token="")
+    r.reachable = False
+    r._check_ha_recovery(0.0)
+    assert r._ha_unreachable_since is None
+    assert r.homes == 0


### PR DESCRIPTION
## The problem

A Home Assistant restart leaves the pulse kiosks stranded on a stale or errored dashboard. They do not recover on their own — each display has to be walked to and tapped **Home**.

Observed directly during an HA restart on 2026-09-08: three of the four kiosks were stranded (`pulse-bedroom`, `pulse-great-room`, `pulse-kitchen`); `pulse-office` happened to survive. That inconsistency is a race between HA's websocket reconnect and the page falling into a hard error state, which is why it is intermittent rather than one device being special.

## Why this is the right layer

The listener **already** polls HA every 60s for now-playing, and already logs the outage straight through a restart:

```
[kiosk-mqtt] now-playing: HA connection error: <urlopen error [Errno 111] Connection refused>
[kiosk-mqtt] now-playing: HA connection error: <urlopen error [Errno 111] Connection refused>
[kiosk-mqtt] now-playing: HA connection error: <urlopen error [Errno 111] Connection refused>
```

The signal was already there and simply was not acted on. This adds an HA-reachability check to the existing watchdog loop and, on an `unreachable -> reachable` transition, calls the existing `handle_home()` — the same hard reload the MQTT `HOME` command performs.

An HA-side automation can cover the restart case by pressing `button.pulse_*_home`, but it only works for restarts HA itself initiates and survives. Device-side detection also covers HA being unreachable for any other reason (network, broker, crash), and needs nothing from HA.

## Guards

A spurious reload is user-visible, so this is deliberately conservative:

| Guard | Value | Why |
|---|---|---|
| `HA_RECOVERY_MIN_OUTAGE_SECONDS` | 120s | one failed probe or a brief wobble must not reload a working page |
| `HA_RECOVERY_SETTLE_SECONDS` | 45s | `/api/` answers *before* the frontend can serve the dashboard; reloading too early just re-strands the kiosk |
| `HA_RECOVERY_MIN_INTERVAL_SECONDS` | 600s | a flapping HA cannot put a display into a reload loop |
| outage during settle | — | cancels the pending reload |

## Two things worth reviewer attention

**The probe must be authenticated.** It uses HA's own `/api/` health endpoint *with* the long-lived token. Polling `/api/` unauthenticated returns 401, which would report a perfectly healthy HA as permanently down.

**`_last_ha_recovery_home` is `None`, not `0.0`.** `time.monotonic()` starts near boot, so a `0.0` sentinel makes the rate limiter swallow the **first** legitimate reload for the first 10 minutes of uptime. The tests caught this — it was a real bug in the first draft, not a test artifact.

## Testing

Six tests drive the state machine against a stub, so no MQTT, DevTools or HTTP is involved — matching the existing "pure helpers only" approach in `tests/test_kiosk_listener.py`:

- restart-length outage reloads
- brief blip does not
- reload waits for the settle window
- outage during settle cancels the pending reload
- flapping HA cannot loop
- no HA credentials means no probing

Locally at the CI-pinned versions: `pytest` 23 passed, `ruff@0.16.6 check` clean, `ruff@0.16.6 format --check` clean, `bandit` unchanged (its one Low finding is pre-existing, in the `sudo systemctl` assistant restart, and CI gates on `-lll -iii`).

Not yet observed recovering a real HA restart in the field — that needs a deploy plus the next restart to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tzrciexikca6629DJJech

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes watchdog behavior on every kiosk with HA credentials: an automatic full dashboard reload is user-visible if thresholds are wrong, though guards limit false positives.
> 
> **Overview**
> Adds **automatic kiosk dashboard recovery** when Home Assistant comes back after a long outage. The existing watchdog loop now probes HA’s authenticated `/api/` endpoint and runs a conservative state machine: require ~2 minutes down, wait ~45 seconds after HA answers again, then call **`handle_home()`** (same hard reload as the MQTT Home button). Rate limiting (~10 minutes between recovery reloads) and cancel-on-flap during settle avoid reload loops and premature reloads while the frontend is still starting.
> 
> New tuning constants and listener state track outage duration, pending settle, and last recovery time; **`_last_ha_recovery_home` uses `None`** so the first legitimate reload isn’t blocked right after boot.
> 
> **Tests** add six stub-driven cases for the recovery state machine (long outage reloads, brief blips ignored, settle window, cancel during settle, flapping rate limit, no credentials → no probing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1a3d1f08aed1320e78f256d9050613ecf3030a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->