### PR TITLE
fix(kiosk): make HA recovery work without a token and stop forcing home

### DIFF
--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -841,6 +841,7 @@ class KioskMqttListener:
         # None, not 0.0: time.monotonic() starts near boot, so a 0.0 sentinel would
         # make the rate limiter suppress the FIRST legitimate reload for 10 minutes.
         self._last_ha_recovery_home: float | None = None
+        self._last_navigated_url: str | None = None
         self.assistant_topics = config.assistant_topics
         self.overlay_config = config.overlay
         self.overlay_state: OverlayStateManager | None = None
@@ -1306,22 +1307,36 @@ class KioskMqttListener:
             finally:
                 self.reboot_lock.release()
 
-    def _probe_home_assistant(self) -> bool:
-        """Return True if Home Assistant's authenticated API is answering.
+    def _recovery_probe_target(self) -> tuple[str, dict[str, str]] | None:
+        """Return (url, headers) to poll for reachability, or None if we cannot.
 
-        Uses /api/, HA's own health endpoint, which returns {"message": "API running."}
-        for a valid long-lived token. This must be called WITH the token -- an
-        unauthenticated poll of /api/ returns 401 and would report a healthy HA as
-        permanently down.
+        Prefers HA's authenticated /api/ health endpoint, which only answers once
+        core is actually up. Falls back to an unauthenticated GET of PULSE_URL --
+        the page the kiosk actually displays -- because HOME_ASSISTANT_TOKEN ships
+        empty in pulse.conf.sample and is only needed for Assist and now-playing.
+        Without that fallback this whole feature silently does nothing for anyone
+        running a plain dashboard kiosk, which is the common case.
+
+        The fallback is slightly less precise: HA's frontend returns 200 a little
+        before core can serve a dashboard. HA_RECOVERY_SETTLE_SECONDS covers that.
         """
-        url = f"{self.config.ha_base_url.rstrip('/')}/api/"
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"Bearer {self.config.ha_token}",
-                "Accept": "application/json",
-            },
-        )
+        if self.config.ha_base_url and self.config.ha_token:
+            return (
+                f"{self.config.ha_base_url.rstrip('/')}/api/",
+                {"Authorization": f"Bearer {self.config.ha_token}", "Accept": "application/json"},
+            )
+        target = self.config.pulse_url or self.config.ha_base_url
+        if not target:
+            return None
+        return (target, {})
+
+    def _probe_home_assistant(self) -> bool:
+        """Return True if the kiosk's page source is answering."""
+        probe = self._recovery_probe_target()
+        if probe is None:
+            return False
+        url, headers = probe
+        request = urllib.request.Request(url, headers=headers)
         open_kwargs: dict[str, Any] = {"timeout": HA_RECOVERY_PROBE_TIMEOUT_SECONDS}
         if self._ha_ssl_context is not None:
             open_kwargs["context"] = self._ha_ssl_context
@@ -1348,7 +1363,7 @@ class KioskMqttListener:
           * at most one reload per HA_RECOVERY_MIN_INTERVAL_SECONDS, so a flapping
             HA cannot put the kiosk into a reload loop.
         """
-        if not self.config.ha_base_url or not self.config.ha_token:
+        if self._recovery_probe_target() is None:
             return
 
         if not self._probe_home_assistant():
@@ -1383,8 +1398,15 @@ class KioskMqttListener:
             self.log("watchdog: skipping HA-recovery reload, one was issued recently")
             return
         self._last_ha_recovery_home = now
-        self.log(f"watchdog: Home Assistant was unreachable for {int(outage)}s; sending kiosk home")
-        self.handle_home()
+        # Restore whatever the kiosk was showing rather than forcing PULSE_URL:
+        # a display driven elsewhere by kiosk/url/set (a camera view, a status
+        # page) must not be silently snapped back home by an unrelated outage.
+        target = self._last_navigated_url or self.config.pulse_url
+        if not target:
+            self.log("watchdog: HA recovered but there is no URL to reload")
+            return
+        self.log(f"watchdog: Home Assistant was unreachable for {int(outage)}s; reloading {target}")
+        self.reload_url(target)
 
     def _collect_telemetry_metrics(self) -> dict[str, int | float | str]:
         metrics: dict[str, int | float | str] = {}
@@ -2206,6 +2228,10 @@ class KioskMqttListener:
             self.log("navigate: empty url, ignoring request")
             return False
 
+        # Remembered so an HA-recovery reload restores what the kiosk was actually
+        # showing (a camera view, an automation-driven URL) instead of forcing it home.
+        self._last_navigated_url = url
+
         try:
             pages = self.fetch_page_targets()
         except urllib.error.URLError as exc:
@@ -2252,9 +2278,11 @@ class KioskMqttListener:
         if not self.config.pulse_url:
             self.log("HOME command received but PULSE_URL is not set")
             return
-        # Add cache-busting parameter to force hard reload
+        self.reload_url(self.config.pulse_url)
+
+    def reload_url(self, url: str) -> bool:
+        """Navigate to url with a cache-busting parameter, forcing a hard reload."""
         cache_buster = int(time.time() * 1000)  # milliseconds timestamp
-        url = self.config.pulse_url
         # Parse URL to add/update cache-busting parameter
         parsed = urllib.parse.urlparse(url)
         query_params = urllib.parse.parse_qs(parsed.query)
@@ -2270,7 +2298,7 @@ class KioskMqttListener:
                 parsed.fragment,
             )
         )
-        self.navigate(new_url)
+        return self.navigate(new_url)
 
     def handle_goto(self, payload: bytes) -> None:
         url = normalize_url(payload)

--- a/tests/test_kiosk_listener.py
+++ b/tests/test_kiosk_listener.py
@@ -81,68 +81,73 @@ def test_text_families_are_offered(listener, name):
 
 # -- Home Assistant recovery state machine ------------------------------------
 #
-# _check_ha_recovery decides whether an HA outage should trigger a dashboard
-# reload. It is driven here against a stub rather than a real listener so no
+# _check_ha_recovery decides whether an HA outage should trigger a reload of the
+# kiosk page. It is driven here against a stub rather than a real listener so no
 # MQTT, DevTools or HTTP is involved -- only the state machine is under test.
+
+_PULSE_URL = "http://ha.example/dashboard-pulse/home"
 
 
 class _Recorder:
     """Minimal stand-in exposing just what _check_ha_recovery touches."""
 
-    def __init__(self, listener, reachable: bool = True):
-        self.config = SimpleNamespace(ha_base_url="http://ha.example", ha_token="tok")
-        self.reachable = reachable
-        self.homes = 0
+    def __init__(self, listener, *, token: str = "tok", pulse_url: str = _PULSE_URL):
+        self.config = SimpleNamespace(ha_base_url="http://ha.example", ha_token=token, pulse_url=pulse_url)
+        self.reachable = True
+        self.reloads: list[str] = []
         self.logs: list[str] = []
+        self._last_navigated_url = None
         self._ha_unreachable_since = None
         self._ha_pending_home_since = None
         self._ha_pending_outage = 0.0
         self._last_ha_recovery_home = None
-        self._check_ha_recovery = listener.KioskMqttListener._check_ha_recovery.__get__(self)
+        cls = listener.KioskMqttListener
+        self._check_ha_recovery = cls._check_ha_recovery.__get__(self)
+        self._recovery_probe_target = cls._recovery_probe_target.__get__(self)
 
     def _probe_home_assistant(self) -> bool:
         return self.reachable
 
-    def handle_home(self) -> None:
-        self.homes += 1
+    def reload_url(self, url: str) -> bool:
+        self.reloads.append(url)
+        return True
 
     def log(self, message: str) -> None:
         self.logs.append(message)
 
 
-def _outage(listener, *, seconds: float, settle: float):
-    """Run one full down->up cycle and return the stub after settling."""
-    r = _Recorder(listener)
+def _outage(r, *, seconds: float, settle: float):
+    """Run one full down->up cycle on an existing recorder."""
     r.reachable = False
-    r._check_ha_recovery(0.0)  # outage starts
-    r._check_ha_recovery(seconds)  # still down
+    r._check_ha_recovery(0.0)
+    r._check_ha_recovery(seconds)
     r.reachable = True
-    r._check_ha_recovery(seconds)  # first success -> starts settle timer
+    r._check_ha_recovery(seconds)  # first success starts the settle timer
     r._check_ha_recovery(seconds + settle)
     return r
 
 
-def test_restart_length_outage_sends_the_kiosk_home(listener):
-    r = _outage(listener, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
-    assert r.homes == 1
+def test_restart_length_outage_reloads_the_kiosk(listener):
+    r = _outage(_Recorder(listener), seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert r.reloads == [_PULSE_URL]
 
 
 def test_brief_blip_does_not_reload(listener):
     # Shorter than HA_RECOVERY_MIN_OUTAGE_SECONDS: a single failed probe or a
     # momentary network wobble must never reload a working dashboard.
     r = _outage(
-        listener,
+        _Recorder(listener),
         seconds=listener.HA_RECOVERY_MIN_OUTAGE_SECONDS - 1,
         settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1,
     )
-    assert r.homes == 0
+    assert r.reloads == []
 
 
 def test_reload_waits_for_the_settle_window(listener):
     # /api/ answers before the frontend can serve the dashboard, so reloading on
     # the first successful probe would just re-strand the kiosk.
-    r = _outage(listener, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS - 1)
-    assert r.homes == 0
+    r = _outage(_Recorder(listener), seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS - 1)
+    assert r.reloads == []
 
 
 def test_outage_during_settle_cancels_the_pending_reload(listener):
@@ -156,27 +161,61 @@ def test_outage_during_settle_cancels_the_pending_reload(listener):
     r.reachable = True
     r._check_ha_recovery(320.0)  # too brief to re-arm
     r._check_ha_recovery(999.0)
-    assert r.homes == 0
+    assert r.reloads == []
 
 
 def test_flapping_ha_cannot_cause_a_reload_loop(listener):
-    r = _outage(listener, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
-    assert r.homes == 1
+    r = _outage(_Recorder(listener), seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert len(r.reloads) == 1
     base = 300 + listener.HA_RECOVERY_SETTLE_SECONDS + 1
-    # A second full outage inside the rate limit must not reload again.
     r.reachable = False
     r._check_ha_recovery(base + 1)
     r._check_ha_recovery(base + 300)
     r.reachable = True
     r._check_ha_recovery(base + 300)
     r._check_ha_recovery(base + 300 + listener.HA_RECOVERY_SETTLE_SECONDS + 1)
-    assert r.homes == 1
+    assert len(r.reloads) == 1
 
 
-def test_no_ha_credentials_means_no_probing(listener):
+# -- what gets reloaded -------------------------------------------------------
+
+
+def test_recovery_restores_the_last_navigated_url(listener):
+    # A kiosk driven elsewhere by kiosk/url/set (a camera view, a status page)
+    # must come back to THAT page, not be snapped home by an unrelated outage.
     r = _Recorder(listener)
-    r.config = SimpleNamespace(ha_base_url="", ha_token="")
+    r._last_navigated_url = "http://cam.example/stream"
+    _outage(r, seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert r.reloads == ["http://cam.example/stream"]
+
+
+def test_recovery_falls_back_to_pulse_url_when_nothing_was_navigated(listener):
+    r = _outage(_Recorder(listener), seconds=300, settle=listener.HA_RECOVERY_SETTLE_SECONDS + 1)
+    assert r.reloads == [_PULSE_URL]
+
+
+# -- probe target selection ---------------------------------------------------
+
+
+def test_probe_prefers_the_authenticated_api_when_a_token_exists(listener):
+    url, headers = _Recorder(listener, token="tok")._recovery_probe_target()
+    assert url == "http://ha.example/api/"
+    assert headers["Authorization"] == "Bearer tok"
+
+
+def test_probe_falls_back_to_pulse_url_without_a_token(listener):
+    # HOME_ASSISTANT_TOKEN ships empty in pulse.conf.sample; requiring it would
+    # silently disable recovery for every install that never minted one.
+    url, headers = _Recorder(listener, token="")._recovery_probe_target()
+    assert url == _PULSE_URL
+    assert headers == {}
+
+
+def test_no_token_and_no_pulse_url_disables_recovery(listener):
+    r = _Recorder(listener, token="", pulse_url="")
+    r.config.ha_base_url = ""
+    assert r._recovery_probe_target() is None
     r.reachable = False
     r._check_ha_recovery(0.0)
     assert r._ha_unreachable_since is None
-    assert r.homes == 0
+    assert r.reloads == []


### PR DESCRIPTION
Follow-up to #262. Two things in that PR were narrower than intended — both make the feature depend on setup specifics rather than working generically.

## 1. It required `HOME_ASSISTANT_TOKEN`, which ships empty

`pulse.conf.sample` has `HOME_ASSISTANT_TOKEN=""`. The token is only needed for Assist and now-playing, so a plain dashboard kiosk won't have one — and #262's guard was:

```python
if not self.config.ha_base_url or not self.config.ha_token:
    return
```

So recovery silently did nothing for those installs. That's the common case, not an edge case.

The probe now prefers HA's authenticated `/api/` health endpoint when a token exists, and otherwise falls back to an **unauthenticated GET of `PULSE_URL`**. Measured against a live HA:

| Endpoint | No token |
|---|---|
| `/api/` | 401 |
| `/` (frontend) | 200 |
| `/dashboard-pulse/home` | 200 |

The fallback is slightly less precise — the frontend answers 200 a little before core can serve a dashboard — but `HA_RECOVERY_SETTLE_SECONDS` already exists to cover exactly that.

Probing `PULSE_URL` is arguably the more honest check anyway: it tests the resource whose failure we're recovering from, and it means a kiosk pointed at something other than Home Assistant is covered too.

## 2. It reloaded `PULSE_URL` unconditionally, discarding kiosk state

`kiosk/url/set` is a supported way to drive a display somewhere else — a camera stream, a status page, a dashboard for a different room. Recovering from an unrelated HA outage by snapping that display **back home** throws away state the user or an automation deliberately set. The outage may have had nothing to do with the page being shown.

`navigate()` now records the URL it went to, and recovery reloads *that*, falling back to `PULSE_URL` when the kiosk has never navigated. The cache-busting reload is factored out of `handle_home()` into `reload_url()` so both paths share one implementation.

This also makes the device-side behaviour consistent with what a sensible HA-side automation would do — restore what should be showing, rather than blindly homing.

## Testing

27 tests in `tests/test_kiosk_listener.py` (up from 23), still driven against a stub so no MQTT, DevTools or HTTP is involved. New coverage:

- recovery restores the last navigated URL
- falls back to `PULSE_URL` when nothing was navigated
- probe prefers authenticated `/api/` when a token exists
- probe falls back to `PULSE_URL` without a token
- no token *and* no `PULSE_URL` disables recovery entirely

Locally at the CI-pinned versions: full suite **2166 passed**, `ruff@0.16.6 check` clean, `ruff@0.16.6 format --check` clean, `bandit -lll -iii` clean.

As with #262, this has not yet been observed recovering a real HA restart in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tzrciexikca6629DJJech

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Watchdog-only kiosk reload behavior with existing outage/settle/rate limits; no auth or data-path changes beyond enabling unauthenticated health checks when no token is configured.
> 
> **Overview**
> Fixes **Home Assistant outage recovery** so it works on typical dashboard-only kiosks and reloads the right page afterward.
> 
> **Reachability probing** no longer requires `HOME_ASSISTANT_TOKEN`. A new `_recovery_probe_target()` still uses authenticated `/api/` when base URL and token are set; otherwise it probes `PULSE_URL` (or `ha_base_url`) with an unauthenticated GET so recovery is not a no-op when the sample config leaves the token empty.
> 
> **After recovery**, the watchdog calls `reload_url()` on `_last_navigated_url` (set in `navigate()`), falling back to `PULSE_URL` only if nothing was navigated—instead of always homing via `handle_home()`. Cache-busting reload logic is shared in `reload_url()` for HOME and recovery.
> 
> Tests now assert `reload_url` targets and probe selection (token vs no token, disabled when no URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff7f58f294f61c8f7fc3c907573fba4cb652785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->