### PR TITLE
fix(kiosk): re-check for a release when Update is pressed

### DIFF
--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -2600,8 +2600,29 @@ class KioskMqttListener:
         else:
             self.log(f"Received message on unexpected topic {msg.topic}")
 
+    def _ensure_update_availability(self) -> bool:
+        """Return whether an update is available, re-checking once if the cache says no.
+
+        The periodic poll runs PULSE_VERSION_CHECKS_PER_DAY times a day (12 by
+        default, and the allowed values bottom out at hourly), so a release cut
+        minutes ago stays invisible for up to two hours. Gating an explicit,
+        human-initiated update request on that cache makes the button look broken
+        and forces a service restart to clear it. Polling faster is the wrong fix:
+        the check is an unauthenticated GitHub API call and every kiosk on the
+        network shares one 60-requests-per-hour budget. Instead, spend exactly one
+        extra request at the moment someone actually asks.
+        """
+        if self.is_update_available():
+            return True
+        self.log("update: nothing cached; re-checking for a new release before giving up")
+        try:
+            self.refresh_update_availability()
+        except Exception as exc:  # noqa: BLE001 - a failed check must not kill the request
+            self.log(f"update: on-demand version check failed: {exc}")
+        return self.is_update_available()
+
     def handle_update(self) -> None:
-        if not self.is_update_available():
+        if not self._ensure_update_availability():
             self.log("update: request ignored because no update is available")
             return
         if not self.update_lock.acquire(blocking=False):

--- a/tests/test_kiosk_listener.py
+++ b/tests/test_kiosk_listener.py
@@ -219,3 +219,61 @@ def test_no_token_and_no_pulse_url_disables_recovery(listener):
     r._check_ha_recovery(0.0)
     assert r._ha_unreachable_since is None
     assert r.reloads == []
+
+
+# -- update button re-check ---------------------------------------------------
+#
+# _ensure_update_availability exists so an explicit "update now" is never refused
+# because the cached availability flag is stale. Driven against a stub: no MQTT,
+# no HTTP, no threads.
+
+
+class _UpdateStub:
+    def __init__(self, listener, *, cached: bool, after_refresh: bool | None = None, boom: bool = False):
+        self._cached = cached
+        self._after_refresh = after_refresh
+        self._boom = boom
+        self.refreshes = 0
+        self.logs: list[str] = []
+        self._ensure_update_availability = listener.KioskMqttListener._ensure_update_availability.__get__(self)
+
+    def is_update_available(self) -> bool:
+        return self._cached
+
+    def refresh_update_availability(self) -> None:
+        self.refreshes += 1
+        if self._boom:
+            raise RuntimeError("github unreachable")
+        if self._after_refresh is not None:
+            self._cached = self._after_refresh
+
+    def log(self, message: str) -> None:
+        self.logs.append(message)
+
+
+def test_cached_availability_skips_the_extra_request(listener):
+    s = _UpdateStub(listener, cached=True)
+    assert s._ensure_update_availability() is True
+    assert s.refreshes == 0  # must not spend a GitHub call when we already know
+
+
+def test_stale_cache_is_refreshed_so_a_fresh_release_is_seen(listener):
+    # The exact case that made the button look broken: a release cut minutes ago
+    # is invisible to the cache for up to 2h.
+    s = _UpdateStub(listener, cached=False, after_refresh=True)
+    assert s._ensure_update_availability() is True
+    assert s.refreshes == 1
+
+
+def test_genuinely_no_update_still_returns_false(listener):
+    s = _UpdateStub(listener, cached=False, after_refresh=False)
+    assert s._ensure_update_availability() is False
+    assert s.refreshes == 1
+
+
+def test_failed_check_does_not_propagate(listener):
+    # GitHub being unreachable must not turn a button press into a crash.
+    s = _UpdateStub(listener, cached=False, boom=True)
+    assert s._ensure_update_availability() is False
+    assert s.refreshes == 1
+    assert any("on-demand version check failed" in m for m in s.logs)


### PR DESCRIPTION
## The problem

`handle_update()` gated on a **cached** availability flag:

```python
def is_update_available(self) -> bool:
    with self._update_state_lock:
        return self.update_available     # only refreshed by the periodic poll
```

`PULSE_VERSION_CHECKS_PER_DAY` defaults to 12, and `ALLOWED_VERSION_CHECK_COUNTS = {2,4,6,8,12,24}` bottoms out at hourly — so a release published minutes ago is invisible for up to two hours.

The symptom is a button that appears broken: pressing **Update** logs `update: request ignored because no update is available` and does nothing, with no hint that the answer is merely stale. Hit for real while deploying #263 — the only way through was restarting `pulse-kiosk-mqtt` on all four devices to force a re-check, which is exactly what a deploy shouldn't require.

## Why not just poll faster

The check is an unauthenticated GitHub API call, and **every kiosk on a network shares one 60-requests-per-hour budget** against the same public IP:

| Interval | Per kiosk/day | 4-kiosk fleet/hour | of 60/hr |
|---|---|---|---|
| 12/day (default) | 12 | 2 | 3% |
| 24/day (hourly, the floor) | 24 | 4 | 7% |
| every 15m (not permitted) | 96 | 16 | 27% |

Shortening the interval multiplies background cost for a signal nobody watches in real time, and it scales badly with fleet size. The interval only needs to be timely enough for the "update available" badge.

## The fix

Spend exactly one extra request at the moment someone actually asks. An explicit update request re-checks once before refusing. A failed check is logged and treated as "no update" rather than propagating, so GitHub being unreachable can't turn a button press into a crash.

Split out as `_ensure_update_availability()` so the decision is unit-testable without threads, MQTT or HTTP.

## Testing

31 kiosk tests (up from 27), full suite **2170 passed**. New coverage:

- cached availability skips the extra request (no wasted API call)
- stale cache is refreshed, so a just-published release is seen
- genuinely no update still returns false
- a failed check is swallowed and logged, not propagated

`ruff@0.16.6 check` / `format --check` clean, `bandit -lll -iii` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Tzrciexikca6629DJJech

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to update gating with defensive error handling; behavior only adds an optional GitHub check on explicit user action.
> 
> **Overview**
> Fixes **Update** being ignored when the periodic version poll has not yet seen a new release (cache can lag up to ~2 hours without increasing GitHub API polling).
> 
> **`handle_update()`** (MQTT and overlay badge) now goes through **`_ensure_update_availability()`**: if the cached flag says no update, it performs **one** on-demand **`refresh_update_availability()`** before refusing. When the cache already says an update exists, no extra GitHub request is made. Failures during that check are logged and treated as unavailable instead of crashing the listener.
> 
> Adds stub-based unit tests for skip-when-cached, stale-cache refresh, still-false when nothing new, and error swallowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4949224748a0604d60986fbb8bfa31c8a4e14e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->