### PR TITLE
feat(kiosk): add a WiFi/Ethernet connectivity pill to the notification bar

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -107,6 +107,108 @@ body {
   color: #ff5c5c;
 }
 
+/* Connectivity pill — pinned leftmost, and the only badge here with no text at all.
+   Text would defeat the purpose: this pill is on screen permanently, so anything that
+   reads like a sentence becomes furniture within a day. Four rungs and a dot are shapes
+   you can take in without reading, which is the only way a permanent indicator stays
+   worth the space. The full story is in the title/aria-label, and one tap away in the
+   info card. */
+.overlay-badge--network {
+  gap: 0.45rem;
+  padding: 0.35rem 0.6rem;
+}
+
+.overlay-network__wifi {
+  position: relative;
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 0.12rem;
+  height: 0.95rem;
+}
+
+/* Unlit rungs stay visible rather than disappearing, so the pill keeps a constant
+   width and a constant shape. A control that changes size as the signal moves draws
+   the eye every time it does — exactly the wrong behaviour for something on screen
+   around the clock. */
+.overlay-network__bar {
+  width: 0.22rem;
+  border-radius: 0.08rem;
+  background: rgba(255, 255, 255, 0.28);
+  transition: background 0.3s ease;
+}
+
+.overlay-network__bar:nth-child(1) { height: 30%; }
+.overlay-network__bar:nth-child(2) { height: 50%; }
+.overlay-network__bar:nth-child(3) { height: 75%; }
+.overlay-network__bar:nth-child(4) { height: 100%; }
+
+.overlay-network__bar--on {
+  background: #4caf50;
+}
+
+/* One bar is not "a bit worse than two", it is the state where this fleet's roam
+   stalls and power-save drops start, so it gets amber — a warning you can act on
+   while the display is still usable, rather than after it has fallen off the network. */
+.overlay-network__wifi--weak .overlay-network__bar--on {
+  background: #e0a030;
+}
+
+/* Kept bright enough to still read as a signal meter under the slash. Dropped much
+   further the rungs disappear and the pill becomes an unexplained red streak — the
+   shape has to survive, because the shape is what says "this is the WiFi". */
+.overlay-network__wifi--off .overlay-network__bar {
+  background: rgba(255, 92, 92, 0.55);
+}
+
+/* The crossed-out state. A diagonal rule over the (all-unlit) rungs rather than a
+   separate glyph, so "no WiFi" occupies the same footprint as every other signal
+   level and the pill never reflows. */
+.overlay-network__slash {
+  position: absolute;
+  left: -0.1rem;
+  right: -0.1rem;
+  top: 50%;
+  height: 2px;
+  background: #ff5c5c;
+  border-radius: 2px;
+  transform: rotate(-35deg);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.55);
+}
+
+.overlay-network__eth {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background 0.3s ease;
+}
+
+.overlay-network__eth--up {
+  background: #4caf50;
+}
+
+/* Red is reserved for a cable that is plugged in and has stopped working. Every kiosk
+   in this fleet runs on WiFi with an empty Ethernet port, so "no cable" has to be a
+   quiet grey — a permanent red dot on four displays would teach everyone to stop
+   looking at this pill, and the one Ethernet fault worth catching would go unseen. */
+.overlay-network__eth--down {
+  background: #ff5c5c;
+  box-shadow: 0 0 6px rgba(255, 92, 92, 0.7);
+}
+
+.overlay-network__eth--absent {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+/* No pulse animation here, unlike the speaker and weather-alert badges. Those appear
+   only when something is wrong, so movement is informative; this pill is always
+   present, and anything that moves on it permanently would be a distraction in the
+   room rather than a signal. */
+.overlay-badge.overlay-badge--network-offline {
+  background: rgba(120, 20, 20, 0.7);
+  border: 1px solid rgba(255, 92, 92, 0.45);
+}
+
 /* Speaker-offline badge — the one badge on this bar that reports a fault, so it gets
    amber rather than the neutral translucent background. Amber, not the earmuffs red:
    red on this bar already means "earmuffs are on", a deliberate user choice, and a

--- a/bin/kiosk-mqtt-listener.py
+++ b/bin/kiosk-mqtt-listener.py
@@ -25,6 +25,7 @@ from pulse import __version__, audio, display
 from pulse.config_persist import ConfigPersister, persist_preference
 from pulse.location_resolver import resolve_location
 from pulse.mqtt_discovery import build_button_entity, build_number_entity, build_select_entity
+from pulse.network import check_network, status_payload
 from pulse.overlay import (
     DEFAULT_FONT_STACK,
     ClockConfig,
@@ -144,6 +145,8 @@ class OverlayConfig:
     bt_autoconnect: bool
     bt_mac: str
     speaker_sink: str  # substring of the expected wired sink; empty disables that check
+    network_pill: bool  # show the always-on WiFi/Ethernet pill at the left of the bar
+    network_interval: int  # seconds between connectivity readings
 
 
 @dataclass(frozen=True)
@@ -598,6 +601,12 @@ def load_config() -> EnvConfig:
         bt_autoconnect=parse_bool(os.environ.get("PULSE_BLUETOOTH_AUTOCONNECT"), True),
         bt_mac=(os.environ.get("PULSE_BT_MAC") or "").strip(),
         speaker_sink=(os.environ.get("PULSE_SPEAKER_SINK") or "").strip(),
+        network_pill=parse_bool(os.environ.get("PULSE_NETWORK_PILL"), True),
+        # Every read is a handful of sysfs files and two ioctls, so this is cheap enough
+        # to run often; 30s is fast enough that a link going bad shows up while somebody
+        # is still standing in front of the display. The 10s floor is there only to stop
+        # a typo'd config from spinning the poll thread.
+        network_interval=max(10, parse_int(os.environ.get("PULSE_NETWORK_INTERVAL"), 30)),
     )
 
     version_source_url = os.environ.get("PULSE_VERSION_SOURCE_URL", DEFAULT_VERSION_SOURCE_URL)
@@ -824,6 +833,9 @@ class KioskMqttListener:
         self._speaker_thread: threading.Thread | None = None
         self._speaker_stop_event = threading.Event()
         self._speaker_offline_streak = 0
+        self._network_lock = threading.Lock()
+        self._network_thread: threading.Thread | None = None
+        self._network_stop_event = threading.Event()
         self._watchdog_thread: threading.Thread | None = None
         self._watchdog_stop_event = threading.Event()
         self._last_mqtt_ok: float = time.monotonic()
@@ -1109,6 +1121,62 @@ class KioskMqttListener:
                     break
         finally:
             client.close()
+
+    def start_network_monitor(self) -> None:
+        if not self.overlay_state or not self.overlay_config.network_pill:
+            return
+        with self._network_lock:
+            if self._network_thread and self._network_thread.is_alive():
+                return
+            self._network_stop_event.clear()
+            thread = threading.Thread(target=self._network_loop, name="pulse-network", daemon=True)
+            self._network_thread = thread
+            thread.start()
+
+    def stop_network_monitor(self) -> None:
+        with self._network_lock:
+            if not self._network_thread:
+                return
+            self._network_stop_event.set()
+            self._network_thread.join(timeout=self.overlay_config.network_interval)
+            self._network_thread = None
+
+    def _network_loop(self) -> None:
+        state = self.overlay_state
+        if not state:
+            return
+        last_logged = ""
+        while not self._network_stop_event.is_set():
+            try:
+                status = check_network()
+                change = state.update_network(status_payload(status))
+                # Logged only on a transition, and only for the states worth a journal
+                # line: a healthy link that stays healthy must not write a line every
+                # poll, or the pill becomes the noisiest thing in the log.
+                if status.wifi_present and not status.wifi_up:
+                    current = "wifi-down"
+                elif status.ethernet == "down":
+                    current = "ethernet-down"
+                elif status.wifi_bars is not None and status.wifi_bars <= 1:
+                    current = f"wifi-weak:{status.wifi_dbm}"
+                else:
+                    current = ""
+                if current != last_logged:
+                    if current.startswith("wifi-weak"):
+                        self.log(f"network: weak WiFi signal ({status.wifi_dbm} dBm on {status.wifi_interface})")
+                    elif current == "wifi-down":
+                        self.log(f"network: WiFi is down ({status.wifi_interface})")
+                    elif current == "ethernet-down":
+                        self.log(f"network: Ethernet cable connected but has no IP ({status.ethernet_interface})")
+                    elif last_logged:
+                        self.log("network: connectivity recovered")
+                    last_logged = current
+                if change.changed:
+                    self._emit_overlay_refresh(change.version, change.reason)
+            except Exception as exc:  # nosec B110 - never let a probe error kill the loop
+                self.log(f"network: check failed: {exc}")
+            if self._network_stop_event.wait(self.overlay_config.network_interval):
+                break
 
     def start_speaker_monitor(self) -> None:
         if not self.overlay_state or not self.overlay_config.speaker_alert:
@@ -2548,6 +2616,7 @@ class KioskMqttListener:
         self.start_ticker()
         self.start_weather_alerts()
         self.start_speaker_monitor()
+        self.start_network_monitor()
         if self.overlay_state:
             # Start the HTTP server BEFORE announcing the boot refresh, otherwise the
             # photo-card re-fetches /overlay against a not-yet-listening port, fails, and
@@ -2898,6 +2967,7 @@ def main():
     atexit.register(listener.stop_ticker)
     atexit.register(listener.stop_weather_alerts)
     atexit.register(listener.stop_speaker_monitor)
+    atexit.register(listener.stop_network_monitor)
     atexit.register(listener.stop_overlay_server)
     atexit.register(listener._stop_watchdog)
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -241,6 +241,8 @@ listening off and is not a mute.
 | `PULSE_SPEAKER_ALERT` | `true` | Shows a notification-bar badge while the configured speaker is unreachable. |
 | `PULSE_SPEAKER_SINK` | *(empty)* | Substring of the expected wired sink name (`pactl list sinks short`) to watch on non-Bluetooth displays. |
 | `PULSE_SPEAKER_INTERVAL` | `60` | Seconds between speaker reachability checks (minimum 15). |
+| `PULSE_NETWORK_PILL` | `true` | Shows the always-on WiFi/Ethernet pill at the far left of the notification bar. |
+| `PULSE_NETWORK_INTERVAL` | `30` | Seconds between connectivity readings (minimum 10). |
 
 ### On-screen device controls
 
@@ -278,6 +280,36 @@ there is no save step.
 
 The day/night targets are hidden entirely on a display with no backlight, since it cannot
 act on a schedule.
+
+### Connectivity pill
+
+`PULSE_NETWORK_PILL` puts a WiFi/Ethernet indicator at the far left of the notification bar,
+left of **Help**. It is the only badge on that bar shown in its healthy state, and that is
+deliberate: every other pill there reports something otherwise invisible, so appearing at all
+is the message. Connectivity instead degrades *gradually*, and the reading worth having is the
+trend — a display that normally sits at four bars and is now at two has a problem worth chasing
+before it drops off the network entirely and takes the overlay with it. A pill that only shows
+up at zero cannot tell you that.
+
+- **WiFi** — four rungs, filled 1–4 by signal strength (≥ −55 dBm = 4, ≥ −65 = 3, ≥ −75 = 2,
+  below that = 1). One bar turns amber: that is where this fleet's roam stalls and power-save
+  drops start, not merely "a bit worse than two". No link at all crosses the rungs out in red.
+- **Ethernet** — a dot: green for a working cable, red for a cable that is plugged in but has
+  no IP address (carrier up, DHCP never completed), grey for no cable. Grey rather than red is
+  the point — every Pulse kiosk runs on WiFi with an empty Ethernet port, and a permanent red
+  dot on every display would teach everyone to ignore the pill, costing exactly the one
+  Ethernet fault worth catching.
+
+Tapping the pill opens a card with SSID, access point (BSSID), signal strength in dBm, IP
+address, and Ethernet state. The access point is there because a kiosk pinned to a specific AP
+silently loses that pin when the AP reboots, and "which radio am I actually on" is then the
+only thing distinguishing a healthy roam from a stalled one — and it is precisely what you
+cannot go look up over SSH, because SSH is what stops working when the answer is bad.
+
+State is read straight from `/sys/class/net` and `/proc/net/wireless` (plus two ioctls for the
+SSID/BSSID) rather than by shelling out to `iw` or `nmcli`: no fork per poll on a Pi, no
+dependency on tools that aren't installed uniformly, and no multi-second block against a wedged
+driver. A probe that cannot run reports "unknown" and renders nothing, never a healthy pill.
 
 ### Speaker-offline badge
 

--- a/pulse.conf.sample
+++ b/pulse.conf.sample
@@ -397,6 +397,19 @@ PULSE_SPEAKER_SINK=""
 # PULSE_SPEAKER_INTERVAL — seconds between speaker reachability checks (minimum 15).
 PULSE_SPEAKER_INTERVAL="60"
 
+# PULSE_NETWORK_PILL — show the always-on connectivity pill at the far left of the
+# notification bar: 1-4 WiFi bars (crossed out in red when there's no link) and a dot for
+# Ethernet (green = working, red = cable in but no IP, grey = no cable). Tap it for the
+# SSID, access point, signal strength and IP address. Unlike the other badges this one is
+# visible in its healthy state on purpose — a display sliding from four bars to one is the
+# early, visible form of the roam-stall and power-save failures, and you can't see a trend
+# from an indicator that only appears once the network is already gone.
+PULSE_NETWORK_PILL="true"
+
+# PULSE_NETWORK_INTERVAL — seconds between connectivity readings (minimum 10). Each read is
+# a handful of sysfs files and two ioctls, so this is cheap to run often.
+PULSE_NETWORK_INTERVAL="30"
+
 # ============================================================================
 # Logging & Reliability
 # ============================================================================

--- a/pulse/network.py
+++ b/pulse/network.py
@@ -1,0 +1,282 @@
+"""Read this kiosk's WiFi signal strength and Ethernet link state.
+
+A Pulse display hangs on a wall with no keyboard, so "is it on the network, and how
+well?" is a question that today can only be answered over SSH -- which is exactly the
+thing that stops working when the answer is bad. The whole point of putting this on
+the bar is that it stays readable while the network is degrading: a kiosk drifting
+from four bars to one is the visible, *early* form of the roam-stall and power-save
+failures this fleet has hit repeatedly.
+
+Everything here reads sysfs and procfs directly rather than shelling out to `iw` or
+`nmcli`. Those are a fork per poll on a Pi Zero-class CPU, they are not installed
+uniformly across the fleet, and both block for seconds against a wedged driver --
+whereas the kernel keeps these files answerable even when the radio is unhappy. The
+one exception is the SSID/BSSID pair, which has no sysfs equivalent; that goes
+through an ioctl on a plain socket, still with no subprocess.
+
+The module deliberately reports "unknown" rather than guessing. A probe that cannot
+run must never render as a healthy green pill -- a display that has quietly stopped
+knowing its own link state is itself the thing worth showing.
+"""
+
+from __future__ import annotations
+
+import array
+import fcntl
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+
+_NET_ROOT = Path("/sys/class/net")
+_PROC_WIRELESS = Path("/proc/net/wireless")
+
+# Virtual and container interfaces are not this kiosk's link to the house. Matching on
+# prefixes keeps the fleet's mix of predictable (enxAABB) and legacy (eth0) names
+# working without an allow-list that has to be edited per device.
+_IGNORED_PREFIXES = ("lo", "docker", "veth", "br-", "virbr", "tun", "tap", "wg", "zt", "sit", "dummy")
+
+# SIOCGIWESSID / SIOCGIWAP from linux/wireless.h. Present on every kernel that has
+# CONFIG_WIRELESS_EXT, which includes the brcmfmac Pis this fleet runs.
+_SIOCGIWESSID = 0x8B1B
+_SIOCGIWAP = 0x8B15
+_IW_ESSID_MAX_SIZE = 32
+
+# Signal thresholds in dBm, strongest first. These are the practical breakpoints for
+# 2.4/5GHz on the Pi radios here, not the vendor marketing curve: -55 and better is a
+# link with headroom to spare, -75 and worse is where throughput collapses and the
+# roam-stall symptoms start. One bar therefore means "this is already a problem",
+# which is the reading that makes the pill worth glancing at.
+_BAR_THRESHOLDS_DBM = ((-55, 4), (-65, 3), (-75, 2))
+
+
+@dataclass(frozen=True)
+class NetworkStatus:
+    """One reading of this kiosk's connectivity.
+
+    ``wifi_bars`` is 1-4, or None when there is no bar count to draw — the radio is
+    down or unassociated, there is no WiFi interface, or the driver gave no usable
+    signal level. There is deliberately no zero: an associated link always gets at
+    least one bar, and "nothing to show" has to stay distinguishable from "shown as
+    the worst possible signal", because only one of those is a measurement.
+    """
+
+    wifi_present: bool
+    wifi_up: bool
+    wifi_bars: int | None
+    wifi_dbm: int | None
+    wifi_ssid: str
+    wifi_bssid: str
+    wifi_ip: str
+    wifi_interface: str
+    # "up" (carrier and usable), "down" (cable in, no link), "absent" (no cable), or
+    # "none" (no Ethernet interface on this device at all).
+    ethernet: str
+    ethernet_ip: str
+    ethernet_interface: str
+
+
+def _read(path: Path) -> str:
+    """First line of a sysfs file, or "" when it cannot be read.
+
+    Never raises: every caller is on a background poll loop, and sysfs entries vanish
+    mid-read when an interface is torn down.
+    """
+    try:
+        return path.read_text(encoding="utf-8", errors="replace").strip()
+    except (OSError, ValueError) as exc:
+        _LOGGER.debug("[network] could not read %s: %s", path, exc)
+        return ""
+
+
+def _interfaces() -> list[str]:
+    try:
+        names = sorted(entry.name for entry in _NET_ROOT.iterdir())
+    except OSError as exc:
+        _LOGGER.debug("[network] could not list %s: %s", _NET_ROOT, exc)
+        return []
+    return [name for name in names if not name.startswith(_IGNORED_PREFIXES)]
+
+
+def _is_wireless(name: str) -> bool:
+    return (_NET_ROOT / name / "wireless").is_dir()
+
+
+def _ip_address(name: str) -> str:
+    """IPv4 address bound to ``name``, or "" if it has none.
+
+    SIOCGIFADDR rather than parsing `ip addr`, for the same no-subprocess reason as the
+    rest of the module. An interface that is up but has no address answers with EADDRNOTAVAIL,
+    which is a meaningful state here -- associated to the AP but DHCP never completed.
+    """
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            packed = fcntl.ioctl(
+                sock.fileno(),
+                0x8915,  # SIOCGIFADDR
+                struct.pack("256s", name[:15].encode("utf-8")),
+            )
+        return socket.inet_ntoa(packed[20:24])
+    except OSError as exc:
+        _LOGGER.debug("[network] no IPv4 on %s: %s", name, exc)
+        return ""
+
+
+def _wireless_identity(name: str) -> tuple[str, str]:
+    """(ssid, bssid) for an associated interface, ("", "") when unassociated.
+
+    The BSSID matters as much as the SSID on this fleet: a kiosk pinned to an AP that
+    has rebooted keeps the SSID and silently loses the pin, so "which AP am I actually
+    on" is the diagnostic somebody standing in front of the display needs.
+    """
+    ssid = ""
+    bssid = ""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            iface = name[:15].encode("utf-8")
+            buffer = array.array("B", b"\x00" * (_IW_ESSID_MAX_SIZE + 1))
+            addr, length = buffer.buffer_info()
+            request = struct.pack("16sPHH", iface, addr, length, 0)
+            try:
+                fcntl.ioctl(sock.fileno(), _SIOCGIWESSID, request)
+                ssid = buffer.tobytes().split(b"\x00", 1)[0].decode("utf-8", errors="replace")
+            except OSError as exc:
+                _LOGGER.debug("[network] no ESSID on %s: %s", name, exc)
+            try:
+                packed = fcntl.ioctl(sock.fileno(), _SIOCGIWAP, struct.pack("256s", iface))
+                raw = packed[18:24]
+                # An unassociated radio answers with the all-zero AP address rather than
+                # an error, so that has to be filtered out here or it renders as a real
+                # (and very confusing) 00:00:00:00:00:00 "access point".
+                if any(raw):
+                    bssid = ":".join(f"{octet:02X}" for octet in raw)
+            except OSError as exc:
+                _LOGGER.debug("[network] no AP address on %s: %s", name, exc)
+    except OSError as exc:
+        _LOGGER.debug("[network] wireless identity failed for %s: %s", name, exc)
+    return ssid, bssid
+
+
+def _signal_dbm(name: str) -> int | None:
+    """Signal level in dBm from /proc/net/wireless, or None when unavailable.
+
+    The level column is written as a float with a trailing dot ("-42.") and, on drivers
+    that report it unsigned, as a 0-255 value that has to be wrapped back into negative
+    dBm. Both forms show up across this fleet's radios.
+    """
+    try:
+        lines = _PROC_WIRELESS.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        _LOGGER.debug("[network] could not read %s: %s", _PROC_WIRELESS, exc)
+        return None
+    for line in lines:
+        stripped = line.strip()
+        if not stripped.startswith(f"{name}:"):
+            continue
+        fields = stripped.split(":", 1)[1].split()
+        if len(fields) < 3:
+            return None
+        try:
+            level = int(float(fields[2].rstrip(".")))
+        except ValueError:
+            return None
+        if level > 0:
+            level -= 256
+        # A driver that has the interface up but no association reports a flat 0, which
+        # would otherwise map to a triumphant four bars.
+        return level if level < 0 else None
+    return None
+
+
+def signal_bars(dbm: int | None) -> int | None:
+    """Map a dBm reading onto the 0-4 bars the pill draws."""
+    if dbm is None:
+        return None
+    for threshold, bars in _BAR_THRESHOLDS_DBM:
+        if dbm >= threshold:
+            return bars
+    return 1
+
+
+def check_network() -> NetworkStatus:
+    """One reading of WiFi and Ethernet state for this kiosk.
+
+    Picks the first non-virtual interface of each kind. Every Pulse display has exactly
+    one of each, so there is nothing to disambiguate; a device with two would simply
+    report the lower-named one rather than inventing a policy nobody needs.
+    """
+    wifi_name = ""
+    ethernet_name = ""
+    for name in _interfaces():
+        if _is_wireless(name):
+            if not wifi_name:
+                wifi_name = name
+        elif not ethernet_name:
+            ethernet_name = name
+
+    wifi_up = False
+    wifi_dbm: int | None = None
+    wifi_ssid = ""
+    wifi_bssid = ""
+    wifi_ip = ""
+    if wifi_name:
+        wifi_up = _read(_NET_ROOT / wifi_name / "operstate") == "up"
+        if wifi_up:
+            wifi_ssid, wifi_bssid = _wireless_identity(wifi_name)
+            wifi_dbm = _signal_dbm(wifi_name)
+            wifi_ip = _ip_address(wifi_name)
+
+    # "absent" and "down" both mean no traffic is flowing, but only one of them is worth
+    # a red dot. Every Pi in this fleet has an eth0 with nothing plugged into it, so
+    # treating a missing carrier as a fault would paint a permanent red dot on all four
+    # displays and teach everyone to ignore the pill -- which costs us the one case that
+    # matters, a cable that *is* plugged in and has stopped working.
+    ethernet = "none"
+    ethernet_ip = ""
+    if ethernet_name:
+        carrier = _read(_NET_ROOT / ethernet_name / "carrier")
+        operstate = _read(_NET_ROOT / ethernet_name / "operstate")
+        if carrier == "1":
+            ethernet_ip = _ip_address(ethernet_name)
+            # Carrier without an address is a live cable that never finished DHCP --
+            # a real fault, and exactly the one a red dot should be spent on.
+            ethernet = "up" if ethernet_ip else "down"
+        elif operstate == "down" or carrier == "0":
+            ethernet = "absent"
+        else:
+            # No carrier file at all, or an unreadable one: no opinion.
+            ethernet = "absent"
+
+    return NetworkStatus(
+        wifi_present=bool(wifi_name),
+        wifi_up=wifi_up,
+        wifi_bars=signal_bars(wifi_dbm) if wifi_up else None,
+        wifi_dbm=wifi_dbm,
+        wifi_ssid=wifi_ssid,
+        wifi_bssid=wifi_bssid,
+        wifi_ip=wifi_ip,
+        wifi_interface=wifi_name,
+        ethernet=ethernet,
+        ethernet_ip=ethernet_ip,
+        ethernet_interface=ethernet_name,
+    )
+
+
+def status_payload(status: NetworkStatus) -> dict[str, object]:
+    """Flatten a reading into the dict the overlay snapshot carries."""
+    return {
+        "wifi_present": status.wifi_present,
+        "wifi_up": status.wifi_up,
+        "bars": status.wifi_bars,
+        "dbm": status.wifi_dbm,
+        "ssid": status.wifi_ssid,
+        "bssid": status.wifi_bssid,
+        "wifi_ip": status.wifi_ip,
+        "wifi_interface": status.wifi_interface,
+        "ethernet": status.ethernet,
+        "ethernet_ip": status.ethernet_ip,
+        "ethernet_interface": status.ethernet_interface,
+    }

--- a/pulse/overlay.py
+++ b/pulse/overlay.py
@@ -94,6 +94,10 @@ class OverlaySnapshot:
     # Active NWS alerts for this kiosk's location, most urgent first. See
     # pulse/weather_alerts.py for the shape of each entry.
     weather_alerts: tuple[dict[str, Any], ...] = ()
+    # Latest WiFi/Ethernet reading as produced by pulse.network.status_payload, or
+    # None before the first poll (or when the network pill is disabled), in which
+    # case the pill renders nothing at all rather than guessing at a state.
+    network: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -184,6 +188,7 @@ class OverlayStateManager:
         self._ticker: tuple[dict[str, Any], ...] = ()
         self._speaker_offline: dict[str, Any] | None = None
         self._weather_alerts: tuple[dict[str, Any], ...] = ()
+        self._network: dict[str, Any] | None = None
         self._version = 0
         self._last_reason = "init"
         self._last_updated = time.time()
@@ -204,6 +209,7 @@ class OverlayStateManager:
             "ticker": "",
             "speaker_offline": "",
             "weather_alerts": "",
+            "network": "",
         }
 
     @property
@@ -518,6 +524,32 @@ class OverlayStateManager:
             self._signatures["speaker_offline"] = signature
             return self._bump("speaker_offline")
 
+    def update_network(self, network: dict[str, Any] | None) -> OverlayChange:
+        """Record the latest WiFi/Ethernet reading.
+
+        Signed on the *rendered* fields only — bar count, link states, SSID/AP — and
+        deliberately not on the raw dBm. Signal strength jitters by a few dB every poll
+        even on a stationary display, and signing it would bump the overlay version on
+        every single cycle, reloading the photo card underneath roughly twice a minute
+        forever. The pill draws bars, so bars are what a change means.
+        """
+        normalized = dict(network) if network else None
+        if normalized is None:
+            signature = ""
+        else:
+            signature = ":".join(
+                str(normalized.get(key, "")) for key in ("wifi_present", "wifi_up", "bars", "ssid", "bssid", "ethernet")
+            )
+        with self._lock:
+            # Stored unconditionally, even when the signature matches: the info card
+            # reads dBm and IP straight off the snapshot, so an open card should track
+            # the live numbers rather than freeze at whatever bumped the version last.
+            self._network = normalized
+            if signature == self._signatures["network"]:
+                return OverlayChange(False, self._version, "network")
+            self._signatures["network"] = signature
+            return self._bump("network")
+
     def set_weather_alerts(self, alerts: Sequence[dict[str, Any]], *, banner_minutes: int = 0) -> OverlayChange:
         """Store the active NWS alerts for this location, most urgent first.
 
@@ -567,6 +599,7 @@ class OverlayStateManager:
                 ticker=tuple(dict(item) for item in self._ticker),
                 speaker_offline=copy.deepcopy(self._speaker_offline),
                 weather_alerts=tuple(copy.deepcopy(item) for item in self._weather_alerts),
+                network=copy.deepcopy(self._network),
             )
 
     def _bump(self, reason: str) -> OverlayChange:
@@ -747,6 +780,8 @@ ICON_MAP = {
     "market": "&#128200;",  # 📈
     "speaker_off": "&#128263;",  # 🔇
     "weather_alert": "&#9888;",  # ⚠
+    "wifi_off": "&#128683;",  # 🚫 — overlaid on the bars when there is no WiFi link
+    "ethernet": "&#128268;",  # 🔌
 }
 
 
@@ -948,6 +983,88 @@ def _build_speaker_pill(snapshot: OverlaySnapshot) -> str:
         f'aria-label="{safe_detail}" title="{safe_detail}">'
         f'<span class="overlay-badge__icon" aria-hidden="true">{icon}</span>'
         f"<span>{safe_label}</span>"
+        "</span>"
+    )
+
+
+def _build_network_pill(network: dict[str, Any] | None) -> str:
+    """Always-on connectivity pill: WiFi bars plus an Ethernet dot.
+
+    The one badge on this bar that is shown in its healthy state, and that is the
+    point of it. Every other pill here appears only when something is wrong, which
+    works because the thing it reports on is otherwise invisible. Connectivity is the
+    opposite: it degrades gradually, and the useful reading is the *trend* — a display
+    that normally sits at four bars and is now at two has a problem worth chasing
+    before it drops off the network entirely and takes the overlay with it. You cannot
+    see that from a pill that only appears at zero.
+
+    Ethernet gets three states rather than two. Green is a working cable; red is a
+    cable that is plugged in and has stopped working (carrier but no address); grey is
+    no cable, which is the normal, permanent condition of every kiosk in this fleet.
+    Painting that grey case red would put a fault indicator on four displays forever
+    and spend the pill's credibility on nothing.
+    """
+    if not network:
+        return ""
+    wifi_present = bool(network.get("wifi_present"))
+    ethernet_state = str(network.get("ethernet") or "none")
+    if not wifi_present and ethernet_state == "none":
+        # Nothing to draw. A device with neither interface is not a state anyone needs
+        # a pill for; it is a device that isn't on the network at all, and the overlay
+        # it would be drawn on could not have loaded.
+        return ""
+
+    bars = network.get("bars")
+    bars = bars if isinstance(bars, int) else None
+    wifi_linked = bool(network.get("wifi_up")) and bars is not None
+    ssid = str(network.get("ssid") or "").strip()
+    dbm = network.get("dbm")
+
+    segments: list[str] = []
+    if wifi_present:
+        filled = bars or 0
+        rungs = "".join(
+            f'<span class="overlay-network__bar'
+            f'{" overlay-network__bar--on" if wifi_linked and index <= filled else ""}"></span>'
+            for index in range(1, 5)
+        )
+        wifi_classes = ["overlay-network__wifi"]
+        if not wifi_linked:
+            wifi_classes.append("overlay-network__wifi--off")
+        elif filled <= 1:
+            wifi_classes.append("overlay-network__wifi--weak")
+        slash = '<span class="overlay-network__slash" aria-hidden="true"></span>' if not wifi_linked else ""
+        segments.append(f'<span class="{" ".join(wifi_classes)}" aria-hidden="true">{rungs}{slash}</span>')
+    if ethernet_state != "none":
+        segments.append(
+            f'<span class="overlay-network__eth overlay-network__eth--{html_escape(ethernet_state, quote=True)}"'
+            f' aria-hidden="true"></span>'
+        )
+
+    if not wifi_present:
+        wifi_text = "No WiFi adapter"
+    elif not wifi_linked:
+        wifi_text = "WiFi disconnected"
+    else:
+        where = f' to "{ssid}"' if ssid else ""
+        strength = f" at {dbm} dBm" if isinstance(dbm, int) else ""
+        wifi_text = f"WiFi {bars}/4{where}{strength}"
+    ethernet_text = {
+        "up": "Ethernet connected",
+        "down": "Ethernet cable plugged in but not working",
+        "absent": "no Ethernet cable",
+    }.get(ethernet_state, "")
+    detail = wifi_text if not ethernet_text else f"{wifi_text}, {ethernet_text}"
+    safe_detail = html_escape(detail, quote=True)
+
+    classes = ["overlay-badge", "overlay-badge--network"]
+    if wifi_present and not wifi_linked:
+        classes.append("overlay-badge--network-offline")
+    return (
+        f'<span class="{" ".join(classes)}" role="button" tabindex="0"'
+        f' data-badge-action="show_network"'
+        f' aria-label="{safe_detail}" title="{safe_detail}">'
+        f"{''.join(segments)}"
         "</span>"
     )
 
@@ -1679,6 +1796,14 @@ def _build_now_playing_card(snapshot: OverlaySnapshot) -> tuple[str, str] | None
 
 def _build_notification_bar(snapshot: OverlaySnapshot, theme: OverlayTheme) -> str:
     badges: list[str] = []
+    # Leftmost, ahead of even Help: it is the only pill that is shown in its healthy
+    # state, so it needs a fixed home on the bar. Anywhere further right and it would
+    # slide sideways every time an alarm or a weather alert appears, which is exactly
+    # the kind of movement that stops a permanent indicator from being readable at a
+    # glance. Pinned first, it is always in the same place.
+    network_pill = _build_network_pill(snapshot.network)
+    if network_pill:
+        badges.append(network_pill)
     badges.append(_render_badge("help", "Help"))
     badges.append(_render_badge("config", "Config"))
     # First of the status pills, ahead of even the speaker badge: nothing else on this bar
@@ -1758,6 +1883,8 @@ def _build_info_overlay(snapshot: OverlaySnapshot, *, hour12: bool = True) -> st
         return _build_routines_info_overlay(card)
     if card_type == "health":
         return _build_health_info_overlay(card)
+    if card_type == "network":
+        return _build_network_info_overlay(snapshot)
     if card_type == "config":
         return _build_config_info_overlay()
     if card_type == "device_controls":
@@ -2874,6 +3001,92 @@ def _build_health_info_overlay(card: dict[str, Any]) -> str:
       {subtitle_html}
     </div>
     <button class="overlay-info-card__close" data-info-card-close aria-label="Close health status">&times;</button>
+  </div>
+  <div class="overlay-info-card__body">
+    {body}
+  </div>
+</div>
+""".strip()
+
+
+def _build_network_info_overlay(snapshot: OverlaySnapshot) -> str:
+    """Detail card behind the connectivity pill.
+
+    Reads the live snapshot rather than a payload frozen at tap time, so an open card
+    tracks the poll — which is what makes it usable for watching a link actually
+    recover instead of having to close and reopen it.
+
+    The AP address earns its place here despite being the least human-readable line on
+    the card: this fleet pins kiosks to specific access points, an AP outage silently
+    strips that pin, and "which radio am I actually on" is then the only question that
+    distinguishes a healthy roam from a stalled one. It is also precisely the thing you
+    cannot go look up over SSH when the answer is bad.
+    """
+    network = snapshot.network
+    if not network:
+        # No reading has happened yet (or the pill is turned off). That is emphatically
+        # not the same as "this device has no wireless adapter", and saying so would
+        # send somebody looking for a hardware fault that doesn't exist.
+        return _network_info_shell('<div class="overlay-info-card__empty">Network status is not available yet.</div>')
+    rows: list[tuple[str, str]] = []
+
+    wifi_interface = str(network.get("wifi_interface") or "")
+    if not network.get("wifi_present"):
+        rows.append(("WiFi", "No wireless adapter"))
+    elif not network.get("wifi_up"):
+        rows.append(("WiFi", f"Disconnected ({wifi_interface})" if wifi_interface else "Disconnected"))
+    else:
+        bars = network.get("bars")
+        dbm = network.get("dbm")
+        if isinstance(bars, int) and isinstance(dbm, int):
+            quality = {4: "excellent", 3: "good", 2: "fair", 1: "weak"}.get(bars, "unusable")
+            rows.append(("Signal", f"{bars}/4 — {quality} ({dbm} dBm)"))
+        elif isinstance(dbm, int):
+            rows.append(("Signal", f"{dbm} dBm"))
+        else:
+            rows.append(("Signal", "Connected, strength unknown"))
+        rows.append(("Network", str(network.get("ssid") or "").strip() or "Unknown"))
+        bssid = str(network.get("bssid") or "").strip()
+        if bssid:
+            rows.append(("Access point", bssid))
+        rows.append(("IP address", str(network.get("wifi_ip") or "").strip() or "None — DHCP has not completed"))
+        if wifi_interface:
+            rows.append(("Interface", wifi_interface))
+
+    ethernet = str(network.get("ethernet") or "none")
+    ethernet_interface = str(network.get("ethernet_interface") or "")
+    if ethernet == "up":
+        address = str(network.get("ethernet_ip") or "").strip()
+        rows.append(("Ethernet", f"Connected — {address}" if address else "Connected"))
+    elif ethernet == "down":
+        rows.append(("Ethernet", "Cable connected but no IP address — DHCP has not completed"))
+    elif ethernet == "absent":
+        rows.append(
+            ("Ethernet", f"No cable connected ({ethernet_interface})" if ethernet_interface else "No cable connected")
+        )
+
+    entries = "".join(
+        f"""
+  <div class="overlay-info-card__reminder">
+    <div class="overlay-info-card__reminder-body">
+      <div class="overlay-info-card__reminder-label">{html_escape(label)}</div>
+      <div class="overlay-info-card__reminder-meta">{html_escape(value)}</div>
+    </div>
+  </div>
+            """.strip()
+        for label, value in rows
+    )
+    return _network_info_shell('<div class="overlay-info-card__alarm-list">' + entries + "</div>")
+
+
+def _network_info_shell(body: str) -> str:
+    return f"""
+<div class="overlay-card overlay-info-card overlay-info-card--network">
+  <div class="overlay-info-card__header">
+    <div>
+      <div class="overlay-info-card__title">Network</div>
+    </div>
+    <button class="overlay-info-card__close" data-info-card-close aria-label="Close network status">&times;</button>
   </div>
   <div class="overlay-info-card__body">
     {body}

--- a/pulse/overlay_server.py
+++ b/pulse/overlay_server.py
@@ -675,6 +675,12 @@ html, body {{
                     change = outer.state.update_info_card({"type": "help"})
                     if outer._on_state_change:
                         outer._on_state_change(change)
+                elif action == "show_network":
+                    # No payload travels with the request: _build_network_info_overlay
+                    # reads the live snapshot, so the open card follows the poll.
+                    change = outer.state.update_info_card({"type": "network"})
+                    if outer._on_state_change:
+                        outer._on_state_change(change)
                 elif action == "show_config":
                     change = outer.state.update_info_card({"type": "config"})
                     if outer._on_state_change:

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from pulse import network
+from pulse.network import check_network, signal_bars, status_payload
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class SignalBarsTests(unittest.TestCase):
+    def test_no_reading_means_no_bars(self) -> None:
+        # Not "zero bars" — an unanswerable probe must never render as a bad signal any
+        # more than it renders as a good one.
+        self.assertIsNone(signal_bars(None))
+
+    def test_thresholds(self) -> None:
+        for dbm, expected in ((-30, 4), (-55, 4), (-56, 3), (-65, 3), (-66, 2), (-75, 2), (-76, 1), (-95, 1)):
+            with self.subTest(dbm=dbm):
+                self.assertEqual(signal_bars(dbm), expected)
+
+
+class SignalDbmTests(unittest.TestCase):
+    def _read(self, body: str, interface: str = "wlan0") -> int | None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "wireless"
+            _write(path, body)
+            with mock.patch.object(network, "_PROC_WIRELESS", path):
+                return network._signal_dbm(interface)
+
+    _HEADER = (
+        "Inter-| sta-|   Quality        |   Discarded packets\n face | tus | link level noise |  nwid  crypt   frag\n"
+    )
+
+    def test_parses_the_trailing_dot_form(self) -> None:
+        # iwlib writes the level column as a float with a bare trailing dot.
+        self.assertEqual(self._read(self._HEADER + " wlan0: 0000   62.  -48.  -256        0      0      0\n"), -48)
+
+    def test_wraps_unsigned_levels_back_into_dbm(self) -> None:
+        # Some drivers report the level as an unsigned 0-255 byte, where 208 is -48 dBm.
+        # Taken at face value that reads as a wildly positive signal and pins the pill
+        # at four bars on a link that is actually failing.
+        self.assertEqual(self._read(self._HEADER + " wlan0: 0000   62.  208.  0.\n"), -48)
+
+    def test_zero_level_is_unknown_not_perfect(self) -> None:
+        # An interface that is up but unassociated reports a flat 0, which would
+        # otherwise map straight to a triumphant four bars.
+        self.assertIsNone(self._read(self._HEADER + " wlan0: 0000   0.  0.  0.\n"))
+
+    def test_other_interfaces_are_not_confused_for_ours(self) -> None:
+        body = self._HEADER + " wlan1: 0000   62.  -48.  -256\n"
+        self.assertIsNone(self._read(body, interface="wlan0"))
+
+    def test_missing_file_is_unknown(self) -> None:
+        with mock.patch.object(network, "_PROC_WIRELESS", Path("/nonexistent/net/wireless")):
+            self.assertIsNone(network._signal_dbm("wlan0"))
+
+    def test_malformed_line_is_unknown(self) -> None:
+        self.assertIsNone(self._read(self._HEADER + " wlan0: 0000\n"))
+
+
+class CheckNetworkTests(unittest.TestCase):
+    """End-to-end reads against a synthetic /sys/class/net."""
+
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        patcher = mock.patch.object(network, "_NET_ROOT", self.root)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _wifi(self, name: str = "wlan0", *, operstate: str = "up") -> None:
+        (self.root / name / "wireless").mkdir(parents=True)
+        _write(self.root / name / "operstate", operstate)
+
+    def _ethernet(self, name: str = "eth0", *, carrier: str = "0", operstate: str = "down") -> None:
+        _write(self.root / name / "carrier", carrier)
+        _write(self.root / name / "operstate", operstate)
+
+    def _check(self, *, dbm: int | None = -48, ssid: str = "Graystorm", ip: str = "192.168.1.50"):
+        with (
+            mock.patch.object(network, "_signal_dbm", return_value=dbm),
+            mock.patch.object(network, "_wireless_identity", return_value=(ssid, "AA:BB:CC:DD:EE:FF")),
+            mock.patch.object(network, "_ip_address", return_value=ip),
+        ):
+            return check_network()
+
+    def test_healthy_wifi_with_no_cable(self) -> None:
+        # The normal state of every kiosk in this fleet.
+        self._wifi()
+        self._ethernet()
+        status = self._check()
+        self.assertTrue(status.wifi_up)
+        self.assertEqual(status.wifi_bars, 4)
+        self.assertEqual(status.wifi_ssid, "Graystorm")
+        self.assertEqual(status.ethernet, "absent")
+
+    def test_wifi_down_reports_no_bars_and_skips_the_radio_probes(self) -> None:
+        # Nothing is asked of a down radio: the ioctls would just block against a driver
+        # that has nothing to say, on a poll loop, forever.
+        self._wifi(operstate="down")
+        self._ethernet()
+        with (
+            mock.patch.object(network, "_signal_dbm") as dbm,
+            mock.patch.object(network, "_wireless_identity") as identity,
+        ):
+            status = check_network()
+        self.assertFalse(status.wifi_up)
+        self.assertIsNone(status.wifi_bars)
+        self.assertTrue(status.wifi_present)
+        dbm.assert_not_called()
+        identity.assert_not_called()
+
+    def test_associated_but_no_signal_reading_is_not_four_bars(self) -> None:
+        self._wifi()
+        self._ethernet()
+        status = self._check(dbm=None)
+        self.assertTrue(status.wifi_up)
+        self.assertIsNone(status.wifi_bars)
+
+    def test_working_cable_is_up(self) -> None:
+        self._wifi()
+        self._ethernet(carrier="1", operstate="up")
+        status = self._check()
+        self.assertEqual(status.ethernet, "up")
+        self.assertEqual(status.ethernet_ip, "192.168.1.50")
+
+    def test_live_cable_with_no_address_is_down(self) -> None:
+        # Carrier but no lease is the one Ethernet fault worth a red dot: something is
+        # plugged in, the link negotiated, and it still isn't working.
+        self._wifi()
+        self._ethernet(carrier="1", operstate="up")
+        status = self._check(ip="")
+        self.assertEqual(status.ethernet, "down")
+
+    def test_no_ethernet_interface_at_all(self) -> None:
+        self._wifi()
+        status = self._check()
+        self.assertEqual(status.ethernet, "none")
+        self.assertEqual(status.ethernet_interface, "")
+
+    def test_virtual_interfaces_are_never_picked(self) -> None:
+        # docker0 has a carrier and would otherwise be reported as this kiosk's working
+        # Ethernet link, painting a green dot on a display with nothing plugged into it.
+        _write(self.root / "lo" / "operstate", "unknown")
+        _write(self.root / "docker0" / "carrier", "1")
+        _write(self.root / "docker0" / "operstate", "up")
+        _write(self.root / "veth123" / "carrier", "1")
+        self._wifi()
+        self._ethernet()
+        status = self._check()
+        self.assertEqual(status.ethernet_interface, "eth0")
+        self.assertEqual(status.ethernet, "absent")
+
+    def test_missing_sysfs_is_survivable(self) -> None:
+        # A container or a stripped-down image has no /sys/class/net to read. That is a
+        # "no opinion" pill, not a crashed poll thread.
+        with mock.patch.object(network, "_NET_ROOT", self.root / "nope"):
+            status = check_network()
+        self.assertFalse(status.wifi_present)
+        self.assertEqual(status.ethernet, "none")
+
+    def test_payload_round_trips_every_rendered_field(self) -> None:
+        self._wifi()
+        self._ethernet()
+        payload = status_payload(self._check())
+        for key in ("wifi_present", "wifi_up", "bars", "dbm", "ssid", "bssid", "ethernet"):
+            self.assertIn(key, payload)
+        self.assertEqual(payload["bars"], 4)
+        self.assertEqual(payload["ethernet"], "absent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -17,6 +17,7 @@ from pulse.overlay import (
     _build_config_info_overlay,
     _build_device_controls_info_overlay,
     _build_help_info_overlay,
+    _build_network_pill,
     _build_now_playing_card,
     _copyright_years,
     _get_library_versions,
@@ -351,6 +352,145 @@ class OverlayRenderTests(unittest.TestCase):
         html = render_overlay_html(snapshot, self.theme)
         self.assertLess(html.index(self._SPEAKER_PILL_MARKUP), html.index("Alarm ringing"))
 
+    # --- Connectivity pill (notification bar) -----------------------------------
+    _NETWORK_PILL_MARKUP = 'data-badge-action="show_network"'
+
+    @staticmethod
+    def _network(**overrides: object) -> dict:
+        data = {
+            "wifi_present": True,
+            "wifi_up": True,
+            "bars": 4,
+            "dbm": -48,
+            "ssid": "Graystorm",
+            "bssid": "AA:BB:CC:DD:EE:FF",
+            "wifi_ip": "192.168.1.50",
+            "wifi_interface": "wlan0",
+            "ethernet": "absent",
+            "ethernet_ip": "",
+            "ethernet_interface": "eth0",
+        }
+        data.update(overrides)
+        return data
+
+    def test_network_pill_absent_before_first_reading(self) -> None:
+        # None means the poll has not run (or the pill is disabled). Rendering a healthy
+        # pill there would claim a link state nothing has actually measured.
+        self.assertEqual(_build_network_pill(None), "")
+        html = render_overlay_html(self._snapshot(network=None), self.theme)
+        self.assertNotIn(self._NETWORK_PILL_MARKUP, html)
+
+    def test_network_pill_shown_when_healthy(self) -> None:
+        # The one badge on this bar that is deliberately visible in its healthy state:
+        # signal degrades gradually, and the trend is the reading worth having.
+        html = render_overlay_html(self._snapshot(network=self._network()), self.theme)
+        self.assertIn(self._NETWORK_PILL_MARKUP, html)
+        self.assertIn("WiFi 4/4 to &quot;Graystorm&quot; at -48 dBm", html)
+
+    def test_network_pill_is_leftmost_badge(self) -> None:
+        # Pinned ahead of Help so it never slides sideways when an alarm or weather
+        # alert appears — a permanent indicator that moves stops being readable.
+        snapshot = self._snapshot(network=self._network(), active_alarm={"label": "Wake up"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertLess(html.index(self._NETWORK_PILL_MARKUP), html.index(">Help<"))
+
+    def test_network_pill_lights_one_bar_per_signal_level(self) -> None:
+        for bars in (1, 2, 3, 4):
+            with self.subTest(bars=bars):
+                pill = _build_network_pill(self._network(bars=bars))
+                self.assertEqual(pill.count("overlay-network__bar--on"), bars)
+                # Unlit rungs stay in the DOM: the pill must keep a constant width
+                # whatever the signal is doing, or it draws the eye every time it moves.
+                self.assertEqual(pill.count('class="overlay-network__bar'), 4)
+
+    def test_network_pill_marks_one_bar_as_weak(self) -> None:
+        # One bar is where this fleet's roam stalls start, so it is amber, not just short.
+        self.assertIn("overlay-network__wifi--weak", _build_network_pill(self._network(bars=1, dbm=-82)))
+        self.assertNotIn("overlay-network__wifi--weak", _build_network_pill(self._network(bars=2, dbm=-70)))
+
+    def test_network_pill_crosses_out_wifi_when_disconnected(self) -> None:
+        pill = _build_network_pill(self._network(wifi_up=False, bars=None, dbm=None, ssid="", bssid="", wifi_ip=""))
+        self.assertIn("overlay-network__wifi--off", pill)
+        self.assertIn("overlay-network__slash", pill)
+        self.assertNotIn("overlay-network__bar--on", pill)
+        self.assertIn("WiFi disconnected", pill)
+
+    def test_network_pill_ignores_a_stale_bar_count_when_wifi_is_down(self) -> None:
+        # A reading can carry the last-known bar count with wifi_up already false. The
+        # pill must follow the link state, not the leftover number, or a display that
+        # has dropped off the network keeps showing four cheerful green rungs.
+        pill = _build_network_pill(self._network(wifi_up=False, bars=4, dbm=-48))
+        self.assertIn("overlay-network__wifi--off", pill)
+        self.assertNotIn("overlay-network__bar--on", pill)
+
+    def test_network_pill_greys_ethernet_when_no_cable(self) -> None:
+        # Every kiosk here runs on WiFi with an empty port. Red for that permanent state
+        # would train everyone to ignore the pill and cost us the real Ethernet fault.
+        pill = _build_network_pill(self._network(ethernet="absent"))
+        self.assertIn("overlay-network__eth--absent", pill)
+        self.assertNotIn("overlay-network__eth--down", pill)
+
+    def test_network_pill_reds_ethernet_only_when_cable_is_broken(self) -> None:
+        pill = _build_network_pill(self._network(ethernet="down", ethernet_ip=""))
+        self.assertIn("overlay-network__eth--down", pill)
+        self.assertIn("Ethernet cable plugged in but not working", pill)
+
+    def test_network_pill_greens_ethernet_when_up(self) -> None:
+        pill = _build_network_pill(self._network(ethernet="up"))
+        self.assertIn("overlay-network__eth--up", pill)
+        self.assertIn("Ethernet connected", pill)
+
+    def test_network_pill_omits_ethernet_dot_when_no_interface(self) -> None:
+        pill = _build_network_pill(self._network(ethernet="none", ethernet_interface=""))
+        self.assertIn(self._NETWORK_PILL_MARKUP, pill)
+        self.assertNotIn("overlay-network__eth", pill)
+
+    def test_network_pill_absent_when_device_has_no_interfaces(self) -> None:
+        pill = _build_network_pill(self._network(wifi_present=False, wifi_up=False, ethernet="none"))
+        self.assertEqual(pill, "")
+
+    def test_network_pill_escapes_ssid(self) -> None:
+        # An SSID is whatever the AP broadcasts, so it is untrusted text.
+        pill = _build_network_pill(self._network(ssid="<img src=x onerror=alert(1)>"))
+        self.assertNotIn("<img", pill)
+        self.assertIn("&lt;img", pill)
+
+    # --- Network info card --------------------------------------------------------
+
+    def test_network_info_card_reads_the_live_snapshot(self) -> None:
+        # The card carries no payload of its own, so an open card follows the poll
+        # instead of freezing at whatever was true when somebody tapped it.
+        snapshot = self._snapshot(network=self._network(bars=2, dbm=-68), info_card={"type": "network"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertIn("overlay-info-card--network", html)
+        self.assertIn("2/4 — fair (-68 dBm)", html)
+        self.assertIn("Graystorm", html)
+        self.assertIn("AA:BB:CC:DD:EE:FF", html)
+        self.assertIn("192.168.1.50", html)
+
+    def test_network_info_card_calls_out_missing_dhcp_lease(self) -> None:
+        # Associated but with no address is a real and confusing failure — the pill shows
+        # full bars while nothing works — so the card has to name it.
+        snapshot = self._snapshot(network=self._network(wifi_ip=""), info_card={"type": "network"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertIn("DHCP has not completed", html)
+
+    def test_network_info_card_separates_no_reading_from_no_adapter(self) -> None:
+        # These are different problems and must not share a message: "no wireless
+        # adapter" would send somebody hunting a hardware fault that doesn't exist.
+        snapshot = self._snapshot(network=None, info_card={"type": "network"})
+        html = render_overlay_html(snapshot, self.theme)
+        self.assertIn("Network status is not available yet.", html)
+        self.assertNotIn("No wireless adapter", html)
+
+        no_adapter = self._snapshot(
+            network=self._network(wifi_present=False, wifi_up=False, ethernet="up", ethernet_ip="10.0.0.9"),
+            info_card={"type": "network"},
+        )
+        html = render_overlay_html(no_adapter, self.theme)
+        self.assertIn("No wireless adapter", html)
+        self.assertNotIn("Network status is not available yet.", html)
+
     def test_only_first_clock_used_if_multiple_provided(self) -> None:
         # Even if multiple clocks are provided, only the first one is rendered
         clocks = (
@@ -420,6 +560,58 @@ class OverlayRenderTests(unittest.TestCase):
         alarm_card = manager.snapshot().info_card
         assert alarm_card is not None
         self.assertIn("alarms", alarm_card)
+
+    def test_update_network_ignores_dbm_jitter(self) -> None:
+        manager = OverlayStateManager()
+
+        def reading(**overrides):
+            data = {
+                "wifi_present": True,
+                "wifi_up": True,
+                "bars": 4,
+                "dbm": -48,
+                "ssid": "Graystorm",
+                "bssid": "AA:BB:CC:DD:EE:FF",
+                "wifi_ip": "192.168.1.50",
+                "wifi_interface": "wlan0",
+                "ethernet": "absent",
+                "ethernet_ip": "",
+                "ethernet_interface": "eth0",
+            }
+            data.update(overrides)
+            return data
+
+        self.assertTrue(manager.update_network(reading()).changed)
+        version = manager.snapshot().version
+
+        # Signal jitters by a few dB every poll even on a display bolted to a wall. The
+        # pill draws bars, so a dBm that moves within the same bar must NOT bump the
+        # version — bumping reloads the photo card underneath, which would mean the
+        # wallpaper flickering roughly twice a minute forever.
+        self.assertFalse(manager.update_network(reading(dbm=-51)).changed)
+        self.assertEqual(manager.snapshot().version, version)
+        # ...but the fresh dBm is still stored, because the info card reads it live off
+        # the snapshot and should track the poll rather than freeze at the last bump.
+        stored = manager.snapshot().network
+        assert stored is not None
+        self.assertEqual(stored["dbm"], -51)
+
+        # A bar actually changing is a visible change, so it bumps.
+        self.assertTrue(manager.update_network(reading(bars=2, dbm=-70)).changed)
+        # So does roaming to a different AP, even at identical strength — that is the
+        # transition worth catching when a pinned kiosk loses its pin.
+        self.assertTrue(manager.update_network(reading(bars=2, dbm=-70, bssid="11:22:33:44:55:66")).changed)
+        # And so does the cable state.
+        self.assertTrue(
+            manager.update_network(reading(bars=2, dbm=-70, bssid="11:22:33:44:55:66", ethernet="up")).changed
+        )
+
+    def test_update_network_clears_back_to_none(self) -> None:
+        manager = OverlayStateManager()
+        manager.update_network({"wifi_present": True, "wifi_up": True, "bars": 3, "ethernet": "absent"})
+        cleared = manager.update_network(None)
+        self.assertTrue(cleared.changed)
+        self.assertIsNone(manager.snapshot().network)
 
     def test_set_ticker_bumps_only_on_symbol_change(self) -> None:
         manager = OverlayStateManager()


### PR DESCRIPTION
Adds an always-on connectivity indicator at the far left of the notification bar, left of **Help**: 1–4 WiFi bars (crossed out in red when there's no link) plus a dot for Ethernet.


| State | Rendering |
|---|---|
| 4 / 3 / 2 bars | green rungs, unlit rungs stay in place so the pill never changes width |
| 1 bar | **amber** — that's where this fleet's roam stalls and power-save drops start, not merely "a bit worse than two" |
| No WiFi link | rungs crossed out in red, pill background goes dark red |
| Ethernet working | green dot |
| Cable in, no IP | **red** dot (carrier up, DHCP never completed) |
| No cable | **grey** dot |

## Why it's visible when healthy

It's the only badge on this bar shown in its healthy state, and that's the point. Every other pill there reports something otherwise invisible, so *appearing at all* is the message. Connectivity instead degrades gradually, and the useful reading is the **trend** — a display that normally sits at four bars and is now at two has a problem worth chasing before it drops off the network entirely and takes the overlay with it. A pill that only shows up at zero can't tell you that.

It's pinned leftmost so it never slides sideways when an alarm or weather alert appears; a permanent indicator that moves stops being readable at a glance.

## Why grey, not red, for "no cable"

Every kiosk in this fleet runs on WiFi with an empty Ethernet port. A permanent red dot on all four displays would teach everyone to ignore the pill — costing us the one Ethernet fault actually worth catching, which is a cable that *is* plugged in and has stopped working.

## Implementation notes

- **No subprocesses.** State comes from `/sys/class/net` and `/proc/net/wireless`, plus two ioctls for SSID/BSSID. Shelling out to `iw`/`nmcli` would be a fork per poll on a Pi, depends on tools that aren't installed uniformly (`iw` isn't even on the unprivileged PATH on these displays), and blocks for seconds against a wedged driver.
- **Verified on real hardware.** Probe output on pulse-office matches `sudo iw dev wlan0 link` exactly (−43 dBm, same BSSID/SSID) — and unlike `iw`, the probe needs no sudo. All four kiosks return sensible readings (−40 to −61 dBm, ethernet correctly `absent`).
- **`update_network` signs on rendered fields only, never raw dBm.** Signal jitters a few dB every poll even on a display bolted to a wall; signing it would bump the overlay version — reloading the photo card underneath — roughly twice a minute forever. The fresh dBm is still stored so the open info card tracks the poll.
- **A probe that can't run reports "unknown" and renders nothing**, never a healthy pill.
- Unsigned-byte signal levels (some drivers report 0–255) are wrapped back into negative dBm; a flat `0` from an unassociated radio maps to "unknown" rather than four bars.

## Info card

Tapping the pill opens a card with SSID, access point (BSSID), signal strength, IP address, and Ethernet state. The BSSID earns its place because a kiosk pinned to a specific AP silently loses that pin when the AP reboots, and "which radio am I actually on" is then the only thing distinguishing a healthy roam from a stalled one — and it's precisely what you can't go look up over SSH, because SSH is what stops working when the answer is bad.

## Config

| Variable | Default | Meaning |
|---|---|---|
| `PULSE_NETWORK_PILL` | `true` | Show the pill |
| `PULSE_NETWORK_INTERVAL` | `30` | Seconds between readings (min 10) |

## Tests

29 new tests (`tests/test_network.py`, plus pill/card/state coverage in `tests/test_overlay.py`) against a synthetic `/sys/class/net`, covering the unsigned-dBm wrap, the unassociated-radio zero, virtual-interface exclusion (`docker0` has a carrier and would otherwise render as a working green Ethernet link), stale-bar-count-while-down, and the dBm-jitter no-bump rule. Full suite: 2223 passed. ruff check/format and bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUJ2u7U6t4XVxGLUUH4iWi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive overlay and read-only network polling with graceful failure and tests; behavior is gated by config and mirrors existing monitor patterns like the speaker badge.
> 
> **Overview**
> Adds an **always-on connectivity pill** at the far left of the overlay notification bar (ahead of Help), driven by a new background poll in `kiosk-mqtt-listener` when `PULSE_NETWORK_PILL` is enabled (`PULSE_NETWORK_INTERVAL`, default 30s).
> 
> **`pulse.network`** probes WiFi/Ethernet via sysfs, `/proc/net/wireless`, and ioctls (no `iw`/`nmcli` subprocesses), maps signal to 1–4 bars, and feeds overlay state through `update_network`—version bumps only when rendered fields change (bars, link state, SSID/BSSID), not dBm jitter. The pill shows WiFi rungs (amber at one bar, red slash when down), an Ethernet dot (green/red/grey), and tap opens a live **Network** info card; CSS covers the new badge styles.
> 
> Config and docs (`PULSE_NETWORK_PILL`, `PULSE_NETWORK_INTERVAL`) are updated, plus unit tests for probing, pill rendering, and state semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a107f74a2aa39ca2e400c57c99913f30c276f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->