### PR TITLE
fix(kiosk): match the connectivity pill's height to the other badges

### DIFF
--- a/assets/overlay/overlay.css
+++ b/assets/overlay/overlay.css
@@ -116,6 +116,14 @@ body {
 .overlay-badge--network {
   gap: 0.45rem;
   padding: 0.35rem 0.6rem;
+  /* Every other badge on this bar is as tall as its emoji ICON's line box, which is
+     meaningfully taller than plain text at the same size — the emoji font's metrics,
+     not the text font's, are what set the height. This pill is the only one with no
+     emoji (it draws its own glyphs), so without this it renders ~5px short and sits
+     visibly low next to Help. 1.32em is that emoji line box measured on the fleet's
+     stack; 0.7rem is this rule's own vertical padding, which border-box folds into
+     min-height. Keep the two in step if the padding above ever changes. */
+  min-height: calc(1.32em + 0.7rem);
 }
 
 .overlay-network__wifi {


### PR DESCRIPTION
The connectivity pill from #265 rendered **26.4px** tall against **31.2px** for every text badge, sitting visibly low next to Help.

The cause isn't the text. Every other badge on this bar is as tall as its **emoji icon's** line box, and the emoji font's metrics run ~2px taller than the text font's at the same size. This pill is the only one with no emoji — it draws its own glyphs — so nothing was holding its box open.

Worth noting because it's a trap: deriving the height from `1lh` looks like the principled fix and still lands 2px short, for exactly that reason. So the emoji line box is measured directly instead.

Measured live on pulse-office (Chrome 152): **31.25px against a 31.19px target** — a sub-pixel delta. Bar sizes are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUJ2u7U6t4XVxGLUUH4iWi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS tweak to overlay badge layout with no logic, auth, or data changes.
> 
> **Overview**
> The kiosk overlay **connectivity pill** (`.overlay-badge--network`) was rendering ~5px shorter than neighboring badges such as Help, so it looked vertically misaligned on the notification bar.
> 
> This change sets **`min-height: calc(1.32em + 0.7rem)`** so the pill matches the height driven by other badges’ emoji icon line boxes (not plain text metrics). Inline comments document why `1lh` would still fall short and how the `1.32em` / padding terms should stay in sync if padding changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ecba26090e150e44da3baefc78e4dce8cd2546c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->